### PR TITLE
Report prompt caching details

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -123,6 +123,7 @@ services:
         --max-cudagraph-capture-size $$(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-5} + 1) ))
         --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION:-0.80}
         --enable-prefix-caching
+        --enable-prompt-tokens-details
         --async-scheduling
         --enable-chunked-prefill
         --speculative-config "$${SPECULATIVE_CONFIG}"


### PR DESCRIPTION
Without this flag there is no usage information reported regarding how many tokens were cached.

Tested with https://github.com/mrexodia/cache-tester