### PR TITLE
fix: issue #4 env/prepare bring-up rough edges

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -19,10 +19,14 @@ HEADLESS=
 # HEADLESS=1
 
 # RoCE / InfiniBand
+# Set these to YOUR fabric IF / HCA / GID (f0 vs f1 and GID index differ by box).
+# Example on one Spark: enp1s0f1np1 / rocep1s0f1 / GID 0; another may use f0 / GID 3.
+# compose defaults TP/GLOO to NCCL_SOCKET_IFNAME when those vars are unset — do not
+# leave a wrong concrete NIC here or the ${NCCL_SOCKET_IFNAME} fallback never runs.
 NCCL_IB_HCA=rocepXsYfZ
 NCCL_SOCKET_IFNAME=enpXsYfZnpN
-TP_SOCKET_IFNAME=enp1s0f1np1
-GLOO_SOCKET_IFNAME=enp1s0f1np1
+TP_SOCKET_IFNAME=enpXsYfZnpN
+GLOO_SOCKET_IFNAME=enpXsYfZnpN
 NCCL_IB_GID_INDEX=0
 NCCL_CROSS_NIC=1
 
@@ -32,6 +36,7 @@ HF_CACHE=${HOME}/.cache/huggingface
 # differs from the head node. If blank, the worker uses HF_CACHE.
 WORKER_HF_CACHE=
 # Prefer offline when both nodes already have a full hub cache (online re-download can fill worker disks).
+# prepare-dspark-model-cache.sh forces online for its download step; keep these at 1 for serve.
 HF_HUB_OFFLINE=1
 TRANSFORMERS_OFFLINE=1
 HF_HUB_DISABLE_XET=1
@@ -49,6 +54,9 @@ WORKER_VLLM_HOST_IP=worker-roce-ip
 # Pull: docker pull ghcr.io/anemll/dspark-vllm-gx10:0.1.1
 # Alternative: build locally with ./build-dspark-vllm-runtime.sh → vllm-dspark-runtime:dspark-nvfp4-stage-c
 DSPARK_VLLM_IMAGE=ghcr.io/anemll/dspark-vllm-gx10:0.1.1
+# Python inside the image (used by prepare-dspark-model-cache.sh).
+# Anemll: /usr/bin/python3 (default). Stage-C overlay: IMAGE_PYTHON=/opt/env/bin/python
+# IMAGE_PYTHON=/usr/bin/python3
 
 # Validated Keys C12 NVFP4 profile.
 MAX_MODEL_LEN=1048576

--- a/README.md
+++ b/README.md
@@ -575,13 +575,13 @@ Edit these values for your cluster:
 - `WORKER_SCRIPT_DIR` if the worker checkout/deployment path differs from the head
 - `MASTER_ADDR`
 - `NCCL_IB_HCA`
-- `NCCL_SOCKET_IFNAME`
-- `NCCL_IB_GID_INDEX`
+- `NCCL_SOCKET_IFNAME` (and matching `TP_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`, or leave those unset so compose inherits the NCCL IF)
+- `NCCL_IB_GID_INDEX` (not always 0 — match your RoCE GID)
 - `HF_CACHE`
 - `WORKER_HF_CACHE` if the worker cache path differs from the head
 - `VLLM_HOST_IP` and `WORKER_VLLM_HOST_IP` for each node's fabric IP
 
-Example cluster fabric values (edit for your nodes):
+Example cluster fabric values (edit for your nodes — f0 vs f1 and GID index vary):
 
 ```env
 WORKER_HOST=10.0.0.2
@@ -623,6 +623,7 @@ Optional: build the historical Stage-C image instead:
 ```bash
 ./build-dspark-vllm-runtime.sh
 # then set DSPARK_VLLM_IMAGE=vllm-dspark-runtime:dspark-nvfp4-stage-c
+# and IMAGE_PYTHON=/opt/env/bin/python for prepare-dspark-model-cache.sh
 ```
 
 Prepare the model cache on both nodes (or rsync a verified hub snapshot):
@@ -630,6 +631,11 @@ Prepare the model cache on both nodes (or rsync a verified hub snapshot):
 ```bash
 ./prepare-dspark-model-cache.sh
 ```
+
+`prepare-dspark-model-cache.sh` forces HF online for the download step even when
+`.env.dspark` has `HF_HUB_OFFLINE=1` (correct for serve after the cache is warm).
+Use `IMAGE_PYTHON=/usr/bin/python3` on the Anemll image (default); Stage-C needs
+`IMAGE_PYTHON=/opt/env/bin/python`.
 
 Start the service:
 

--- a/prepare-dspark-model-cache.sh
+++ b/prepare-dspark-model-cache.sh
@@ -47,12 +47,15 @@ need_cmd docker
 mkdir -p "$HF_CACHE"
 verify_local_image
 
+# Serve profiles keep HF_HUB_OFFLINE=1; download must ignore that for this run only.
+echo "prepare: forcing HF online for download (serve can keep HF_HUB_OFFLINE=1)" >&2
+
 run_download() {
   docker run --rm -i \
     -v "${HF_CACHE}:/cache/huggingface" \
     -e HF_HOME=/cache/huggingface \
-    -e HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}" \
-    -e TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}" \
+    -e HF_HUB_OFFLINE=0 \
+    -e TRANSFORMERS_OFFLINE=0 \
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
     -e DSPARK_MODEL="$DSPARK_MODEL" \
     -e HF_DOWNLOAD_WORKERS="$HF_DOWNLOAD_WORKERS" \
@@ -62,11 +65,12 @@ run_download() {
 }
 
 verify_cache() {
+  # local_files_only=True; force offline so verify never re-hits the hub.
   docker run --rm -i \
     -v "${HF_CACHE}:/cache/huggingface" \
     -e HF_HOME=/cache/huggingface \
-    -e HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}" \
-    -e TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}" \
+    -e HF_HUB_OFFLINE=1 \
+    -e TRANSFORMERS_OFFLINE=1 \
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
     -e DSPARK_MODEL="$DSPARK_MODEL" \
     --entrypoint "$IMAGE_PYTHON" \


### PR DESCRIPTION
## Summary

Closes the remaining items from #4 (item 2 was already fixed in #6).

1. **Socket IFs** — `.env.dspark.example` no longer hardcodes `enp1s0f1np1` for `TP_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`. They use the same placeholders as `NCCL_SOCKET_IFNAME`, with a note that compose falls back to NCCL when unset, and that f0 vs f1 / GID vary by box.
2. **Prepare vs offline** — `prepare-dspark-model-cache.sh` forces `HF_HUB_OFFLINE=0` for download only (serve keeps offline=1). Verify runs with offline + `local_files_only=True`.
3. **Docs** — `IMAGE_PYTHON` note for Anemll vs Stage-C; README prepare/socket notes.

## Test plan

- [x] `bash -n prepare-dspark-model-cache.sh`
- [ ] Copy updated example → `.env.dspark`, set real fabric IF once, confirm TP/GLOO match
- [ ] With `HF_HUB_OFFLINE=1` in env, run `./prepare-dspark-model-cache.sh` and confirm download proceeds (no `OfflineModeIsEnabled`)
