### PR TITLE
Restore --enable-prompt-tokens-details (supported by default image)

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -131,6 +131,7 @@ services:
         --max-cudagraph-capture-size $$(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-5} + 1) ))
         --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION:-0.80}
         --enable-prefix-caching
+        --enable-prompt-tokens-details
         --async-scheduling
         --enable-chunked-prefill
         --speculative-config "$${SPECULATIVE_CONFIG}"


### PR DESCRIPTION
# Restore `--enable-prompt-tokens-details` (supported by the default image)

Restores the `--enable-prompt-tokens-details` flag that was dropped in `1e5661e` ("fix: drop …"). That drop was based on an incorrect check; the flag **is** supported by the default `ghcr.io/anemll/dspark-vllm-gx10:0.1.1` image and should stay as it was after #15.

## Why the drop was wrong

The original claim (issue #17) was that the flag is unregistered because it doesn't exist in `vllm/engine/arg_utils.py` / `EngineArgs`. That's true but misleading — **it's a serve-level arg, not an engine arg.** It lives in the OpenAI serve args dataclass:

- `vllm/entrypoints/openai/cli_args.py:132` — `enable_prompt_tokens_details: bool = False`
- `cli_args.py:198 add_cli_args()` auto-generates the `--enable-prompt-tokens-details` option from that field

## Verification (against the byte-exact default image, vLLM `0.25.2.dev0+g752a3a504.d20260714`)

1. **Accepted by the real CLI**: `vllm serve … --enable-prompt-tokens-details` runs in the `0.1.1` image and parses the flag — log shows `non-default args: {…, 'enable_prompt_tokens_details': True, …}` and startup proceeds.
2. **Parsing is strict** (control): a genuinely bogus flag `--definitely-not-a-real-flag-xyz123` is rejected with `vllm: error: unrecognized arguments` (exit 2). Since the real flag does **not** error, it is registered, not silently swallowed.
3. **Field lookup**: `enable_prompt_tokens_details` is a real field of the serve-args dataclass wired to the flag.
4. **Field evidence in the wild**: the reference 2× DGX Spark deployment on this machine has been running `0.1.1` with this flag for hours without issue (container command verified via `docker inspect`/`ps`).

## Effect

- `docker-compose.dspark.yml` regains `--enable-prompt-tokens-details` (the exact line from post-#15, between `--enable-prefix-caching` and `--async-scheduling`).
- Restores PR #15's behavior: `prompt_tokens_details` (with cached-token counts) in chat-completion `usage`, i.e. client-visible prompt-cache reporting.

## Housekeeping

- This replaces the earlier un-reviewed direct-push revert `6f8bd12` on `main` (rewound out); this PR is the same 1-line restoration, now reviewable.
- The issue #17 `--enable-prompt-tokens-details` finding is rescinded in a comment there; the remaining GB10 0x51/livelock finding is a separate platform/driver issue and is out of scope here.

Closes the flag portion of #17 (the flag portion; the platform freeze follow-up stays open).
