### PR TITLE
fix: prepare-dspark-model-cache.sh entrypoint path for Anemll image

### DIFF
--- a/prepare-dspark-model-cache.sh
+++ b/prepare-dspark-model-cache.sh
@@ -19,6 +19,8 @@ fi
 : "${HF_CACHE:=$HOME/.cache/huggingface}"
 : "${HF_DOWNLOAD_WORKERS:=1}"
 : "${DSPARK_VLLM_IMAGE:=vllm-dspark-runtime:dspark-nvfp4-stage-c}"
+# Anemll image ships python at /usr/bin/python3 (Stage-C used /opt/env/bin/python).
+: "${IMAGE_PYTHON:=/usr/bin/python3}"
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -54,7 +56,7 @@ run_download() {
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
     -e DSPARK_MODEL="$DSPARK_MODEL" \
     -e HF_DOWNLOAD_WORKERS="$HF_DOWNLOAD_WORKERS" \
-    --entrypoint /opt/env/bin/python \
+    --entrypoint "$IMAGE_PYTHON" \
     "$DSPARK_VLLM_IMAGE" \
     -c 'from huggingface_hub import snapshot_download; import os; print(snapshot_download(os.environ["DSPARK_MODEL"], max_workers=int(os.environ.get("HF_DOWNLOAD_WORKERS", "1"))))'
 }
@@ -67,7 +69,7 @@ verify_cache() {
     -e TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}" \
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
     -e DSPARK_MODEL="$DSPARK_MODEL" \
-    --entrypoint /opt/env/bin/python \
+    --entrypoint "$IMAGE_PYTHON" \
     "$DSPARK_VLLM_IMAGE" \
     - <<'PY'
 import json


### PR DESCRIPTION
## Problem

`prepare-dspark-model-cache.sh` hardcodes `--entrypoint /opt/env/bin/python` in both `run_download()` and `verify_cache()`.

That path is a Stage-C overlay artifact and does not exist on the current default image (`ghcr.io/anemll/dspark-vllm-gx10:0.1.1`), which is what `.env.dspark.example` and the README both document as the default.

Running the script fresh against the documented default fails immediately:

```text
docker: Error response from daemon: failed to create task for container:
failed to create shim task: OCI runtime create failed: runc create
failed: unable to start container process: error during container init:
exec: "/opt/env/bin/python": stat /opt/env/bin/python: no such file or
directory
```

## Fix

Adds an `IMAGE_PYTHON` variable (default `/usr/bin/python3`, where `python3` actually lives in the Anemll image) and uses it for both Docker invocations.

The value remains overridable via the environment for anyone still building the Stage-C overlay:

```bash
IMAGE_PYTHON=/opt/env/bin/python
```

## Verification

Ad hoc (the repository has no test suite):

- `bash -n` syntax check passes.
- Confirmed `/usr/bin/python3` exists in the image and successfully imports `huggingface_hub`:

  ```bash
  docker run --rm \
    --entrypoint /usr/bin/python3 \
    ghcr.io/anemll/dspark-vllm-gx10:0.1.1 \
    -c "from huggingface_hub import snapshot_download; print(1)"
  ```

- Negative control: re-ran the same invocation with the old `/opt/env/bin/python` path and reproduced the original failure, confirming both that the bug was real and that this change fixes it.
- Ran the patched script end-to-end against `deepseek-ai/DeepSeek-V4-Flash-DSpark` on a live 2-node DGX Spark cluster. The snapshot download proceeds correctly.