### PR TITLE
fix: render RoCE GID helper without invalid heredoc

### DIFF
--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -234,20 +234,18 @@ resolve_rocev2_gid_index() {
   local hex remote
   hex="$(ipv4_to_gid_suffix "$match_ip")" || return 1
   remote=$(
-    cat <<EOF
-hca=$(printf '%q' "$hca")
-hex=$(printf '%q' "$hex")
-for g in /sys/class/infiniband/\$hca/ports/1/gids/*; do
-  [ -e "\$g" ] || continue
-  i=\${g##*/}
-  t=\$(cat /sys/class/infiniband/\$hca/ports/1/gid_attrs/types/\$i 2>/dev/null || true)
-  [ "\$t" = "RoCE v2" ] || continue
-  case \$(cat "\$g" 2>/dev/null) in
-    *ffff:\${hex}) echo "\$i"; exit 0 ;;
-  esac
-done
-exit 1
-EOF
+    printf 'hca=%q\nhex=%q\n' "$hca" "$hex"
+    printf '%s\n' \
+      'for g in /sys/class/infiniband/$hca/ports/1/gids/*; do' \
+      '  [ -e "$g" ] || continue' \
+      '  i=${g##*/}' \
+      '  t=$(cat /sys/class/infiniband/$hca/ports/1/gid_attrs/types/$i 2>/dev/null || true)' \
+      '  [ "$t" = "RoCE v2" ] || continue' \
+      '  case $(cat "$g" 2>/dev/null) in' \
+      '    *ffff:${hex}) echo "$i"; exit 0 ;;' \
+      '  esac' \
+      'done' \
+      'exit 1'
   )
   if [ -z "$ssh_target" ]; then
     bash -c "$remote"


### PR DESCRIPTION
## Summary
Fixes a Bash parse error in `start-deepseek-v4-flash-dspark.sh` that prevents the launcher from running at all:

```text
line 246: syntax error near unexpected token `;;'
```

The RoCEv2 GID-resolution helper generated a remote shell fragment with an unquoted heredoc. Its `case ... ;;` arm was parsed by the outer launcher. This replaces that heredoc with equivalent explicit `printf` construction of the remote body.

## Scope
- One file: `start-deepseek-v4-flash-dspark.sh`
- No deployment profile, model, image, scheduler, or runtime-option changes.
- Preserves local execution and `ssh "$target" "bash -s" <<< "$remote"` behavior.

## Validation
- `bash -n start-deepseek-v4-flash-dspark.sh`
- `shellcheck -S warning start-deepseek-v4-flash-dspark.sh`
- `bash -n stop-deepseek-v4-flash-dspark.sh validate-dspark-config.sh prepare-dspark-model-cache.sh`
- `git diff --check`
- Synthetic RoCE sysfs test: generated helper selects the expected RoCEv2 GID index while ignoring RoCEv1.
