### PR TITLE
fix: cap benchmark output so unbounded reasoning cannot stall the sweep

### DIFF
--- a/scripts/benchmark-0731.py
+++ b/scripts/benchmark-0731.py
@@ -34,14 +34,19 @@ def build_prompt(base_url, model, target, nonce):
         text += unit * max(1, (target - count) // 3)
 
 
-def stream_one(base_url, model, prompt):
+def stream_one(base_url, model, prompt, max_tokens):
     instruction = "\nReturn exactly 128 numbered lowercase English words, then stop."
-    body = {"model": model, "messages": [{"role": "user", "content": prompt + instruction}], "stream": True, "stream_options": {"include_usage": True}, "temperature": 0.6, "top_p": 0.95}
+    # max_tokens is mandatory here: the server's DEFAULT_THINKING can put reasoning
+    # on by default, and reasoning is not obliged to reach EOS. Without a cap a
+    # single lane can generate for hours (observed: >200k tokens, ~75 tok/s, no
+    # error) and stall the whole sweep behind it.
+    body = {"model": model, "messages": [{"role": "user", "content": prompt + instruction}], "stream": True, "stream_options": {"include_usage": True}, "temperature": 0.6, "top_p": 0.95, "max_tokens": max_tokens}
     request = urllib.request.Request(f"{base_url}/chat/completions", data=json.dumps(body).encode(), headers={"Content-Type": "application/json"})
     started = time.perf_counter()
     first = None
     usage = None
     output = []
+    finish_reason = None
     with urllib.request.urlopen(request, timeout=3600) as response:
         for raw in response:
             line = raw.decode().strip()
@@ -50,6 +55,8 @@ def stream_one(base_url, model, prompt):
             event = json.loads(line[6:])
             choices = event.get("choices") or []
             delta = choices[0].get("delta", {}) if choices else {}
+            if choices and choices[0].get("finish_reason"):
+                finish_reason = choices[0]["finish_reason"]
             if first is None and (delta.get("content") or delta.get("reasoning") or delta.get("reasoning_content")):
                 first = time.perf_counter()
             reasoning = delta.get("reasoning") or delta.get("reasoning_content") or ""
@@ -62,19 +69,21 @@ def stream_one(base_url, model, prompt):
     output_tokens = (usage or {}).get("completion_tokens", measured or 0)
     ttft = (first or finished) - started
     prompt_tokens = (usage or {}).get("prompt_tokens", 0)
-    return {"ttft_s": ttft, "elapsed_s": finished - started, "prompt_tokens": prompt_tokens, "prefill_tok_s": prompt_tokens / max(0.001, ttft), "output_tokens": output_tokens, "output_tok_s": output_tokens / max(0.001, finished - (first or finished))}
+    # truncated == the cap bound this request, so output_tokens is a floor rather
+    # than the model's natural length. Rates stay valid; total-length claims do not.
+    return {"ttft_s": ttft, "elapsed_s": finished - started, "prompt_tokens": prompt_tokens, "prefill_tok_s": prompt_tokens / max(0.001, ttft), "output_tokens": output_tokens, "output_tok_s": output_tokens / max(0.001, finished - (first or finished)), "finish_reason": finish_reason, "truncated": finish_reason == "length"}
 
 
-async def run_case(base_url, model, target_prompt_tokens, concurrency):
+async def run_case(base_url, model, target_prompt_tokens, concurrency, max_tokens):
     prompts = await asyncio.gather(*[
         asyncio.to_thread(build_prompt, base_url, model, target_prompt_tokens, f"p{target_prompt_tokens}-c{concurrency}-r{index}")
         for index in range(concurrency)
     ])
     started = time.perf_counter()
-    results = await asyncio.gather(*[asyncio.to_thread(stream_one, base_url, model, prompt) for prompt in prompts])
+    results = await asyncio.gather(*[asyncio.to_thread(stream_one, base_url, model, prompt, max_tokens) for prompt in prompts])
     elapsed = time.perf_counter() - started
     total = sum(item["output_tokens"] for item in results)
-    return {"concurrency": concurrency, "elapsed_s": elapsed, "aggregate_tok_s": total / max(0.001, elapsed), "median_ttft_s": statistics.median(item["ttft_s"] for item in results), "median_prefill_tok_s": statistics.median(item["prefill_tok_s"] for item in results), "median_output_tok_s": statistics.median(item["output_tok_s"] for item in results), "requests": results}
+    return {"concurrency": concurrency, "elapsed_s": elapsed, "aggregate_tok_s": total / max(0.001, elapsed), "median_ttft_s": statistics.median(item["ttft_s"] for item in results), "median_prefill_tok_s": statistics.median(item["prefill_tok_s"] for item in results), "median_output_tok_s": statistics.median(item["output_tok_s"] for item in results), "truncated_requests": sum(1 for item in results if item["truncated"]), "requests": results}
 
 
 async def main():
@@ -83,14 +92,15 @@ async def main():
     parser.add_argument("--model", default="deepseek-v4-flash-0731")
     parser.add_argument("--prompt-lengths", default="256,2048,8192,32768,131072")
     parser.add_argument("--concurrency", default="1,2,4,6")
+    parser.add_argument("--max-tokens", type=int, default=4096, help="Per-request output cap. Guards against unbounded reasoning under DEFAULT_THINKING=high/max; raise it if truncated_requests is non-zero and you need natural lengths.")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
     path = Path(args.output)
     path.parent.mkdir(parents=True, exist_ok=True)
-    report = {"model": args.model, "base_url": args.base_url, "cases": []}
+    report = {"model": args.model, "base_url": args.base_url, "max_tokens": args.max_tokens, "cases": []}
     for prompt_length in [int(value) for value in args.prompt_lengths.split(",")]:
         for concurrency in [int(value) for value in args.concurrency.split(",")]:
-            case = await run_case(args.base_url, args.model, prompt_length, concurrency)
+            case = await run_case(args.base_url, args.model, prompt_length, concurrency, args.max_tokens)
             case["target_prompt_tokens"] = prompt_length
             report["cases"].append(case)
             path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")


### PR DESCRIPTION
## Problem

`scripts/benchmark-0731.py` issues chat completions with no `max_tokens`, relying on
the model to emit EOS. With `DEFAULT_THINKING=high/max` the server enables reasoning
by default, and reasoning is not obliged to terminate — so a single lane can generate
indefinitely and stall the entire sweep behind it.

## Evidence

2× DGX Spark (GB10), Anemll `0.1.1` @ `sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8`,
recipe `cbd719f`, recipe defaults except `GPU_MEMORY_UTILIZATION_TEXT=0.80`, with
`DEFAULT_THINKING=max`:

One lane of the `2048 × c=6` case ran **47 minutes and ~200k tokens** at a steady
~75 tok/s while the other five lanes had long finished. No error, no preemption, no
truncation warning — the engine was perfectly healthy and reported `Running: 1 reqs`
for the entire period:

```
Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 77.2 tokens/s,
Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.5%, Prefix cache hit rate: 0.0%
```

For scale: the preceding 7 cases took ~10 minutes *combined*. At that rate, reaching
`max_model_len` (1M) would have taken roughly 3 more hours.

## Fix

- add `--max-tokens` (default 4096) and send it on every request
- record `finish_reason` and `truncated` per request, `truncated_requests` per case,
  and `max_tokens` in the report header

The reporting half matters as much as the cap: capping without reporting would silently
turn "natural length" numbers into "capped" numbers. With this, a capped run is visibly
capped — **rates stay valid under truncation, output-length and aggregate-throughput
claims do not.**

## Validation

Live run on the same cluster, with `--max-tokens 512` chosen deliberately *below* the
~2471-token natural length measured at `thinking=max`, so that truncation is forced and
the new reporting is actually exercised:

```
python3 scripts/benchmark-0731.py --output results/validate-max-tokens.json \
  --prompt-lengths 256,2048 --concurrency 1,6 --max-tokens 512
```

| case | elapsed | `truncated_requests` | `output_tokens` |
|---|---:|---:|---:|
| 256 × c=1 | 10.1s | 1/1 | 512 |
| 256 × c=6 | 24.2s | 6/6 | 512 |
| 2048 × c=1 | 10.1s | 1/1 | 512 |
| **2048 × c=6** | **30.5s** | 6/6 | 512 |

Whole sweep: 1m15s.

The last row is the case that hung: one of its lanes had been generating for 47 minutes
when I killed it. With the cap it completes in 30.5 seconds. Every request reports
`finish_reason: "length"` and `truncated: true`, and `output_tokens` lands exactly on the
cap, so a capped run is unambiguous in the JSON.

Not covered: I did not re-run an uncapped sweep to reconfirm the hang (it costs hours by
construction), and I have not exercised this with `DEFAULT_THINKING=off/low`, where natural
EOS should arrive well before any sane cap and `truncated_requests` should stay 0.

## Open question for maintainers

Default `4096` is a judgement call. Measured natural length at `thinking=max`, 256-token
prompt, `c=1` was 2471 tokens, so 4096 lets most requests finish naturally while bounding
the pathological case. If you would rather preserve the historical "natural length"
semantics exactly, make the default `None` (opt-in cap) — happy to flip it. Any non-`None`
default changes measured numbers relative to the README benchmarks, so this is worth a
deliberate call rather than my guess.
