### PR TITLE
validator: warn when pinned revision is not in the local HF cache

### DIFF
--- a/validate-dspark-config.sh
+++ b/validate-dspark-config.sh
@@ -60,6 +60,41 @@ if [ -n "${DSPARK_REVISION:-}" ]; then
 else
   echo "  revision: (default branch tip / unpinned)"
 fi
+
+# Warn when the pinned revision is not in the local HF cache: starting the
+# stack would silently begin a very large download (~155 GB for 0731). This is
+# easy to hit when upgrading a deployment that predates the issue #19 pin, as
+# its cached snapshot is whatever `main` was at install time.
+check_revision_cached() {
+  [ -n "${DSPARK_REVISION:-}" ] || return 0
+
+  hf_home="${HF_HOME:-${DSPARK_HF_CACHE:-$HOME/.cache/huggingface}}"
+  case "$hf_home" in
+    */huggingface) hub_dir="$hf_home/hub" ;;
+    *) hub_dir="$hf_home/hub" ;;
+  esac
+  model_dir="$hub_dir/models--$(printf '%s' "$DSPARK_MODEL" | sed 's|/|--|g')"
+  snapshots_dir="$model_dir/snapshots"
+
+  # No local cache at all: a first-time install is expected to download.
+  [ -d "$snapshots_dir" ] || return 0
+  [ -d "$snapshots_dir/$DSPARK_REVISION" ] && return 0
+
+  cached="$(ls -1 "$snapshots_dir" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
+  [ -n "$cached" ] || return 0
+
+  echo ""
+  echo "  [WARN] Pinned revision is NOT in the local HF cache:"
+  echo "           pinned: $DSPARK_REVISION"
+  echo "           cached: $cached"
+  echo "         Starting will download the full checkpoint (~155 GB for 0731)."
+  echo "         To keep using the cached weights, set in $ENV_FILE on BOTH nodes:"
+  echo "           DSPARK_REVISION=${cached%% *}"
+  echo "         To fetch the pinned revision deliberately, run"
+  echo "         ./prepare-dspark-model-cache.sh first."
+  echo ""
+}
+check_revision_cached
 echo "  model: ${DSPARK_MODEL}"
 echo "  served model: ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
 echo "  max model len: ${MAX_MODEL_LEN:-1048576}"


### PR DESCRIPTION
### Summary

Thanks for the recipe — and for the #19 pin fix; honoring the tested revision is the right call.

One side effect worth a guard rail: because the downloader now honors the pinned `DSPARK_REVISION`, a deployment built **before** that fix has a *different* snapshot cached (whatever `main` was at install time), and the next start silently begins a **full checkpoint download (~155 GB for 0731)**. `validate-dspark-config.sh` prints the resolved revision but never checks whether those weights are present locally, so there's no warning before the download starts.

Anyone who deployed during the window described in #19 is in exactly this state.

### What this changes

Adds `check_revision_cached()` to `validate-dspark-config.sh`. When the pinned `DSPARK_REVISION` is **not** found under `snapshots/` but other revisions **are** cached, it prints a warning listing the cached revision(s) and the one-line `.env.dspark` change to keep using them:

```
  [WARN] Pinned revision is NOT in the local HF cache:
           pinned: 9e165c30...
           cached: 7872f01b...
         Starting will download the full checkpoint (~155 GB for 0731).
         To keep using the cached weights, set in .env.dspark on BOTH nodes:
           DSPARK_REVISION=7872f01b...
         To fetch the pinned revision deliberately, run
         ./prepare-dspark-model-cache.sh first.
```

It stays **silent** in the normal cases:
- pinned revision is cached (fast-forward upgrades)
- no local cache at all (first-time install is expected to download)
- unpinned config (`DSPARK_REVISION=`)

### Testing (2× DGX Spark, GB10)

- Mismatched pin (cached `7872f01b…`, pinned `9e165c30…`) → warning fires with correct revisions and `.env.dspark` path
- Cached revision / unpinned / first-install (no cache) → silent, exit 0
- `bash -n` clean; validator output otherwise unchanged

Scoped to a single file; no behavior change beyond the added notice.
