### PR TITLE
Add DEFAULT_THINKING configuration option

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -85,6 +85,9 @@ MAX_NUM_SEQS=6
 MAX_NUM_BATCHED_TOKENS=8192
 GPU_MEMORY_UTILIZATION=0.80
 MTP_NUM_TOKENS=5
+# Default reasoning mode: off, low, high, or max. "low" is DeepSeek V4's
+# base thinking mode (no extra effort prefix); request-level overrides still win.
+DEFAULT_THINKING=low
 
 # No sampling override. The launcher keeps --generation-config vllm only.
 # Explicit client request parameters still win.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ logic ships inside the image rather than as a host bind-mount.
 - `kv_cache_dtype=nvfp4_ds_mla`
 - `gpu_memory_utilization=0.80`
 - `MTP_NUM_TOKENS=5` (checkpoint `dspark_block_size` is 5; k must be ≥ 5)
+- `DEFAULT_THINKING=low` (`off`, `low`, `high`, or `max`; request-level overrides still win)
 - `VLLM_USE_BREAKABLE_CUDAGRAPH=0` (keep regular CUDA graphs; Anemll auto-enables the slower breakable path when unset)
 - API bind address `0.0.0.0:8888`
 
@@ -570,8 +571,11 @@ On this deployment there are three checks to make before blaming the weights:
    `--override-generation-config`; explicit client request parameters still
    win.
 
-The compose launcher includes `--generation-config vllm`, sets `thinking=false`,
-uses DSpark speculative decoding with `MTP_NUM_TOKENS=5` and
+The compose launcher includes `--generation-config vllm` and defaults to
+`DEFAULT_THINKING=low`. It validates `off`, `low`, `high`, or `max` and
+translates the selected mode into vLLM chat-template kwargs; explicit
+request-level overrides still win. It uses DSpark speculative decoding with
+`MTP_NUM_TOKENS=5` and
 `draft_sample_method=probabilistic`, keeps regular CUDA graphs via
 `VLLM_USE_BREAKABLE_CUDAGRAPH=0`, and enables the FlashInfer sampler. For
 exact deterministic curl checks, send `temperature: 0` in the request body.
@@ -808,6 +812,50 @@ http://HEAD_NODE_IP:VLLM_PORT/v1
 `VLLM_HOST=127.0.0.1`. For Hermes/OpenClaw or
 another machine to use the endpoint, keep `VLLM_HOST=0.0.0.0` and control
 access at the network/firewall layer.
+
+## Pi reasoning controls (off / low / high / max)
+
+The 0731 checkpoint has no Hugging Face Jinja `chat_template`.
+`--tokenizer-mode deepseek_v4` instead calls the checkpoint's installed
+`encoding/encoding_dsv4.py`, which supports `off`, `low`, `high`, and `max`.
+The recipe defaults to `DEFAULT_THINKING=low`, the base reasoning mode. This
+mode opens `<think>` but adds no effort prefix. Clients should still send an
+explicit request-level override when they require deterministic behavior.
+
+A ready-to-copy pi configuration is provided in
+[`pi-models.dspark.example.json`](pi-models.dspark.example.json):
+
+```bash
+mkdir -p ~/.pi/agent
+cp pi-models.dspark.example.json ~/.pi/agent/models.json
+# If pi runs away from the head node, replace 127.0.0.1 with HEAD_NODE_IP.
+```
+
+Select the supported modes with pi's normal thinking control:
+
+```bash
+pi --model local-dspark/deepseek-v4-flash-0731 --thinking off
+pi --model local-dspark/deepseek-v4-flash-0731 --thinking low
+pi --model local-dspark/deepseek-v4-flash-0731 --thinking high
+pi --model local-dspark/deepseek-v4-flash-0731 --thinking max
+```
+
+`DEFAULT_THINKING` and pi use the same mapping. The pi configuration hides the
+unsupported `minimal`, `medium`, and `xhigh` levels:
+
+| Pi level | vLLM request |
+|---|---|
+| `off` | `chat_template_kwargs: {"thinking": false}` |
+| `low` | `chat_template_kwargs: {"thinking": true, "reasoning_effort": "low"}` |
+| `high` | `chat_template_kwargs: {"thinking": true, "reasoning_effort": "high"}` |
+| `max` | `chat_template_kwargs: {"thinking": true, "reasoning_effort": "max"}` |
+
+Do not use pi's generic top-level OpenAI `reasoning_effort` mapping for this
+endpoint. The specialized DeepSeek V4 tokenizer reads these values from
+`chat_template_kwargs`. vLLM returns the generated reasoning in its `reasoning`
+stream field; pi recognizes that field, stores it as a thinking block, and
+replays it as `reasoning`. vLLM normalizes that to `reasoning_content` before
+the custom encoder runs, so tool-call reasoning is not lost.
 
 ## Runtime Profile
 

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -86,6 +86,7 @@ services:
       MASTER_PORT: "${MASTER_PORT:-25000}"
       # Checkpoint dspark_block_size is 5; k<5 truncates draft blocks (silent on 0.25.2 image).
       MTP_NUM_TOKENS: "${MTP_NUM_TOKENS:-5}"
+      DEFAULT_THINKING: "${DEFAULT_THINKING:-low}"
 
     command:
       - bash
@@ -107,6 +108,13 @@ services:
           VLLM_QUANTIZATION_ARGS="--quantization modelopt_gb10_hybrid";
         fi;
         SPECULATIVE_CONFIG="{\"method\":\"dspark\",\"num_speculative_tokens\":$${MTP_NUM_TOKENS:-5},\"draft_sample_method\":\"probabilistic\"}";
+        case "$${DEFAULT_THINKING:-low}" in
+          off) DEFAULT_CHAT_TEMPLATE_KWARGS='{"thinking":false}' ;;
+          low) DEFAULT_CHAT_TEMPLATE_KWARGS='{"thinking":true,"reasoning_effort":"low"}' ;;
+          high) DEFAULT_CHAT_TEMPLATE_KWARGS='{"thinking":true,"reasoning_effort":"high"}' ;;
+          max) DEFAULT_CHAT_TEMPLATE_KWARGS='{"thinking":true,"reasoning_effort":"max"}' ;;
+          *) echo "DEFAULT_THINKING must be one of: off, low, high, max (got: $${DEFAULT_THINKING})" >&2; exit 2 ;;
+        esac;
         exec /usr/local/bin/vllm serve ${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
         --served-model-name ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}
         --host ${VLLM_HOST:-127.0.0.1}
@@ -134,7 +142,7 @@ services:
         --enable-auto-tool-choice
         --reasoning-parser deepseek_v4
         --reasoning-config '{"reasoning_parser":"deepseek_v4","reasoning_start_str":"<think>","reasoning_end_str":"</think>"}'
-        --default-chat-template-kwargs '{"thinking":false}'
+        --default-chat-template-kwargs "$${DEFAULT_CHAT_TEMPLATE_KWARGS}"
         --generation-config vllm
         --enable-flashinfer-autotune
         --nnodes 2

--- a/docs/DEEPSEEK_V4_FLASH_0731.md
+++ b/docs/DEEPSEEK_V4_FLASH_0731.md
@@ -21,6 +21,19 @@ The model card does not ship a Jinja chat template. It includes an `encoding` pa
 
 Set `DSPARK_ENCODING_FILE` to the checkpoint's `encoding/encoding_dsv4.py` path inside the container when the runtime image predates the checkpoint. The launcher installs that encoder into vLLM before import, on both ranks. It also corrects pre-0731 tokenizer wrappers that mapped `low` reasoning effort to `high`. These changes are required for the 0731 `reasoning_content`, reasoning-effort, and tool-argument semantics.
 
+The equivalent Unsloth GGUF Jinja template implements the same central DS4
+behavior—DSML tools, `<think>` boundaries, `high`/`max` instruction prefixes,
+and retention of tool-turn `reasoning_content`—but it is not loaded by this
+vLLM profile. Here, request controls are consumed by vLLM's custom tokenizer
+wrapper and passed to the Python encoder. The underlying implementations fall
+back to non-thinking when no kwarg exists, but this recipe defaults
+`DEFAULT_THINKING=low` to match DeepSeek V4's intended base reasoning mode.
+The setting accepts `off`, `low`, `high`, or `max`; `low` opens
+`<think>` but adds no effort instruction. For pi, use
+`pi-models.dspark.example.json`; it maps pi's off/low/high/max selector
+to request-level `chat_template_kwargs.thinking` and
+`chat_template_kwargs.reasoning_effort`.
+
 ## Benchmark Method
 
 Run `scripts/benchmark-0731.py` against a warmed endpoint. The default sweep covers 256, 2K, 8K, 32K, and 128K prompt tokens at concurrency 1, 2, 4, and 6. Each request has a distinct first cache block so prefix caching cannot make later cases reuse earlier prefill work. It streams each response, records time to first token, prefill throughput, per-request decode throughput, and aggregate decode throughput using API-reported token counts from naturally completed responses. It does not impose a server-side output limit.

--- a/pi-models.dspark.example.json
+++ b/pi-models.dspark.example.json
@@ -1,0 +1,51 @@
+{
+  "providers": {
+    "local-dspark": {
+      "baseUrl": "http://127.0.0.1:8888/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "supportsStrictMode": false,
+        "maxTokensField": "max_tokens"
+      },
+      "models": [
+        {
+          "id": "deepseek-v4-flash-0731",
+          "name": "DeepSeek V4 Flash 0731 (2x DGX Spark)",
+          "reasoning": true,
+          "thinkingLevelMap": {
+            "minimal": null,
+            "low": "low",
+            "medium": null,
+            "high": "high",
+            "xhigh": null,
+            "max": "max"
+          },
+          "input": ["text"],
+          "contextWindow": 1048576,
+          "maxTokens": 32768,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "compat": {
+            "thinkingFormat": "chat-template",
+            "chatTemplateKwargs": {
+              "thinking": {
+                "$var": "thinking.enabled"
+              },
+              "reasoning_effort": {
+                "$var": "thinking.effort",
+                "omitWhenOff": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -98,7 +98,15 @@ fi
 VLLM_PORT="$((10#$VLLM_PORT))"
 # Keep PORT as a backwards-compatible alias, but use VLLM_PORT internally.
 PORT="$VLLM_PORT"
-export VLLM_HOST VLLM_PORT PORT
+DEFAULT_THINKING="${DEFAULT_THINKING:-low}"
+case "$DEFAULT_THINKING" in
+  off|low|high|max) ;;
+  *)
+    echo "DEFAULT_THINKING must be one of: off, low, high, max (got: $DEFAULT_THINKING)" >&2
+    exit 2
+    ;;
+esac
+export VLLM_HOST VLLM_PORT PORT DEFAULT_THINKING
 
 # A wildcard is valid for binding but not a useful health-check destination.
 API_HOST="${API_HOST:-$VLLM_HOST}"
@@ -376,6 +384,7 @@ print_resolved_profile() {
   echo "  max batched tokens: ${MAX_NUM_BATCHED_TOKENS:-8192}"
   echo "  gpu memory utilization: ${GPU_MEMORY_UTILIZATION:-0.80}"
   echo "  mtp speculative tokens: ${MTP_NUM_TOKENS:-5} (dspark_block_size min is 5)"
+  echo "  default thinking: $DEFAULT_THINKING (off/low/high/max)"
   echo "  cudagraph capture size: $(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-5} + 1) ))"
   echo "  API bind: $VLLM_HOST:$VLLM_PORT"
   echo "  API probe: $API_URL"

--- a/stop-deepseek-v4-flash-dspark.sh
+++ b/stop-deepseek-v4-flash-dspark.sh
@@ -22,14 +22,42 @@ WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
 WORKER_HF_CACHE="${WORKER_HF_CACHE:-${HF_CACHE:-}}"
 WORKER_VLLM_HOST_IP="${WORKER_VLLM_HOST_IP:-}"
 
+local_project_has_resources() {
+  local project="$1"
+  {
+    docker ps -aq --filter "label=com.docker.compose.project=$project"
+    docker network ls -q --filter "label=com.docker.compose.project=$project"
+    docker volume ls -q --filter "label=com.docker.compose.project=$project"
+  } | grep -q .
+}
+
 stop_project() {
   local project="$1"
 
-  echo "Stopping DSpark head project ${project}..."
-  COMPOSE_DISABLE_ENV_FILE=1 docker compose -p "$project" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" down || true
+  if local_project_has_resources "$project"; then
+    echo "Stopping DSpark head project ${project}..."
+    COMPOSE_DISABLE_ENV_FILE=1 docker compose -p "$project" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" down || true
+  else
+    echo "No DSpark head resources for project ${project}; skipping."
+  fi
 
-  echo "Stopping DSpark worker project ${project} on ${WORKER_HOST}..."
-  ssh "$WORKER_HOST" "cd '$WORKER_DIR' && env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS COMPOSE_DISABLE_ENV_FILE=1 HF_CACHE='$WORKER_HF_CACHE' VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' docker compose -p '$project' --env-file .env.dspark -f docker-compose.dspark.yml down" || true
+  ssh "$WORKER_HOST" "
+    cd '$WORKER_DIR' || exit 1
+    if {
+      docker ps -aq --filter 'label=com.docker.compose.project=$project'
+      docker network ls -q --filter 'label=com.docker.compose.project=$project'
+      docker volume ls -q --filter 'label=com.docker.compose.project=$project'
+    } | grep -q .; then
+      echo 'Stopping DSpark worker project $project on $WORKER_HOST...'
+      env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS \
+        COMPOSE_DISABLE_ENV_FILE=1 HF_CACHE='$WORKER_HF_CACHE' \
+        VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' \
+        docker compose -p '$project' --env-file .env.dspark \
+          -f docker-compose.dspark.yml down
+    else
+      echo 'No DSpark worker resources for project $project on $WORKER_HOST; skipping.'
+    fi
+  " || true
 }
 
 stop_project "$PROJECT_NAME"


### PR DESCRIPTION
Ran some overnight benchmarks and discovered that thinking is disabled per default. Added `DEFAULT_THINKING` environment variable where you can specify `off/low/high/max` (default `low`, but happy to change). Also added example pi configuration and fixed a minor issue in the stop script where it would unnecessarily warn.