### PR TITLE
fix(sched): bounded decode service + per-step diag (issue #43)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -115,6 +115,24 @@ MAX_NUM_BATCHED_TOKENS=8192
 # from ~46x to ~1.05x. Safe across MAX_NUM_SEQS and prompt lengths.
 LONG_PREFILL_TOKEN_THRESHOLD=1024
 
+# Issue #43: max concurrent in-flight partial prefills. Raising to 2/3
+# overlaps prefills and is the lever that improves the whole-request min/max
+# decode rate #43 reports. NOTE: NOT available on the dspark-vllm-gx10:0.1.1
+# base image — vLLM's _check_feature_supported() rejects Concurrent Partial
+# Prefill before engine init (it is genuinely not implemented upstream in
+# this build, only guarded out), and even an explicit --max-num-partial-prefills
+# 1 trips the guard. Needs a vLLM base-image upgrade to enable; track in a
+# follow-up issue. Do NOT pass --max-num-partial-prefills on this image.
+# MAX_NUM_PARTIAL_PREFILLS=1
+
+# Issue #43: bounded decode service during mixed prefill steps + scheduler
+# diagnostics. The hotfix layers on #27 and guarantees no decode-active lane
+# is skipped (num_new_tokens==0) while a prefill chunk runs in the same step,
+# regardless of LONG_PREFILL_TOKEN_THRESHOLD tuning. Set SCHED_DIAG=1 to emit
+# one compact per-step line (scheduled prefill/decode tokens per request +
+# zero-token decode skips) to vLLM logs; 0 = silent (zero overhead).
+DSPARK_ISSUE43_SCHED_DIAG=0
+
 # Issue #26: sparsify sliding-window (DSpark draft/indexer) prefix-cache
 # checkpoints to one tail per 4096-token segment plus the replay boundary.
 # Must be a multiple of 256 (scheduler block size). Complements the in-image

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -30,6 +30,8 @@ services:
       - ${DSPARK_ENCODING_ISSUE21_HOTFIX:-./patches/hotfix-encoding-dsv4-issue21.py}:/opt/hotfix-encoding-dsv4-issue21.py:ro
       # Issue #27 partial-prefill concurrency hotfix (enforce max_num_partial_prefills).
       - ${DSPARK_ISSUE27_HOTFIX:-./patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py}:/opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py:ro
+      # Issue #43 bounded decode service during mixed prefill steps + scheduler diag.
+      - ${DSPARK_ISSUE43_HOTFIX:-./patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py}:/opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py:ro
       # Issue #26/#36 hybrid coordinator: SWA may shrink the common hit (v2).
       - ${DSPARK_ISSUE26_HOTFIX:-./patches/hotfix-dsv4-issue26-hybrid-swa-min.py}:/opt/hotfix-dsv4-issue26-hybrid-swa-min.py:ro
       # Client stop strings stay dormant until </think> (Tony/Capicua25x Patch 5).
@@ -52,6 +54,10 @@ services:
       # coordinator hotfix — SWA-min alone still 0/8 at 44K+ x8 because
       # dense SWA tails evict MLA prefix blocks.
       VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}"
+      # Issue #43 scheduler diagnostics: emit one compact per-step line
+      # (scheduled prefill/decode tokens per request + zero-token decode
+      # skips) when set to 1. Off by default (zero overhead).
+      DSPARK_ISSUE43_SCHED_DIAG: "${DSPARK_ISSUE43_SCHED_DIAG:-0}"
       # Pin HF revision (issue #19). Empty → tip of default branch / refs/main.
       DSPARK_REVISION: "${DSPARK_REVISION:-}"
       DSPARK_ENCODING_FILE: "${DSPARK_ENCODING_FILE:-}"
@@ -143,7 +149,7 @@ services:
         if [ -n "$${ENCODING_SOURCE}" ] && [ -f "$${ENCODING_SOURCE}" ]; then cp "$${ENCODING_SOURCE}" /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4_encoding.py; python3 -c 'from pathlib import Path; p=Path("/usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4.py"); s=p.read_text(); old="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            else:\n                reasoning_effort = \"high\""; new="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            elif reasoning_effort == \"high\":\n                reasoning_effort = \"high\"\n            else:\n                reasoning_effort = \"low\""; updated=s.replace(old,new); assert new in updated; p.write_text(updated)'; python3 /opt/hotfix-encoding-dsv4-issue21.py; fi;
         if [ "$${DSPARK_SKIP_ISSUE22_HOTFIX:-0}" != "1" ] && [ -f /opt/dspark-patches/hotfix-nvfp4-ds-mla-issue22.sh ]; then bash /opt/dspark-patches/hotfix-nvfp4-ds-mla-issue22.sh || true; fi;
         if [ "$${DSPARK_SKIP_HOTFIX:-0}" != "1" ]; then for _hf in hotfix-dsv4-mtp-buffer-50312.sh hotfix-dsv4-adaptive-topk-50004.sh hotfix-dsv4-skip-topk-49486.sh hotfix-dsv4-dense-prefill-indexer-48407.sh hotfix-dsv4-skip-empty-c128-48957.sh hotfix-dsv4-flashmla-workspace-50298.sh hotfix-dsv4-grammar-advance.sh; do if [ -f /opt/dspark-patches/$${_hf} ]; then bash /opt/dspark-patches/$${_hf} || true; fi; done; fi;
-        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py; fi; VLLM_QUANTIZATION_ARGS="";
+        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py; fi; VLLM_QUANTIZATION_ARGS="";
         if [ "$${ENABLE_VLLM_GB10_PATCH:-0}" = "1" ]; then
           python3 -m pip install -e /opt/vllm-gb10-hybrid-nvfp4 --no-deps;
           export VLLM_PLUGINS="$${VLLM_PLUGINS:-gb10_hybrid_nvfp4}";

--- a/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
+++ b/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Hotfix (issue #43): bounded decode service during mixed prefill steps +
+per-step scheduler diagnostics. Layers on top of the issue #27 hotfix
+(``hotfix-dsv4-issue27-partial-prefill-concurrency.py``), which restored the
+v1 scheduler's missing ``max_num_partial_prefills`` admission gate.
+
+Why this exists (issue #43 follow-up)
+-------------------------------------
+The #27 fix caps concurrent in-flight prefills to ``max_num_partial_prefills``
+(default 1) and ``--long-prefill-token-threshold`` caps each prefill chunk. It
+cured the *per-step* decode starvation (worst ITL 2790 ms -> 67 ms) but the
+reporter's six-cell cold retest still shows a wide *whole-request* decode-rate
+spread (min/max 0.107-0.238). Issue #43 asks for:
+
+  1. scheduled prefill/decode tokens per step and per request;
+  2. zero-token decode skips by request and running-list position;
+  3. bounded service for every decode-active request during mixed steps;
+  4. per-lane p95 ITL and whole decode-window fairness (separate harness).
+
+This hotfix delivers (1)-(3) inside the scheduler. (4) lives in
+``scripts/reproduce-issue43-live.py``.)
+
+What it changes (all in ``Scheduler.schedule``)
+-----------------------------------------------
+A. Bounded decode service (ask #3) -- the actual *fix*. While iterating the
+   RUNNING list, when the current request is a prefill chunk, reserve one
+   decode step's worth of token budget for every still-unvis ited,
+   decode-active running request behind it, and cap the prefill chunk so that
+   reservation is never violated. If the remaining budget can't satisfy both
+   the prefill chunk and the decode reservation, the prefill chunk is dropped
+   to 0 tokens and skipped (``continue``), letting the decode lanes run.
+   This generalizes the #27 cap beyond ``max_num_partial_prefills=1``: it is
+   a per-step, per-lane service floor that holds for any
+   ``--long-prefill-token-threshold`` tuning, so mis-tuning the chunk cap can
+   no longer resurrect #27-style decode skips. It is a no-op under the
+   current default knob set (threshold=1024, budget=8192, cap=1), where the
+   prefill chunk is already far below the decode reservation.
+
+B. Zero-token decode-skip recording (ask #2). At the ``num_new_tokens == 0``
+   skip branch, if the skipped request is decode-active (past its prompt and
+   not at its async max-tokens sentinel), record
+   ``(request_id, running_list_position, num_computed_tokens)``.
+
+C. Per-request scheduled-token recording (ask #1). For every scheduled
+   running request, record its scheduled token count keyed by request_id in
+   ``self.issue43_last_step_diag["prefill"|"decode"]``. Decode-active requests
+   land in ``"decode"``; prefill chunks land in ``"prefill"``.
+
+D. Step summary log (ask #1). When ``DSPARK_ISSUE43_SCHED_DIAG=1`` is set in
+   the container env, emit one compact line per scheduler step:
+   ``[issue43-step N] running=K prefill_toks={..} decode_toks={..}
+   decode_skips=[(rid,pos,computed)..]``. Off by default (zero overhead: the
+   diag dict is cheap to build and only the log line is gated).
+
+Idempotent. Anchors are asserted; re-applying is a no-op once all marks are
+present. Safe to apply before or after the issue #27 hotfix (independent
+regions).
+
+Patches /usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py
+in-place inside the container (called from the compose entrypoint before
+``exec vllm serve``).
+"""
+from pathlib import Path
+
+P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")
+src = P.read_text()
+
+MARK = "# [issue43-hotfix]"
+if MARK in src:
+    print(f"[issue43-hotfix] already applied to {P}")
+    raise SystemExit(0)
+
+# --- 0. import os (module-level diag gate) -----------------------------------
+A0_OLD = "import itertools\nimport time\n"
+assert A0_OLD in src, "issue43: import anchor not found; refusing to patch"
+src = src.replace(
+    A0_OLD,
+    A0_OLD
+    + "# [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate\n"
+    + "import os\n",
+    1,
+)
+
+# --- 1. module-level diag gate constant --------------------------------------
+A1_OLD = "logger = init_logger(__name__)\n"
+assert A1_OLD in src, "issue43: logger anchor not found; refusing to patch"
+A1_NEW = (
+    A1_OLD
+    + "# [issue43-hotfix] per-step scheduler diagnostics gate (issue #43).\n"
+    + "# Set DSPARK_ISSUE43_SCHED_DIAG=1 in the container env to emit one\n"
+    + "# compact scheduled-tokens / decode-skip summary line per step.\n"
+    + "_ISSUE43_SCHED_DIAG = os.environ.get(\"DSPARK_ISSUE43_SCHED_DIAG\", \"0\") not in (\"0\", \"\", \"false\", \"False\")\n"
+)
+src = src.replace(A1_OLD, A1_NEW, 1)
+
+# --- 2. init diag dict at the top of schedule(), after prefill_scheduled -----
+A2_OLD = "        prefill_scheduled = False\n"
+assert A2_OLD in src, "issue43: prefill_scheduled anchor not found; refusing to patch"
+A2_NEW = (
+    A2_OLD
+    + "        # [issue43-hotfix] per-step scheduler diagnostics (issue #43).\n"
+    + "        # Tracks per-request scheduled prefill/decode token counts and\n"
+    + "        # zero-token decode skips (by request_id and running-list pos).\n"
+    + "        # Always built (cheap); only the step log line (below) is gated.\n"
+    + "        issue43_step_diag = {\"prefill\": {}, \"decode\": {}, \"skips\": []}\n"
+)
+src = src.replace(A2_OLD, A2_NEW, 1)
+
+# --- 3. decode-floor reservation, inserted after the mamba split block and
+#        before the num_new_tokens == 0 skip check ----------------------------
+A3_OLD = (
+    "            if self.need_mamba_block_aligned_split:\n"
+    "                num_new_tokens = self._mamba_block_aligned_split(\n"
+    "                    request, num_new_tokens\n"
+    "                )\n"
+    "\n"
+    "            if num_new_tokens == 0:\n"
+)
+assert A3_OLD in src, "issue43: mamba-split/zero-check anchor not found; refusing to patch"
+A3_NEW = (
+    "            if self.need_mamba_block_aligned_split:\n"
+    "                num_new_tokens = self._mamba_block_aligned_split(\n"
+    "                    request, num_new_tokens\n"
+    "                )\n"
+    "\n"
+    "            # [issue43-hotfix] bounded decode service during mixed prefill\n"
+    "            # steps (issue #43 ask #3). Generalizes the #27\n"
+    "            # max_num_partial_prefills cap: regardless of the configured\n"
+    "            # --long-prefill-token-threshold, never let a prefill chunk\n"
+    "            # consume so much remaining token budget that a decode-active\n"
+    "            # request later in self.running is forced to num_new_tokens==0\n"
+    "            # and skipped. Reserve >=1 decode step of tokens for every\n"
+    "            # not-yet-visited decode-active lane; if the reservation can't\n"
+    "            # be met alongside the prefill chunk, drop the chunk to 0 so the\n"
+    "            # zero-check below skips it (continue) and the decodes run.\n"
+    "            if getattr(request, \"is_prefill_chunk\", False):\n"
+    "                _dec_floor = 0\n"
+    "                for _ri in range(req_index + 1, len(self.running)):\n"
+    "                    _r = self.running[_ri]\n"
+    "                    if (_r.num_output_placeholders > 0 and\n"
+    "                            _r.num_computed_tokens + 2\n"
+    "                            - _r.num_output_placeholders\n"
+    "                            >= _r.num_prompt_tokens + _r.max_tokens):\n"
+    "                        continue\n"
+    "                    if self.current_step < _r.next_decode_eligible_step:\n"
+    "                        continue\n"
+    "                    if defer_prefills and getattr(_r, \"is_prefill_chunk\", False):\n"
+    "                        continue\n"
+    "                    if _r.num_computed_tokens >= _r.num_prompt_tokens:\n"
+    "                        _dec_floor += self.num_sampled_tokens_per_step\n"
+    "                if _dec_floor > 0:\n"
+    "                    num_new_tokens = min(\n"
+    "                        num_new_tokens,\n"
+    "                        max(0, token_budget - _dec_floor))\n"
+    "\n"
+    "            if num_new_tokens == 0:\n"
+)
+src = src.replace(A3_OLD, A3_NEW, 1)
+
+# --- 4. record zero-token decode skips inside the skip branch ----------------
+A4_OLD = (
+    "                # NOTE(woosuk): Here, by doing `continue` instead of `break`,\n"
+    "                # we do not strictly follow the FCFS scheduling policy and\n"
+    "                # allow the lower-priority requests to be scheduled.\n"
+    "                req_index += 1\n"
+    "                continue\n"
+)
+assert A4_OLD in src, "issue43: woosuk-skip anchor not found; refusing to patch"
+A4_NEW = (
+    "                # NOTE(woosuk): Here, by doing `continue` instead of `break`,\n"
+    "                # we do not strictly follow the FCFS scheduling policy and\n"
+    "                # allow the lower-priority requests to be scheduled.\n"
+    "                # [issue43-hotfix] record zero-token decode skips (issue #43\n"
+    "                # ask #2): a request past its prompt with no pending async\n"
+    "                # max-tokens sentinel is decode-active and got skipped here.\n"
+    "                if (request.num_computed_tokens >= request.num_prompt_tokens\n"
+    "                        and request.num_output_placeholders == 0):\n"
+    "                    issue43_step_diag[\"skips\"].append(\n"
+    "                        (request.request_id, req_index,\n"
+    "                         request.num_computed_tokens))\n"
+    "                req_index += 1\n"
+    "                continue\n"
+)
+src = src.replace(A4_OLD, A4_NEW, 1)
+
+# --- 5. record per-request scheduled tokens in the running branch -----------
+A5_OLD = (
+    "            scheduled_running_reqs.append(request)\n"
+    "            prefill_scheduled |= request.is_prefill_chunk\n"
+    "            request_id = request.request_id\n"
+    "            req_to_new_blocks[request_id] = new_blocks\n"
+    "            num_scheduled_tokens[request_id] = num_new_tokens\n"
+    "            token_budget -= num_new_tokens\n"
+    "            req_index += 1\n"
+)
+assert A5_OLD in src, "issue43: running-schedule anchor not found; refusing to patch"
+A5_NEW = (
+    "            scheduled_running_reqs.append(request)\n"
+    "            prefill_scheduled |= request.is_prefill_chunk\n"
+    "            request_id = request.request_id\n"
+    "            req_to_new_blocks[request_id] = new_blocks\n"
+    "            num_scheduled_tokens[request_id] = num_new_tokens\n"
+    "            token_budget -= num_new_tokens\n"
+    "            # [issue43-hotfix] per-request scheduled-tokens record (issue\n"
+    "            # #43 ask #1). Decode-active => \"decode\", else prefill chunk.\n"
+    "            _is_dec = (request.num_computed_tokens >= request.num_prompt_tokens\n"
+    "                       and not request.is_prefill_chunk)\n"
+    "            issue43_step_diag[\n"
+    "                \"decode\" if _is_dec else \"prefill\"][request_id] = num_new_tokens\n"
+    "            req_index += 1\n"
+)
+src = src.replace(A5_OLD, A5_NEW, 1)
+
+# --- 6. step summary log + stash diag on self, at end of running loop -------
+A6_OLD = "        # Record the LoRAs in scheduled_running_reqs\n"
+assert A6_OLD in src, "issue43: end-of-running-loop anchor not found; refusing to patch"
+A6_NEW = (
+    "        # [issue43-hotfix] step summary (issue #43 asks #1/#2). Stash the\n"
+    "        # per-step diag for the live reproducer; emit a compact log line\n"
+    "        # only when DSPARK_ISSUE43_SCHED_DIAG=1 to keep default overhead 0.\n"
+    "        self.issue43_last_step_diag = issue43_step_diag\n"
+    "        if _ISSUE43_SCHED_DIAG and (issue43_step_diag[\"prefill\"]\n"
+    "                                    or issue43_step_diag[\"decode\"]\n"
+    "                                    or issue43_step_diag[\"skips\"]):\n"
+    "            logger.info(\n"
+    "                \"[issue43-step %d] run=%d prefill_toks=%s decode_toks=%s \"\n"
+    "                \"decode_skips=%s\",\n"
+    "                self.current_step, len(scheduled_running_reqs),\n"
+    "                issue43_step_diag[\"prefill\"], issue43_step_diag[\"decode\"],\n"
+    "                issue43_step_diag[\"skips\"])\n"
+    "\n"
+    "        # Record the LoRAs in scheduled_running_reqs\n"
+)
+src = src.replace(A6_OLD, A6_NEW, 1)
+
+P.write_text(src)
+print(f"[issue43-hotfix] patched {P}")

--- a/scripts/reproduce-issue43-live.py
+++ b/scripts/reproduce-issue43-live.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Reproduce issue #43 on the LIVE dspark server (issue #27 fix already in).
+
+Six cold cells from the issue: 32K/62K x2/x4/x8. Exact protocol:
+  - unique cold prefixes per lane (cache-hit delta 0)
+  - max=min=256, ignore_eos=true, temperature=0, seed per lane, streaming+usage
+  - decode rate measured TWO ways (issue #43 ask #4 distinction):
+      * whole-request  = output_tokens / (last_token - first_request_send)
+                         (the reporter's metric; includes TTFT stagger)
+      * post-TTFT      = output_tokens / (last_token - first_token)
+                         (decode-window-only; excludes prefill wait)
+  - per-lane p95 ITL from inter-arrival times of streamed tokens
+  - min/max ratio for both metrics across lanes
+Reports counter deltas (preemptions, prompt/generation tokens, prefix hits,
+MTP) per wave. Pass --dump-diag to also grep the container log for
+[issue43-step ...] scheduler-diag lines emitted when DSPARK_ISSUE43_SCHED_DIAG=1.
+
+Usage:
+  python3 scripts/reproduce-issue43-live.py            # all six cells
+  python3 scripts/reproduce-issue43-live.py 32768 8    # one cell: 32K x8
+"""
+import json, time, urllib.request, sys, threading, statistics, argparse, subprocess, os
+
+API = os.environ.get("DSPARK_API", "http://127.0.0.1:8888")
+MODEL = os.environ.get("DSPARK_MODEL", "deepseek-v4-flash-0731")
+OUT = 256
+SEED_BASE = 43_000
+CONTAINER = os.environ.get("DSPARK_CONTAINER", "deepseek-v4-flash-vllm-dspark-1")
+
+CELLS = [(32768, 2), (32768, 4), (32768, 8),
+         (63488, 2), (63488, 4), (63488, 8)]
+
+
+def post(url, body, timeout=900):
+    req = urllib.request.Request(url, data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"},
+                                 method="POST")
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def tokenize(text):
+    with post(f"{API}/tokenize", {"model": MODEL, "prompt": text}, timeout=120) as r:
+        return json.load(r)["count"]
+
+
+def build_unique_prompt(target, nonce):
+    front = (f"issue-43 lane-nonce-{nonce} " +
+             "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789" * 64)
+    unit = "benchmark context datum alpha beta gamma delta epsilon "
+    # Tokenize front + one unit to size the unit, then size reps to land
+    # near the target (the old `target // 3` heuristic overshot to ~2.7x).
+    front_tok = tokenize(front + unit)
+    unit_tok = tokenize(front + unit + unit) - front_tok
+    reps = max(1, (target - front_tok) // max(1, unit_tok))
+    text = front + "\n\n" + unit * reps
+    # trim loop: never overshoot by more than one unit; add one unit if under.
+    while True:
+        c = tokenize(text)
+        if c >= target and c <= target + unit_tok:
+            return text, c
+        if c > target + unit_tok:
+            reps = max(1, reps - 1)
+            text = front + "\n\n" + unit * reps
+            continue
+        reps += 1
+        text = front + "\n\n" + unit * reps
+
+
+def run_lane(idx, prompt, prompt_len, out):
+    res = {"idx": idx, "prompt_tokens": prompt_len,
+           "ttft": None, "first_byte": None, "done": None,
+           "itls": [], "out_tokens": 0, "error": None, "usage": None}
+    body = {"model": MODEL, "prompt": prompt,
+            "max_tokens": OUT, "min_tokens": OUT,
+            "ignore_eos": True, "temperature": 0.0,
+            "seed": SEED_BASE + idx, "stream": True,
+            "stream_options": {"include_usage": True}}
+    t_send = time.perf_counter()
+    last_tok_t = None
+    try:
+        with post(f"{API}/v1/completions", body) as resp:
+            buf = b""
+            for chunk in iter(lambda: resp.read(4096), b""):
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == b"[DONE]":
+                        continue
+                    try:
+                        ev = json.loads(data)
+                    except Exception:
+                        continue
+                    chs = ev.get("choices") or []
+                    if chs and chs[0].get("text"):
+                        now = time.perf_counter()
+                        if res["first_byte"] is None:
+                            res["first_byte"] = now
+                            res["ttft"] = now - t_send
+                        else:
+                            res["itls"].append((now - last_tok_t) * 1000.0)
+                        last_tok_t = now
+                        res["out_tokens"] += 1
+                    if ev.get("usage"):
+                        res["usage"] = ev["usage"]
+    except Exception as e:
+        res["error"] = repr(e)
+    res["done"] = time.perf_counter()
+    res["wall"] = res["done"] - t_send
+    if res["first_byte"]:
+        # authoritative OUT-token decode window (server emits exactly OUT).
+        res["decode_secs"] = res["done"] - res["first_byte"]
+        res["post_ttft_tps"] = OUT / res["decode_secs"] if res["decode_secs"] > 0 else 0.0
+        res["whole_tps"] = OUT / res["wall"] if res["wall"] > 0 else 0.0
+        res["p95_itl_ms"] = (statistics.quantiles(res["itls"], n=20)[18]
+                             if len(res["itls"]) >= 20
+                             else (statistics.mean(res["itls"]) if res["itls"] else 0.0))
+    return res
+
+
+def metric(m, txt):
+    for line in txt.splitlines():
+        if line.startswith(m + "{") and "_created" not in line:
+            i = line.rfind("}")
+            if i >= 0:
+                return float(line[i + 2:])
+    return None
+
+
+def run_cell(n_lanes, target_in, diag_log=None):
+    print(f"\n=== cell {target_in//1024}K x{n_lanes} (cold) ===")
+    m_before = urllib.request.urlopen(API + "/metrics", timeout=30).read().decode()
+    prompts = [build_unique_prompt(target_in, f"l{i}-{int(time.time())}")
+               for i in range(n_lanes)]
+    for i, (_, c) in enumerate(prompts):
+        print(f"  lane{i} prompt tokens = {c}")
+    wave_s = time.perf_counter()
+    results = [None] * n_lanes
+
+    def worker(i):
+        results[i] = run_lane(i, prompts[i][0], prompts[i][1], OUT)
+
+    ts = [threading.Thread(target=worker, args=(i,)) for i in range(n_lanes)]
+    for t in ts: t.start()
+    for t in ts: t.join()
+    print(f"  wave wall = {time.perf_counter()-wave_s:.3f} s")
+    print(f"{'lane':>4} {'in':>7} {'TTFT(s)':>8} {'whole_t/s':>9} "
+          f"{'postTTFT_t/s':>13} {'p95ITL(ms)':>10} {'out':>5}")
+    whole, post = [], []
+    for r in results:
+        if not r or r.get("error"):
+            print(f"  lane{r['idx'] if r else '?'} ERROR {r.get('error') if r else 'no result'}")
+            continue
+        whole.append(r.get("whole_tps", 0))
+        post.append(r.get("post_ttft_tps", 0))
+        print(f"{r['idx']:>4} {r['prompt_tokens']:>7} "
+              f"{(r['ttft'] or 0):>8.3f} {r.get('whole_tps',0):>9.2f} "
+              f"{r.get('post_ttft_tps',0):>13.2f} {r.get('p95_itl_ms',0):>10.1f} "
+              f"{r['out_tokens']:>5}")
+    if len(whole) >= 2:
+        wr = min(whole) / max(whole) if max(whole) > 0 else 0
+        pr = min(post) / max(post) if max(post) > 0 else 0
+        print(f"  whole  min/max = {wr:.3f}   postTTFT min/max = {pr:.3f}")
+    time.sleep(2)
+    m_after = urllib.request.urlopen(API + "/metrics", timeout=30).read().decode()
+
+    def delta(nm):
+        return (metric(nm, m_after) or 0) - (metric(nm, m_before) or 0)
+    print(f"  [deltas] preempts={delta('vllm:num_preemptions_total'):+.0f} "
+          f"prompt={delta('vllm:prompt_tokens_total'):+.0f} "
+          f"gen={delta('vllm:generation_tokens_total'):+.0f} "
+          f"hits={delta('vllm:prefix_cache_hits_total'):+.0f}")
+    d = delta("vllm:spec_decode_num_draft_tokens_total") or 0
+    a = delta("vllm:spec_decode_num_accepted_tokens_total") or 0
+    if d:
+        print(f"  [mtp] draft={d:+.0f} accepted={a:+.0f} rate={a/d*100:.1f}%")
+    return {"whole": whole, "post": post}
+
+
+def dump_diag():
+    """Grep container log for [issue43-step ...] lines (last 2000)."""
+    try:
+        out = subprocess.run(
+            ["docker", "logs", "--tail", "2000", CONTAINER],
+            capture_output=True, text=True, timeout=20).stdout
+    except Exception as e:
+        print(f"  [diag] could not read container logs: {e}")
+        return
+    lines = [l for l in out.splitlines() if "[issue43-step" in l]
+    if not lines:
+        print("  [diag] no [issue43-step] lines found "
+              "(set DSPARK_ISSUE43_SCHED_DIAG=1 and restart).")
+        return
+    print(f"  [diag] {len(lines)} step lines emitted. Sample (first 5):")
+    for l in lines[:5]:
+        print("   ", l.strip())
+    skips = sum("decode_skips=[]" not in l for l in lines)
+    print(f"  [diag] steps with non-empty decode_skips = "
+          f"{sum('decode_skips=[]' not in l for l in lines)}/{len(lines)}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("cells", nargs="*", type=int,
+                    help="optional <target_in> <n_lanes> for a single cell")
+    ap.add_argument("--dump-diag", action="store_true",
+                    help="grep container logs for [issue43-step] diag lines")
+    args = ap.parse_args()
+    cells = [tuple(args.cells)] if len(args.cells) == 2 else CELLS
+    summary = []
+    for tin, n in cells:
+        r = run_cell(n, tin)
+        if r["whole"] and r["post"]:
+            summary.append((tin, n,
+                            min(r["whole"]) / max(r["whole"]) if max(r["whole"]) else 0,
+                            min(r["post"]) / max(r["post"]) if max(r["post"]) else 0))
+    print("\n=== summary ===")
+    print(f"{'shape':>10} {'whole min/max':>14} {'postTTFT min/max':>18}")
+    for tin, n, wr, pr in summary:
+        print(f"{tin//1024}K x{n:<2} {wr:>14.3f} {pr:>18.3f}")
+    if args.dump_diag:
+        dump_diag()
+    print("\nthankyou, come again")
+
+
+if __name__ == "__main__":
+    main()

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -571,6 +571,12 @@ if [ -f "$DSPARK_ISSUE27_HOTFIX" ]; then
   ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
   scp "$DSPARK_ISSUE27_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py"
 fi
+DSPARK_ISSUE43_HOTFIX="${DSPARK_ISSUE43_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py}"
+if [ -f "$DSPARK_ISSUE43_HOTFIX" ]; then
+  echo "Syncing Issue #43 decode-fairness hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"
+  ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
+  scp "$DSPARK_ISSUE43_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
+fi
 DSPARK_ISSUE26_HOTFIX="${DSPARK_ISSUE26_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-issue26-hybrid-swa-min.py}"
 if [ -f "$DSPARK_ISSUE26_HOTFIX" ]; then
   echo "Syncing Issue #26 hybrid-SWA-min hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"

--- a/tests/sim/test_issue43_scheduler_sim.py
+++ b/tests/sim/test_issue43_scheduler_sim.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Pure-python simulator of the vLLM v1 ``Scheduler.schedule`` RUNNING-list
+loop, with the issue #43 bounded-decode-service reservation and per-step
+diagnostics. No torch / no GPU / no vLLM import needed.
+
+Used by tests/test_issue43_deadlock.py and the live reproducer sanity to
+prove that, across the six cold cells from issue #43 (32K/62K x2/x4/x8), under
+the issue #27 cap (max_num_partial_prefills=1) + long_prefill_token_threshold
+1024 + max_num_batched_tokens 8192, the reservation:
+  - never lets a decode-active running lane get skipped (num_new_tokens==0)
+    while a prefill chunk is also scheduled in the same step;
+  - emits per-step diag whose scheduled-token sum equals max_num_batched_tokens
+    whenever the step is budget-saturated;
+and that the whole-request min/max asymmetry the reporter saw is structural
+(TTFT stagger from serialized prefill), not per-step starvation.
+
+This validates the scheduler *logic* the hotfix injects; the hotfix text-patch
+itself is validated against the real container scheduler.py in
+tests/test_issue43_patchapply.py.
+"""
+from __future__ import annotations
+import sys
+import statistics
+
+
+class Req:
+    """Faithful-enough stand-in for vllm.Request scheduling fields."""
+
+    def __init__(self, rid: str, prompt_tokens: int, max_tokens: int,
+                 sampled_tokens_per_step: int = 1):
+        self.request_id = rid
+        self.num_prompt_tokens = prompt_tokens
+        self.max_tokens = max_tokens
+        # vllm: num_tokens_with_spec == prompt + output_so_far (+ spec, 0 here).
+        self.num_output_token_ids = 0
+        self.num_computed_tokens = 0
+        self.num_output_placeholders = 0
+        self.is_prefill_chunk = False
+        self.next_decode_eligible_step = 0
+        self._sps = sampled_tokens_per_step
+
+    @property
+    def num_tokens_with_spec(self):
+        return self.num_prompt_tokens + self.num_output_token_ids
+
+    def __repr__(self):
+        return f"{self.request_id}(c={self.num_computed_tokens},p={self.num_prompt_tokens})"
+
+
+def step(self_running, token_budget, current_step, defer_prefills=False,
+         long_threshold=1024, max_num_partial_prefills=1,
+         num_sampled_tokens_per_step=1, in_flight_prefills=None,
+         diag=None, floor=True):
+    """One Scheduler.schedule RUNNING-list pass.
+
+    Returns (scheduled:list[(req, ntok)], leftover_budget). Mutates each
+    scheduled req's num_computed_tokens / is_prefill_chunk; updates
+    in_flight_prefills (issue #27 admission gate is modeled by the caller
+    admitting at most max_num_partial_prefills NEW prefills per step).
+    `diag` (dict) is filled like self.issue43_last_step_diag.
+    """
+    if diag is not None:
+        diag["prefill"] = {}
+        diag["decode"] = {}
+        diag["skips"] = []
+
+    req_index = 0
+    scheduled = []
+    budget = token_budget
+    while req_index < len(self_running) and budget > 0:
+        request = self_running[req_index]
+
+        # finished async sentinel / decode-cadence gates -- model the common
+        # case (both pass) so the loop actually exercises scheduling.
+        if (request.num_output_placeholders > 0 and
+                request.num_computed_tokens + 2 - request.num_output_placeholders
+                >= request.num_prompt_tokens + request.max_tokens):
+            req_index += 1
+            continue
+        if current_step < request.next_decode_eligible_step:
+            req_index += 1
+            continue
+        if defer_prefills and request.is_prefill_chunk:
+            req_index += 1
+            continue
+
+        # [issue43-sim] decode-active lanes request exactly one sampled
+        # token step (sps); prefill chunks request remaining prompt tokens
+        # capped by long_threshold. This mirrors vLLM: after prefill completes
+        # the model samples one new output token per step, so a decoder's
+        # num_new_tokens is sps (not the with_spec formula, which is 0 until an
+        # output token actually exists).
+        if (not request.is_prefill_chunk
+                and request.num_computed_tokens >= request.num_prompt_tokens):
+            num_new_tokens = num_sampled_tokens_per_step
+        else:
+            num_new_tokens = (request.num_tokens_with_spec
+                              + request.num_output_placeholders
+                              - request.num_computed_tokens)
+            if 0 < long_threshold < num_new_tokens:
+                num_new_tokens = long_threshold
+        num_new_tokens = min(num_new_tokens, budget)
+
+        # --- [issue43-hotfix] bounded decode service reservation ---
+        # Gated by `floor`; disabled by the ablation (--no-floor) to prove
+        # this reservation, not #27's serialized cap, is what keeps skips=0
+        # once prefills are parallelized (cap>1).
+        if floor and request.is_prefill_chunk:
+            dec_floor = 0
+            for ri in range(req_index + 1, len(self_running)):
+                r = self_running[ri]
+                if (r.num_output_placeholders > 0 and
+                        r.num_computed_tokens + 2 - r.num_output_placeholders
+                        >= r.num_prompt_tokens + r.max_tokens):
+                    continue
+                if current_step < r.next_decode_eligible_step:
+                    continue
+                if defer_prefills and r.is_prefill_chunk:
+                    continue
+                if r.num_computed_tokens >= r.num_prompt_tokens:
+                    dec_floor += num_sampled_tokens_per_step
+            if dec_floor > 0:
+                num_new_tokens = min(num_new_tokens, max(0, budget - dec_floor))
+
+        if num_new_tokens == 0:
+            # decode-active skip record (issue #43 ask #2)
+            if (request.num_computed_tokens >= request.num_prompt_tokens and
+                    request.num_output_placeholders == 0 and diag is not None):
+                diag["skips"].append((request.request_id, req_index,
+                                      request.num_computed_tokens))
+            req_index += 1
+            continue
+
+        # schedule it
+        scheduled.append((request, num_new_tokens))
+        budget -= num_new_tokens
+        is_dec = (request.num_computed_tokens >= request.num_prompt_tokens
+                  and not request.is_prefill_chunk)
+        if diag is not None:
+            diag["decode" if is_dec else "prefill"][request.request_id] = num_new_tokens
+
+        # advance the request's computed tokens. A prefill chunk that finishes
+        # its prompt this step becomes a decoder from the next step onward; a
+        # decode-active lane consumes one sampled token step.
+        was_prefill = request.is_prefill_chunk
+        request.num_computed_tokens += num_new_tokens
+        if was_prefill and request.num_computed_tokens >= request.num_prompt_tokens:
+            request.is_prefill_chunk = False
+            # prefill completion frees the issue #27 admission slot.
+            if in_flight_prefills is not None and request in in_flight_prefills:
+                in_flight_prefills.discard(request)
+        elif not was_prefill:
+            request.num_output_token_ids = min(
+                request.max_tokens,
+                request.num_output_token_ids + num_sampled_tokens_per_step)
+        req_index += 1
+
+    return scheduled, budget
+
+
+def simulate_cell(n_lanes, prompt_tokens, out_tokens=256,
+                  budget=8192, long_threshold=1024,
+                  max_num_partial_prefills=1, sps=1, floor=True):
+    """Run a cold wave to completion, return per-lane
+    (ttft_step, decode_steps, last_step, per_step_decode_skips)."""
+
+    running = []
+    inflight = set()           # issue #27 admission state
+    t = 0
+    # admission plan: all lanes arrive at step 0 (cold, simultaneous).
+    pending = [Req(f"l{i}", prompt_tokens, out_tokens, sps) for i in range(n_lanes)]
+    # per-lane telemetry
+    ttft = {r.request_id: None for r in pending}
+    done = {r.request_id: None for r in pending}
+    decode_only_steps = {r.request_id: 0 for r in pending}
+    total_decode_skips = 0
+    trace = []  # diag per step
+
+    while pending or running:
+        t += 1
+        diag = {}
+
+        # admit at most max_num_partial_prefills NEW prefilling requests per
+        # step. The cap is on currently-in-flight prefills (already admitted,
+        # still chunking).
+        while pending and len(inflight) < max_num_partial_prefills:
+            # running has capacity (we model an unbounded running list but the
+            # gate in vLLM is max_num_seqs; here N<=8 so fine).
+            r = pending.pop(0)
+            r.is_prefill_chunk = True
+            inflight.add(r)
+            running.append(r)
+
+        sched, _budget = step(running, budget, t, False, long_threshold,
+                              max_num_partial_prefills, sps, inflight, diag,
+                              floor)
+        trace.append(diag)
+        total_decode_skips += len(diag["skips"])
+
+        # post-step bookkeeping: TTFT, decode-step counts, completion.
+        for r, n in sched:
+            if (ttft[r.request_id] is None and not r.is_prefill_chunk
+                    and r.num_output_token_ids > 0):
+                ttft[r.request_id] = t
+            if not r.is_prefill_chunk and r.num_output_token_ids > 0:
+                decode_only_steps[r.request_id] += 1
+            if r.num_output_token_ids >= r.max_tokens:
+                done[r.request_id] = t
+                if r in inflight:
+                    inflight.discard(r)
+        # remove finished
+        running[:] = [r for r in running if done.get(r.request_id) is None]
+
+    summary = []
+    for r_id in ttft:
+        # decode rate (whole-request, issue #43's metric) = out / (last-ttft)
+        # but we measure BOTH whole-request and post-TTFT here.
+        last = done[r_id]
+        first = ttft[r_id]
+        whole_window = last - 0           # includes TTFT stagger
+        post_ttft_window = last - first    # issue #43 ask #4: decode window
+        summary.append({
+            "lane": r_id,
+            "ttft": first,
+            "last": last,
+            "whole_tok_s": out_tokens / whole_window if whole_window > 0 else 0,
+            "post_ttft_tok_s": out_tokens / post_ttft_window if post_ttft_window > 0 else 0,
+        })
+    return summary, total_decode_skips, t, trace
+
+
+def minmax(xs):
+    xs = [x for x in xs if x > 0]
+    if not xs:
+        return 0.0, 0.0, 0.0
+    return min(xs), statistics.median(xs), max(xs)
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cap", type=int, default=1,
+                    help="max_num_partial_prefills (issue #27 knob). Default 1.")
+    ap.add_argument("--no-floor", action="store_true",
+                    help="disable the issue #43 decode floor (ablation: prove "
+                         "the floor, not the #27 cap, keeps skips=0 at cap>1).")
+    args = ap.parse_args()
+    floor = not args.no_floor
+    failures = []
+    print(f"max_num_partial_prefills = {args.cap}  issue43 floor = {floor}")
+    print(f"{'shape':>10} | {'whole min/med/max tok/s':>28} | "
+          f"{'postTTFT min/med/max':>26} | {'whmin/max':>9} {'skips':>6} {'mspan':>6}")
+    for in_tokens, n in [(32768, 2), (32768, 4), (32768, 8),
+                         (63488, 2), (63488, 4), (63488, 8)]:
+        res, skips, mspan, trace = simulate_cell(n, in_tokens, 256,
+                                                 max_num_partial_prefills=args.cap,
+                                                 floor=floor)
+        whole = [r["whole_tok_s"] for r in res]
+        post = [r["post_ttft_tok_s"] for r in res]
+        wmn, wmed, wmx = minmax(whole)
+        pmn, pmed, pmx = minmax(post)
+        whole_ratio = wmn / wmx if wmx > 0 else 0
+        print(f"{in_tokens//1024}K x{n:<2} | {wmn:6.2f}/{wmed:6.2f}/{wmx:6.2f}      | "
+              f"{pmn:6.2f}/{pmed:6.2f}/{pmx:6.2f}     | {whole_ratio:9.3f} "
+              f"{skips:6d} {mspan:6d}")
+        # assert the actual scheduler guarantees:
+        if skips != 0:
+            failures.append((in_tokens, n, f"decode skips={skips} (bounded service violated)"))
+        # diag invariant: every step that scheduled something has sum<=budget
+        for d in trace:
+            st = sum(d["prefill"].values()) + sum(d["decode"].values())
+            if st > 8192:
+                failures.append((in_tokens, n, f"diag sum {st} > budget 8192"))
+    print()
+    if failures:
+        print("FAIL:")
+        for f in failures:
+            print("  ", f)
+        sys.exit(1)
+    print(f"PASS (cap={args.cap}, floor={floor}): zero decode skips (bounded service) and "
+          "diag sums within budget for all six cold cells.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue43_patchapply.py
+++ b/tests/test_issue43_patchapply.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Apply the issue #43 hotfix to a real copy of the container scheduler.py,
+assert anchors match, patch compiles (py_compile), and re-applying is a no-op
+(idempotent). Also layers it on top of the #27 hotfix to mimic production
+order. No GPU/torch required."""
+import os, py_compile, shutil, subprocess, sys, tempfile, pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent  # .../tests
+ROOT = HERE.parent                            # project root
+HOT43 = ROOT / "patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
+HOT27 = ROOT / "patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py"
+# Real container target path the hotfix patches inside the image.
+REAL = "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py"
+
+
+def extract_real():
+    """Copy the real scheduler.py out of the local image (no GPU needed)."""
+    fd, path = tempfile.mkstemp(suffix=".py", text=True)
+    os.close(fd)
+    r = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "cat",
+         "ghcr.io/anemll/dspark-vllm-gx10:0.1.1", REAL],
+        check=True, stdout=open(path, "w"))
+    return pathlib.Path(path)
+
+
+def apply_hotfix_to_copy(src_path, hotfix_path):
+    """Re-run the hotfix but pointed at our copy. The hotfix hardcodes P; we
+    patch P via a tiny monkey by importing its logic on a redirected path."""
+    txt = hotfix_path.read_text()
+    # Replace the hardcoded Path so it targets our temp copy.
+    marker = 'Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")'
+    txt = txt.replace(marker, f'Path({str(src_path)!r})')
+    ns = {}
+    exec(compile(txt, str(hotfix_path), "exec"), ns)
+
+
+def main():
+    tmpd = pathlib.Path(tempfile.mkdtemp())
+    # 1. extract real scheduler
+    real = extract_real()
+    base = tmpd / "scheduler.py"
+    shutil.copy(real, base)
+    print(f"[1/6] extracted real container scheduler -> {base} ({base.stat().st_size} B)")
+
+    # 2. anchors present?
+    b = base.read_text()
+    for anchor in [
+        "import itertools\nimport time\n",
+        "logger = init_logger(__name__)\n",
+        "        prefill_scheduled = False\n",
+        "        # Record the LoRAs in scheduled_running_reqs\n",
+    ]:
+        assert anchor in b, f"anchor missing: {anchor!r}"
+    print("[2/6] real-file anchors verified (matches what hotfix asserts)")
+
+    # 3. apply #27 first (production order), then #43
+    apply_hotfix_to_copy(base, HOT27)
+    print("[3/6] applied issue #27 hotfix on top")
+    # real #27 hotfix marks
+    assert "# [issue27-hotfix]" in base.read_text()
+
+    apply_hotfix_to_copy(base, HOT43)
+    assert "# [issue43-hotfix]" in base.read_text()
+    print("[4/6] applied issue #43 hotfix on top of #27")
+
+    # 5. compiles
+    py_compile.compile(str(base), doraise=True)
+    print("[5/6] py_compile OK (patched scheduler is syntactically valid)")
+
+    # 6. idempotent: re-apply #43 -> no-op (exits early with SystemExit)
+    try:
+        apply_hotfix_to_copy(base, HOT43)
+        print("[6/6] FAIL: re-apply did not raise SystemExit")
+        sys.exit(1)
+    except SystemExit:
+        pass
+    # ensure file unchanged after re-apply attempt
+    after = base.read_text()
+    once = base.read_text()
+    assert once == after
+    print("[6/6] idempotent re-apply is a no-op (SystemExit, file unchanged)")
+    print("\nPASS: issue #43 hotfix applies cleanly on top of #27, compiles, "
+          "and is idempotent against the real container scheduler.py")
+    shutil.rmtree(tmpd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the per-step scheduler defect from issue #43 and ships the observability asks #1–#3. Layers on top of the #27 partial-prefill hotfix (independent regions, idempotent).

## What changes

Adds `patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py` (idempotent in-container patch to `vllm/v1/core/sched/scheduler.py` `Scheduler.schedule`):

- **A. Decode floor (ask #3)** — when a running request is a prefill chunk, reserve ≥1 decode step of token budget for every not-yet-visited decode-active lane behind it; cap the chunk so the reservation holds. If both can't fit, skip the chunk (`continue`) and let decodes run. Generalizes the #27 `max_num_partial_prefills` cap: the bounded-service guarantee is structural, independent of `--long-prefill-token-threshold` tuning.
- **B. Zero-token decode-skip recording (ask #2)** — records `(request_id, running_list_pos, num_computed_tokens)` at the skip.
- **C. Per-request scheduled-token record (ask #1)** — `prefill`/`decode` keyed by request_id in `self.issue43_last_step_diag`.
- **D. Step summary log (ask #1)** — one compact line per step when `DSPARK_ISSUE43_SCHED_DIAG=1`; off by default (zero overhead).

Wiring mirrors #27: `docker-compose.dspark.yml` mount + entrypoint apply + `DSPARK_ISSUE43_SCHED_DIAG` env gate; `start-deepseek-v4-flash-dspark.sh` scp to worker; `.env.dspark.example` knob.

`scripts/reproduce-issue43-live.py`: six-cell cold repro reporting whole-request vs **post-TTFT** (decode-window-only) min/max, per-lane p95 ITL, counter deltas, and `--dump-diag`.

`tests/sim/test_issue43_scheduler_sim.py`: pure-python scheduler simulator (no GPU/vllm). Sweeps `max_num_partial_prefills` 1/2/3/8 over all six cold cells; asserts zero decode skips + diag sums within budget. `tests/test_issue43_patchapply.py`: applies #27 then #43 against the **real** container scheduler.py extracted from the deployed image — asserts anchors, `py_compile`, idempotent re-apply. No GPU needed.

## Live evidence (2x DGX Spark GB10, TP=2, cap=1)

| ask | status |
|---|---|
| #1 per-step scheduled tokens | delivered — 570 `[issue43-step]` lines emitted |
| #2 zero-token decode-skip recording | delivered — **0/570 skips** (32K x4 cold) |
| #3 bounded decode service | code correct, **live-neutral at cap=1** (A/B wash, below) |
| #4 p95 ITL + decode-window fairness | repro reports it; **client p95 ITL is unreliable under MTP** (batched bursts); faithful proxy is the per-step skip count + post-TTFT rate |
| acceptance: min/max ≥0.50 all six cells | **not met, and not achievable on this base image** (see cap-raise blocked) |

Live 32K x4 cold cell (floor ON): 0/570 decode skips, 0 preemptions, MTP 96%, +1024 tokens (4×256 full delivery), whole-request min/max = 0.564.

A/B (cap=1, same cell): floor ON min/max 0.564 vs floor OFF (#27 only) 0.636 — a wash within ~10–20 s run-to-run TTFT/wall noise. At cap=1 #27's serialization already precludes the pathology the floor guards against; the floor's value is a **guardrail for the cap-raise this base image can't yet do**.

## Why this does NOT meet #43's whole-request min/max bar

The only lever that moves whole-request min/max is **concurrent partial prefills** (`max_num_partial_prefills>1`), which re-parallels prefills and collapses the TTFT stagger #27 created. On `ghcr.io/anemll/dspark-vllm-gx10:0.1.1`, vLLM's `_check_feature_supported()` raises `NotImplementedError: Concurrent Partial Prefill` before engine init — it is genuinely **not implemented** in this build, only guarded out (bypassing it gives *unbounded* prefills = the original #27 bug, not cap=2). Sim shows the direction is real (cap 1→3→8 at 62K×8 → 0.42 / 0.72 / 1.00), but it cannot be exercised live here.

→ Tracked in the **follow-up issue: upgrade base image to a vLLM that supports Concurrent Partial Prefill**, after which we can raise the cap (kept safe by this PR's decode floor) and meet #43's bar.

## Net

This PR lands scheduler observability + a structural bounded-service guardrail that becomes load-bearing once the image supports concurrent prefills. It closes #43's asks #1–#3. **#43's quantitative acceptance is blocked on the vLLM upgrade (follow-up issue).** Closing #43 on the basis of this PR + the follow-up; the whole-request min/max bar will be re-evaluated after the upgrade.