### PR TITLE
Add MTP_NUM_TOKENS=0 escape hatch and document concurrent-decode corruption in the DSpark proposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ Runtime:
 - `max_num_seqs=6`
 - `max_num_batched_tokens=8192`
 - `gpu_memory_utilization=0.85`
-- `MTP_NUM_TOKENS=3`
+- `MTP_NUM_TOKENS=3` (set `0` to disable speculative decoding entirely; see
+  the known issue on concurrent-decode corruption below)
+- `DRAFT_SAMPLE_METHOD=probabilistic` (or `greedy`)
 - `VLLM_USE_FLASHINFER_SAMPLER=1`
 - `VLLM_USE_B12X_WO_PROJECTION=1`
 - `VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK=1`
@@ -386,6 +388,34 @@ MTP3 probabilistic draft sampling active
 This keeps NVFP4 KV and MTP3. Do not switch to fp8 or drop to a smaller fallback
 model just to hide the symptom unless you intentionally accept the context and
 quality tradeoff.
+
+### Known issue: output corruption under concurrent decode with MTP enabled
+
+With speculative decoding active and more than one request decoding
+concurrently, the DSpark proposer can misalign flattened hidden-state rows
+against scheduled positions. The detectable subset is caught by the guard in
+`dspark_proposer.py` (`non-uniform flattened batch ... skipping speculation`
+— logged once per boot, at which point speculation for that step is safely
+skipped). Undetected cases silently draft from the wrong request's hidden
+states and corrupt committed tokens. Observed symptoms in long agentic
+sessions (seen at batch sizes 2-3 on a 2x DGX Spark, upstream `bb75f33`):
+
+- isolated garbage tokens inside otherwise coherent output (random
+  CJK/Greek/rare-vocabulary tokens);
+- `<|begin_of_sentence|>` emitted as literal text followed by replays of
+  stale earlier answers (with prefix caching on, one corrupted token
+  poisons the session's cached prefix for all later turns);
+- generation jumping mid-sentence into verbatim copies of earlier context;
+- DSML tool-call markup leaking as plain text instead of parsed
+  `tool_calls`.
+
+`draft_sample_method=greedy` does not help (the misalignment is upstream of
+sampling). Workaround until the proposer is fixed: disable speculation by
+setting `MTP_NUM_TOKENS=0` in `.env.dspark` — the launcher then omits
+`--speculative-config` entirely — at the cost of the MTP decode speedup.
+When validating any fix, use a fresh client session: a session whose
+history already contains leaked markers keeps imitating them even against
+a healthy server.
 
 ## Important Caveat
 

--- a/README.md
+++ b/README.md
@@ -392,13 +392,8 @@ quality tradeoff.
 ### Known issue: output corruption under concurrent decode with MTP enabled
 
 With speculative decoding active and more than one request decoding
-concurrently, the DSpark proposer can misalign flattened hidden-state rows
-against scheduled positions. The detectable subset is caught by the guard in
-`dspark_proposer.py` (`non-uniform flattened batch ... skipping speculation`
-— logged once per boot, at which point speculation for that step is safely
-skipped). Undetected cases silently draft from the wrong request's hidden
-states and corrupt committed tokens. Observed symptoms in long agentic
-sessions (seen at batch sizes 2-3 on a 2x DGX Spark, upstream `bb75f33`):
+concurrently, output can be silently corrupted. Observed in long agentic
+sessions (batch sizes 2-3 on a 2x DGX Spark, upstream `bb75f33`):
 
 - isolated garbage tokens inside otherwise coherent output (random
   CJK/Greek/rare-vocabulary tokens);
@@ -409,13 +404,28 @@ sessions (seen at batch sizes 2-3 on a 2x DGX Spark, upstream `bb75f33`):
 - DSML tool-call markup leaking as plain text instead of parsed
   `tool_calls`.
 
-`draft_sample_method=greedy` does not help (the misalignment is upstream of
-sampling). Workaround until the proposer is fixed: disable speculation by
-setting `MTP_NUM_TOKENS=0` in `.env.dspark` — the launcher then omits
-`--speculative-config` entirely — at the cost of the MTP decode speedup.
-When validating any fix, use a fresh client session: a session whose
-history already contains leaked markers keeps imitating them even against
-a healthy server.
+What the bisection establishes: a server-side sampling default override did
+not help, `draft_sample_method=greedy` did not help, and setting
+`MTP_NUM_TOKENS=0` removed the corruption completely (confirmed over long
+multi-turn agentic sessions). So the trigger is speculation itself under
+concurrent decode, not the draft sampling method.
+
+We have not confirmed the mechanism against the proposer code, so treat this
+as a hypothesis rather than a diagnosis: the proposer's own guard logs
+`dspark_proposer.py: non-uniform flattened batch ... skipping speculation`
+(seen at batch_size 2 and 3 on separate boots; it logs only the first
+occurrence), which would be consistent with hidden-state/position
+misalignment under concurrent batches, where cases the guard does not catch
+could draft from the wrong request's rows. Happy to run diagnostics if that
+would help narrow it down.
+
+Workaround until this is fixed: disable speculation with `MTP_NUM_TOKENS=0`
+in `.env.dspark` — the launcher then omits `--speculative-config` entirely —
+at the cost of the MTP decode speedup.
+
+When validating any fix, use a fresh client session: a session whose history
+already contains leaked markers keeps imitating them even against a healthy
+server.
 
 ## Important Caveat
 

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -83,6 +83,7 @@ services:
       MASTER_ADDR: "${MASTER_ADDR}"
       MASTER_PORT: "${MASTER_PORT:-25000}"
       MTP_NUM_TOKENS: "${MTP_NUM_TOKENS:-3}"
+      DRAFT_SAMPLE_METHOD: "${DRAFT_SAMPLE_METHOD:-probabilistic}"
 
     command:
       - bash
@@ -99,7 +100,11 @@ services:
           export VLLM_PLUGINS="$${VLLM_PLUGINS:-gb10_hybrid_nvfp4}";
           VLLM_QUANTIZATION_ARGS="--quantization modelopt_gb10_hybrid";
         fi;
-        SPECULATIVE_CONFIG="{\"method\":\"dspark\",\"num_speculative_tokens\":$${MTP_NUM_TOKENS:-3},\"draft_sample_method\":\"probabilistic\"}";
+        if [ "$${MTP_NUM_TOKENS:-3}" = "0" ]; then
+          SPECULATIVE_ARGS="";
+        else
+          SPECULATIVE_ARGS="--speculative-config {\"method\":\"dspark\",\"num_speculative_tokens\":$${MTP_NUM_TOKENS:-3},\"draft_sample_method\":\"$${DRAFT_SAMPLE_METHOD:-probabilistic}\"}";
+        fi;
         exec /opt/env/bin/vllm serve ${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
         --served-model-name ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}
         --host ${VLLM_HOST:-127.0.0.1}
@@ -118,7 +123,7 @@ services:
         --enable-prefix-caching
         --async-scheduling
         --enable-chunked-prefill
-        --speculative-config "$${SPECULATIVE_CONFIG}"
+        $${SPECULATIVE_ARGS}
         --tokenizer-mode deepseek_v4
         --distributed-executor-backend mp
         --tool-call-parser deepseek_v4


### PR DESCRIPTION
## Summary

Running this profile on 2x DGX Spark at upstream `bb75f33`, we hit silent output corruption in long agentic sessions whenever more than one request was decoding concurrently, with speculative decoding enabled:

- isolated garbage tokens inside otherwise coherent text (random CJK/Greek/rare-vocabulary tokens);
- `<|begin_of_sentence|>` emitted as literal text, after which the model replays stale earlier answers (with prefix caching on, one corrupted committed token poisons the session's cached prefix for every later turn);
- generation jumping mid-sentence into verbatim copies of earlier context;
- DSML tool-call markup leaking as plain text instead of being parsed into `tool_calls`.

## What we established

Bisection, each step verified with a fresh client session:

- a server-side sampling default override (`temperature=0.6/top_p=0.95`) did **not** fix it;
- `draft_sample_method=greedy` did **not** fix it;
- `MTP_NUM_TOKENS=0` (speculation off) **removed the corruption completely**, confirmed over long multi-turn agentic sessions with tools.

So the trigger is speculation itself under concurrent decode, not the draft sampling method.

## What we did not establish

We have **not** confirmed the mechanism against the proposer code — please treat the following as a hypothesis, not a diagnosis. The proposer's own guard fired on two separate boots, minutes into concurrent load:

```
WARNING [dspark_proposer.py:798] DSpark proposer: non-uniform flattened batch (7785 hidden rows / 7785 positions for batch_size=2); skipping speculation for this step. Further occurrences will not be logged.
WARNING [dspark_proposer.py:798] DSpark proposer: non-uniform flattened batch (28 hidden rows / 28 positions for batch_size=3); skipping speculation for this step. Further occurrences will not be logged.
```

That would be consistent with hidden-state/position misalignment under concurrent batches — where cases the guard does not catch could draft from the wrong request's rows — but we have not proven that link. Happy to run further diagnostics or share full transcripts/configs if useful.

## Changes

- `docker-compose.dspark.yml`: `MTP_NUM_TOKENS=0` now omits `--speculative-config` entirely (previously it would emit `num_speculative_tokens: 0`, which vLLM rejects); `draft_sample_method` is parameterized as `DRAFT_SAMPLE_METHOD` (default `probabilistic` — no behavior change).
- `README.md`: documents the two knobs and adds a "Known issue" section describing the corruption signatures, the bisection, the guard log line, and the workaround — including the validation gotcha that a client session with leaked markers in its history keeps imitating them against a healthy server, so fixes must be verified with fresh sessions.

Defaults are unchanged; this only gives operators a clean way to trade the MTP speedup for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)