### PR TITLE
fix: per-node NCCL_IB_GID_INDEX via start-script injection

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -27,7 +27,14 @@ NCCL_IB_HCA=rocepXsYfZ
 NCCL_SOCKET_IFNAME=enpXsYfZnpN
 TP_SOCKET_IFNAME=enpXsYfZnpN
 GLOO_SOCKET_IFNAME=enpXsYfZnpN
+# Head-node RoCEv2 GID index (compose / head rank). Confirm with show_gids on each box.
+# Index can differ per node and drift after reboot; a single shared IPv4 index applied
+# to both ranks can wedge NCCL at init with "unhandled system error".
 NCCL_IB_GID_INDEX=0
+# Optional worker override. Set on the HEAD .env; start-deepseek-v4-flash-dspark.sh
+# injects NCCL_IB_GID_INDEX on remote compose (shared/scp'd .env is fine).
+# Defaults to NCCL_IB_GID_INDEX when unset.
+# WORKER_NCCL_IB_GID_INDEX=3
 NCCL_CROSS_NIC=1
 
 # Caches / model

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -40,11 +40,17 @@ VLLM_HOST_IP="${VLLM_HOST_IP:-$MASTER_ADDR}"
 WORKER_VLLM_HOST_IP="${WORKER_VLLM_HOST_IP:-$WORKER_HOST}"
 WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
 WORKER_HF_CACHE="${WORKER_HF_CACHE:-${HF_CACHE:-}}"
+# Per-node RoCEv2 GID: worker may differ from head (and can drift after reboot).
+# Set WORKER_NCCL_IB_GID_INDEX in the head .env; start script injects it on remote compose.
+# Do not put WORKER_* first in docker-compose substitution — that is not rank-aware.
+WORKER_NCCL_IB_GID_INDEX="${WORKER_NCCL_IB_GID_INDEX:-${NCCL_IB_GID_INDEX:-}}"
 REMOTE_WORKER_DIR="$(printf '%q' "$WORKER_DIR")"
 REMOTE_COMPOSE_FILE="$REMOTE_WORKER_DIR/docker-compose.dspark.yml"
 REMOTE_ENV_FILE="$REMOTE_WORKER_DIR/.env.dspark"
 REMOTE_VLLM_GB10_PATCH_DIR="$REMOTE_WORKER_DIR/vllm_patch_gb10"
 REMOTE_COMPOSE="cd $REMOTE_WORKER_DIR && env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS COMPOSE_DISABLE_ENV_FILE=1"
+# Env overrides on every remote compose invocation (beats a synced .env.dspark GID pin).
+REMOTE_NCCL_ENV="NCCL_IB_GID_INDEX='$WORKER_NCCL_IB_GID_INDEX'"
 STARTUP_LOG_SINCE=""
 
 need_cmd() {
@@ -72,7 +78,7 @@ compose_base() {
 }
 
 remote_compose() {
-  ssh "$WORKER_HOST" "$REMOTE_COMPOSE $*"
+  ssh "$WORKER_HOST" "$REMOTE_COMPOSE $REMOTE_NCCL_ENV $*"
 }
 
 log_since() {
@@ -128,6 +134,8 @@ print_resolved_profile() {
   echo "  mtp speculative tokens: ${MTP_NUM_TOKENS:-5}"
   echo "  head host/ip: ${VLLM_HOST:-127.0.0.1} / $VLLM_HOST_IP"
   echo "  worker host/ip: $WORKER_HOST / $WORKER_VLLM_HOST_IP"
+  echo "  head NCCL_IB_GID_INDEX: ${NCCL_IB_GID_INDEX:-}"
+  echo "  worker NCCL_IB_GID_INDEX: $WORKER_NCCL_IB_GID_INDEX"
   echo "  worker dir: $WORKER_DIR"
   echo "  worker cache: ${WORKER_HF_CACHE:-${HF_CACHE:-}}"
   echo "  GB10 vLLM patch: $ENABLE_VLLM_GB10_PATCH"


### PR DESCRIPTION
## Problem

On dual-Spark TP=2, RoCEv2 `NCCL_IB_GID_INDEX` can differ per node and drift after reboot. A single shared index on both ranks can wedge NCCL at init (`unhandled system error`).

## Why not #10

#10 put `WORKER_NCCL_IB_GID_INDEX` first in `docker-compose.dspark.yml` substitution. Compose has one service and is **not** rank-aware, so that value would apply on whichever host runs compose (including the head) whenever the var is set. Shared/scp'd `.env.dspark` makes that footgun worse.

## Fix

Wire the override through the dual-node launcher, the same place head vs worker env already splits:

1. **`start-deepseek-v4-flash-dspark.sh`**
   - `WORKER_NCCL_IB_GID_INDEX` defaults to head `NCCL_IB_GID_INDEX`
   - `REMOTE_NCCL_ENV` injects `NCCL_IB_GID_INDEX=<worker value>` on every remote compose call
   - Head still uses head `NCCL_IB_GID_INDEX` via `compose_base`
   - Resolved profile prints both indexes

2. **`.env.dspark.example`**
   - Document head `NCCL_IB_GID_INDEX` and optional commented `WORKER_NCCL_IB_GID_INDEX`
   - Set the worker override on the **head** env; start script applies it remotely (shared env is fine)

3. **`docker-compose.dspark.yml`**
   - Unchanged: still `NCCL_IB_GID_INDEX: "${NCCL_IB_GID_INDEX:-}"` only

## Usage

```bash
# head .env.dspark
NCCL_IB_GID_INDEX=0
WORKER_NCCL_IB_GID_INDEX=3   # only if worker show_gids differs
```

## Supersedes

Closes the gap intended by #10 with correct injection. #10 should be closed in favor of this PR.
