### PR TITLE
Add DSPARK_SKIP_ISSUE26_HOTFIX escape hatch; document agentic-session output corruption

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -119,6 +119,12 @@ LONG_PREFILL_TOKEN_THRESHOLD=1024
 # and this interval keeps SWA dense tails from evicting MLA prefix blocks
 # during x8 32K+ waves. Unset/empty is not supported via compose default.
 VLLM_PREFIX_CACHE_RETENTION_INTERVAL=4096
+# Escape hatch: set to 1 to skip the Issue #26 coordinator hotfix entirely
+# (VLLM_PREFIX_CACHE_RETENTION_INTERVAL becomes inert). Use this if you see
+# output corruption in long agentic sessions — garbage token runs followed by
+# the model replaying verbatim earlier-context text (see Known issue in
+# CHANGELOG). Costs the 32K+ x8 warm prefix-cache hits that #26 restored.
+# DSPARK_SKIP_ISSUE26_HOTFIX=1
 # Main GPU util is chosen by ENABLE_VL_SIDECAR (see Experimental: Vision in README).
 # Do not set GPU_MEMORY_UTILIZATION here — start-deepseek-v4-flash-dspark.sh
 # exports it from these two profiles:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 2026-08-13
 
+### Known issue
+
+- **Output corruption in long agentic sessions with the Issue #26 coordinator hotfix applied**: on a 2x DGX Spark TP=2 deployment at recipe defaults (official 0731, `MTP_NUM_TOKENS=5`, `MAX_NUM_SEQS=6`, `DEFAULT_THINKING=low`), a real agentic-harness session (zcode) produced mid-generation corruption — a short garbage-token run (mixed-script fragments) followed by the model replaying **verbatim earlier-context text** (its own system prompt) as if it were the answer. Server stayed healthy; HTTP 200; no scheduler/proposer warnings; spec-decode acceptance normal. Bisect on the same host: with `patches/hotfix-dsv4-issue26-hybrid-swa-min.py` skipped (coordinator back to stock, everything else unchanged, including #27 and #31), a comparable fresh-session agentic workload ran clean. Suspected mechanism: with the SWA-min constraint relaxed, a prefix-cache hit can be backed by sliding-window KV blocks that were already freed/evicted, so the request resumes on wrong attention state. Not yet root-caused; single-lane and short-context smoke tests do not reproduce it — it needs a long multi-turn agentic session.
+
+### New
+
+- **`DSPARK_SKIP_ISSUE26_HOTFIX=1`** — escape hatch that skips the Issue #26 coordinator hotfix in the compose entrypoint (both nodes; `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` becomes inert). Default `0` (hotfix applies as before). Costs the 32K+ x8 warm prefix-cache restoration from #26; use it if you hit the corruption above. Resolved-profile output of `start-deepseek-v4-flash-dspark.sh` now reports the #26 hotfix status either way.
+
 ### Fixed
 
 - **Blank turns on stock OpenAI clients ([Issue #34](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/34))**: #31 only applied `thinking_token_budget` when the request sent the field. pi / OMP / VS Code custom EP cannot, so `DEFAULT_THINKING=max` still returned `content: null`. Recipe now applies omit-field defaults: `DEFAULT_THINKING_TOKEN_BUDGET=32768` and `DEFAULT_MAX_TOKENS=131072` (request wins; empty/`0` restores the old path). Generous on purpose — this model thinks a lot; 32k think + 128k total leaves ~100k for the answer. A client that still sends `max_tokens: 256` can blank; the server does not raise an explicit cap.

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -47,6 +47,10 @@ services:
       # coordinator hotfix — SWA-min alone still 0/8 at 44K+ x8 because
       # dense SWA tails evict MLA prefix blocks.
       VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}"
+      # Escape hatch: 1 skips the Issue #26 coordinator hotfix (see Known issue
+      # in CHANGELOG: output corruption observed in a long agentic session with
+      # the hotfix applied). Retention interval above is inert when skipped.
+      DSPARK_SKIP_ISSUE26_HOTFIX: "${DSPARK_SKIP_ISSUE26_HOTFIX:-0}"
       # Pin HF revision (issue #19). Empty → tip of default branch / refs/main.
       DSPARK_REVISION: "${DSPARK_REVISION:-}"
       DSPARK_ENCODING_FILE: "${DSPARK_ENCODING_FILE:-}"
@@ -133,7 +137,7 @@ services:
         if [ -z "$${ENCODING_SOURCE}" ]; then for candidate in /cache/huggingface/hub/models--deepseek-ai--DeepSeek-V4-Flash-0731/snapshots/*/encoding/encoding_dsv4.py; do if [ -f "$${candidate}" ]; then ENCODING_SOURCE="$${candidate}"; break; fi; done; fi;
         if [ -z "$${ENCODING_SOURCE}" ] && [ -f /models/deepseek-ai/DeepSeek-V4-Flash-0731/encoding/encoding_dsv4.py ]; then ENCODING_SOURCE=/models/deepseek-ai/DeepSeek-V4-Flash-0731/encoding/encoding_dsv4.py; fi;
         if [ -n "$${ENCODING_SOURCE}" ] && [ -f "$${ENCODING_SOURCE}" ]; then cp "$${ENCODING_SOURCE}" /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4_encoding.py; python3 -c 'from pathlib import Path; p=Path("/usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4.py"); s=p.read_text(); old="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            else:\n                reasoning_effort = \"high\""; new="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            elif reasoning_effort == \"high\":\n                reasoning_effort = \"high\"\n            else:\n                reasoning_effort = \"low\""; updated=s.replace(old,new); assert new in updated; p.write_text(updated)'; python3 /opt/hotfix-encoding-dsv4-issue21.py; fi;
-        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; python3 /opt/hotfix-dsv4-issue31-v2-thinking-budget.py; VLLM_QUANTIZATION_ARGS="";
+        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; if [ "$${DSPARK_SKIP_ISSUE26_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; else echo "[issue26-hotfix] SKIPPED (DSPARK_SKIP_ISSUE26_HOTFIX=1)"; fi; python3 /opt/hotfix-dsv4-issue31-v2-thinking-budget.py; VLLM_QUANTIZATION_ARGS="";
         if [ "$${ENABLE_VLLM_GB10_PATCH:-0}" = "1" ]; then
           python3 -m pip install -e /opt/vllm-gb10-hybrid-nvfp4 --no-deps;
           export VLLM_PLUGINS="$${VLLM_PLUGINS:-gb10_hybrid_nvfp4}";

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -466,6 +466,11 @@ print_resolved_profile() {
   else
     echo "  Issue #22 hotfix: not found"
   fi
+  if [ "${DSPARK_SKIP_ISSUE26_HOTFIX:-0}" = "1" ]; then
+    echo "  Issue #26 hotfix: SKIPPED (DSPARK_SKIP_ISSUE26_HOTFIX=1; VLLM_PREFIX_CACHE_RETENTION_INTERVAL inert)"
+  else
+    echo "  Issue #26 hotfix: will apply on start (DSPARK_SKIP_ISSUE26_HOTFIX=1 to skip)"
+  fi
   if [ "${DSPARK_SKIP_HOTFIX:-0}" = "1" ]; then
     echo "  DSV4 perf hotfixes (#50312/#50004/#49486/#48407/#48957/#50298/#44993-grammar): SKIPPED (DSPARK_SKIP_HOTFIX=1)"
   else
@@ -618,6 +623,9 @@ SIDECAR_COMPOSE_FILE="${SIDECAR_COMPOSE_FILE:-$SCRIPT_DIR/docker-compose.vl-side
 # when present.  Opt-outs:
 #   DSPARK_SKIP_HOTFIX=1          skip the v0.27 perf backports only
 #   DSPARK_SKIP_ISSUE22_HOTFIX=1  also skip Issue #22 (fully clean baseline)
+#   DSPARK_SKIP_ISSUE26_HOTFIX=1  skip the Issue #26 coordinator hotfix
+#                                 (consumed by the compose entrypoint; see
+#                                 Known issue in CHANGELOG)
 DSV4_HOTFIX_FILES=()
 if [ "${DSPARK_SKIP_ISSUE22_HOTFIX:-0}" != "1" ]; then
   DSV4_HOTFIX_FILES+=("hotfix-nvfp4-ds-mla-issue22.sh")


### PR DESCRIPTION
# Add `DSPARK_SKIP_ISSUE26_HOTFIX` escape hatch; document agentic-session corruption under the #26 coordinator hotfix

## Summary

With the Issue #26 coordinator hotfix (`1f9765e`) applied, a real long agentic-harness session (zcode) on a 2x DGX Spark TP=2 deployment at recipe defaults produced **mid-generation output corruption**: a short garbage-token run (mixed-script fragments, e.g. `-force">gia.</กัน`), after which the model replayed **verbatim earlier-context text** — its own system prompt — as if it were the answer. The server stayed healthy throughout: HTTP 200, no scheduler or proposer warnings, normal spec-decode acceptance.

Bisect on the same host, same day:

| Config | Result |
|---|---|
| `018c6bc` recipe defaults, all hotfixes applied (#26, #27, #31, #24-grammar, v0.27 perf, #22) | corruption in long agentic session |
| identical, **only** the #26 coordinator patch skipped (coordinator stock; retention interval inert) | comparable fresh-session agentic workload clean |

Corrupted-session gotcha accounted for: the clean run used a fresh client session (a session whose history already contains corrupted output keeps corrupting by imitation).

## Suspected mechanism (not root-caused)

`hotfix-dsv4-issue26-hybrid-swa-min.py` relaxes `HybridKVCacheCoordinator.find_longest_cache_hit` so SWA groups no longer shrink the common hit. If a sliding-window group's blocks for the matched prefix were already freed/evicted while the MLA group's survived, the coordinator can report a hit backed by incomplete SWA KV — the request resumes on wrong attention state, which matches the symptoms (garbage tokens + replay of cached prefix content). Long multi-turn agentic sessions are exactly the workload that maximizes shared prefixes + eviction churn; single-lane and short-context smoke tests (including the in-repo #26 repro scripts) do not reproduce it.

## Environment

- Recipe: `018c6bc` (corrupting) / `524054d` (bisect host)
- Image: `ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8`
- vLLM `0.25.2.dev0+g752a3a504.d20260714`, 2x DGX Spark TP=2 over RoCEv2
- Official `DeepSeek-V4-Flash-0731` (`ABLITERATED=0`), `MTP_NUM_TOKENS=5`, `MAX_NUM_SEQS=6`, `MAX_NUM_BATCHED_TOKENS=8192`, `LONG_PREFILL_TOKEN_THRESHOLD=1024`, `DEFAULT_THINKING=low`, `GPU_MEMORY_UTILIZATION_TEXT=0.835`

## Changes

- `docker-compose.dspark.yml`: entrypoint applies the #26 patch only when `DSPARK_SKIP_ISSUE26_HOTFIX != 1`; env passthrough with default `0` (**no behavior change by default**).
- `start-deepseek-v4-flash-dspark.sh`: resolved-profile output reports #26 hotfix status; opt-out documented next to the existing `DSPARK_SKIP_HOTFIX` / `DSPARK_SKIP_ISSUE22_HOTFIX` notes.
- `.env.dspark.example`: commented `DSPARK_SKIP_ISSUE26_HOTFIX=1` with symptom description and the trade-off (skipping costs the 32K+ x8 warm prefix-cache hits #26 restored; `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` becomes inert).
- `CHANGELOG.md`: Known issue entry + escape hatch under 2026-08-13.

## Validation

- `docker compose config` validates; `bash -n` clean.
- Live TP=2 bisect deployment runs with the coordinator patch skipped: health OK, short/3x-concurrent/40k-retrieval smoke clean, and the corruption-triggering agentic workload clean in a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
