### PR TITLE
Add derived image for 2ms vLLM shared-memory spin wait

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -116,6 +116,17 @@ DEFAULT_THINKING=max
 # applied the hotfix manually or are using a patched image).
 # DSPARK_SKIP_HOTFIX=0
 
+# CPU/thermal mitigation for vLLM's shared-memory broadcast SpinCondition.
+# Build from the known unpatched image (do not use $DSPARK_VLLM_IMAGE after it
+# has already been switched to the derived tag):
+#   docker build \
+#     --build-arg BASE_IMAGE='ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8' \
+#     -t vllm-dspark-runtime:spin-wait-2ms \
+#     -f Dockerfile.vllm-spin-wait-2ms .
+# Then set DSPARK_VLLM_IMAGE to the derived tag on the head; the launcher
+# copies the env file to the worker and requires the same tag to exist there.
+# Roll back by restoring the previous image value.
+
 # No sampling override. The launcher keeps --generation-config vllm only.
 # Explicit client request parameters still win.
 

--- a/Dockerfile.vllm-spin-wait-2ms
+++ b/Dockerfile.vllm-spin-wait-2ms
@@ -1,0 +1,55 @@
+# Narrow mitigation for vLLM's shared-memory broadcast spin wait.
+#
+# Build example:
+#   docker build \
+#     --build-arg BASE_IMAGE='ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8' \
+#     -t vllm-dspark-runtime:spin-wait-2ms \
+#     -f Dockerfile.vllm-spin-wait-2ms .
+ARG BASE_IMAGE=ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8
+FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.title="DSpark vLLM with 2ms SpinCondition wait"
+LABEL org.opencontainers.image.description="Changes only vLLM shm_broadcast.py SpinCondition busy_loop_s default from 1s to 2ms"
+LABEL com.seapy.vllm.spin-wait.busy-loop-seconds="0.002"
+
+RUN python3 - <<'PY'
+from pathlib import Path
+
+path = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/distributed/"
+    "device_communicators/shm_broadcast.py"
+)
+old = "busy_loop_s: float = 1,"
+new = "busy_loop_s: float = 0.002,"
+text = path.read_text()
+
+if text.count(old) != 1:
+    raise SystemExit(
+        f"refusing to patch {path}: expected exactly one {old!r}, "
+        f"found {text.count(old)}"
+    )
+if new in text:
+    raise SystemExit(f"refusing to patch {path}: {new!r} already exists")
+
+path.write_text(text.replace(old, new, 1))
+patched = path.read_text()
+if patched.count(new) != 1 or old in patched:
+    raise SystemExit(f"post-patch verification failed for {path}")
+print(f"patched {path}: {old!r} -> {new!r}")
+PY
+
+RUN python3 - <<'PY'
+from pathlib import Path
+
+path = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/distributed/"
+    "device_communicators/shm_broadcast.py"
+)
+lines = [
+    line.strip()
+    for line in path.read_text().splitlines()
+    if "busy_loop_s: float" in line
+]
+assert lines == ["busy_loop_s: float = 0.002,"], lines
+print(lines)
+PY


### PR DESCRIPTION
## Summary

- add a fail-closed derived-image Dockerfile that changes only `SpinCondition(... busy_loop_s)` from 1 second to 2 ms
- document build and rollback selection in `.env.dspark.example`
- keep the current default image unchanged

## Validation

- `docker build --check` passed against the DSpark base image
- built and loaded on two DGX Spark nodes
- verified `shm_broadcast.py` contains exactly `busy_loop_s: float = 0.002` on both live containers
- `/v1/models` and a 1,024-token `/v1/chat/completions` request succeeded
- 40-second load telemetry on rank 0 observed `VLLM::EngineCore` median 5.3%, max 5.4%; the previous 1-second A/B was approximately 100%

The original image/tag remains available for rollback.