### PR TITLE
fix: per-node RoCEv2 GID index override for dual-Spark TP2

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -28,6 +28,11 @@ NCCL_SOCKET_IFNAME=enpXsYfZnpN
 TP_SOCKET_IFNAME=enpXsYfZnpN
 GLOO_SOCKET_IFNAME=enpXsYfZnpN
 NCCL_IB_GID_INDEX=0
+# Per-node RoCEv2 GID index override for the WORKER (rank 1). Set in the worker's
+# copy of this file if the worker's index drifts after a reboot. Both nodes using
+# index 0 (link-local IPv6) is the most reboot-stable; a single shared IPv4 index
+# (e.g. 3) can wedge NCCL at init if the worker drifts. See howtospark dual-spark.
+WORKER_NCCL_IB_GID_INDEX=0
 NCCL_CROSS_NIC=1
 
 # Caches / model

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -83,7 +83,13 @@ services:
       NCCL_SOCKET_IFNAME: "${NCCL_SOCKET_IFNAME}"
       TP_SOCKET_IFNAME: "${TP_SOCKET_IFNAME:-${NCCL_SOCKET_IFNAME}}"
       GLOO_SOCKET_IFNAME: "${GLOO_SOCKET_IFNAME:-${NCCL_SOCKET_IFNAME}}"
-      NCCL_IB_GID_INDEX: "${NCCL_IB_GID_INDEX:-}"
+      # Per-node RoCEv2 GID index. WORKER_NCCL_IB_GID_INDEX (rank 1) takes
+      # precedence when set; otherwise falls back to NCCL_IB_GID_INDEX (rank 0).
+      # The RoCEv2 IPv4 GID index differs per node and can drift across reboots;
+      # a single shared IPv4 index (e.g. 3) applied to both ranks can wedge NCCL
+      # at init with "unhandled system error". Setting the worker's index separately
+      # avoids this. Link-local IPv6 (index 0) is the most reboot-stable choice.
+      NCCL_IB_GID_INDEX: "${WORKER_NCCL_IB_GID_INDEX:-${NCCL_IB_GID_INDEX:-0}}"
       NCCL_IB_ADDR_FAMILY: "${NCCL_IB_ADDR_FAMILY:-AF_INET}"
       NCCL_IB_ROCE_VERSION_NUM: "${NCCL_IB_ROCE_VERSION_NUM:-2}"
       NCCL_CROSS_NIC: "${NCCL_CROSS_NIC:-1}"


### PR DESCRIPTION
# Problem

On a 2-node DGX Spark TP=2 deployment, the RoCEv2 IPv4 GID index (`NCCL_IB_GID_INDEX`) is used by both ranks from a single value. The index differs per node and can drift across reboots or link events. Upstream's own `.env.dspark.example` already warns that the **GID index is not always 0** and must match the node's RoCE GID.

When a single shared IPv4 index (for example, `3`) is applied to both ranks and the worker's actual index differs, NCCL fails during initialization with an **"unhandled system error"**, preventing the worker from joining the cluster. This is the #1 troubleshooting item in the howtospark dual-spark guide, and the failure is difficult to diagnose because the error surfaces deep inside NCCL initialization rather than during vLLM configuration validation.

# Fix

Add `WORKER_NCCL_IB_GID_INDEX` so the worker rank (rank 1) can use a different GID index than the head node.

`docker-compose.dspark.yml` now resolves the value as:

```text
WORKER_NCCL_IB_GID_INDEX
        ↓
NCCL_IB_GID_INDEX
        ↓
0
```

Resolution behavior:

- If `WORKER_NCCL_IB_GID_INDEX` is set, the worker uses that value.
- Otherwise, it falls back to `NCCL_IB_GID_INDEX` (the head node's value).
- If neither variable is set, the default is `0` (link-local IPv6).

This preserves existing behavior for clusters where both nodes share the same GID index while allowing heterogeneous configurations to work correctly.

The new variable and the associated failure mode are documented in `.env.dspark.example`.

# Why Default to `0` (Link-Local IPv6)

The IPv4 RoCEv2 GID index (for example, `3`) is the one that commonly changes after reboots or network events. In contrast, index `0` (link-local IPv6) is assigned by the fabric and remains stable across reboots, making it the safest default.

Operators only need to set `WORKER_NCCL_IB_GID_INDEX` if the worker's IPv4 GID index differs from the head node's.

# Verification

- Verified the resolved GID indexes on both nodes using `show_gids`.
- Confirmed that both nodes currently resolve to index `0` (link-local IPv6), making the worker override a no-op on this cluster by design.
- Confirmed that the Compose change affects only GID environment variable resolution and does **not** modify the inline `vllm serve` command or any serving parameters.
- Verified that the deployment continues to boot successfully and serves normally with the new resolution logic.

# Notes

- This change improves deployment robustness only. It does **not** affect performance, throughput, or correctness during normal operation.
- Reference: howtospark dual-spark guide, troubleshooting section: **"NCCL dies at init with 'unhandled system error'"**.