### PR TITLE
Adapt prefill chunks around active decode

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -114,6 +114,10 @@ MAX_NUM_BATCHED_TOKENS=8192
 # hotfix (max_num_partial_prefills actually enforced) it collapses x8 spread
 # from ~46x to ~1.05x. Safe across MAX_NUM_SEQS and prompt lengths.
 LONG_PREFILL_TOKEN_THRESHOLD=1024
+# The issue-27 adaptive scheduler uses this smaller threshold only while a
+# decode lane is active. This permits a larger LONG_PREFILL_TOKEN_THRESHOLD
+# for faster idle/cold ingestion without multi-second reply stalls.
+DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD=1024
 
 # Issue #43: max concurrent in-flight partial prefills. Raising to 2/3
 # overlaps prefills and is the lever that improves the whole-request min/max

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -115,6 +115,9 @@ services:
       # Checkpoint dspark_block_size is 5; k<5 truncates draft blocks (silent on 0.25.2 image).
       MTP_NUM_TOKENS: "${MTP_NUM_TOKENS:-5}"
       DEFAULT_THINKING: "${DEFAULT_THINKING:-low}"
+      # Large chunks when prefill-only, bounded chunks while a reply decodes.
+      # Must be a multiple of the scheduler block size.
+      DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD: "${DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD:-1024}"
       DSPARK_SKIP_HOTFIX: "${DSPARK_SKIP_HOTFIX:-0}"
       DSPARK_SKIP_ISSUE22_HOTFIX: "${DSPARK_SKIP_ISSUE22_HOTFIX:-0}"
       DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX: "${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}"

--- a/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
+++ b/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Hotfix: enforce SchedulerConfig.max_num_partial_prefills in the v1 scheduler.
+"""Hotfix: enforce partial-prefill admission and protect live decode lanes.
 
 Upstream vLLM 0.25.2.dev0 (ghcr.io/anemll/dspark-vllm-gx10:0.1.1) defines
 ``max_num_partial_prefills`` / ``max_long_partial_prefills`` on SchedulerConfig
@@ -13,7 +13,7 @@ step; decode-active requests later in the running list get
 producing severe, cold-only, zero-preemption decode lane starvation that
 grows with prompt length. (Issue #27.)
 
-Fix: at the top of the waiting-admission loop, break (don't admit a new
+Fix 1: at the top of the waiting-admission loop, break (don't admit a new
 prefill request) once the number of in-flight partial prefills has reached
 ``max_num_partial_prefills``. ``self._inflight_prefills`` is maintained by
 ``_update_after_schedule`` (populated for requests still needing more prefill
@@ -24,6 +24,12 @@ behind it in ``self.running`` always receive budget (chunk cap via
 ``--long-prefill-token-threshold`` keeps that one chunk below
 ``max_num_batched_tokens`` leaving room for decode tokens).
 
+Fix 2: use a small prefill chunk while any decode request is live, but retain
+the configured large chunk when the engine is prefill-only. A static large
+chunk improves isolated cold prefill, but each mixed prefill/decode kernel then
+creates multi-second inter-token gaps. ``DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD``
+defaults to 1024 tokens and must be a multiple of the scheduler block size.
+
 Idempotent: re-applying is a no-op once the marker is present.
 
 Patches /usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py
@@ -31,21 +37,20 @@ in-place inside the container (called from the compose entrypoint before
 ``exec vllm serve``).
 """
 from pathlib import Path
+import sys
 
-P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")
+P = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py"
+)
 src = P.read_text()
 MARK = "# [issue27-hotfix] enforce max_num_partial_prefills on admission"
-if MARK in src:
-    print(f"[issue27-hotfix] already applied to {P}")
-    raise SystemExit(0)
+ADAPTIVE_MARK = "# [issue27-adaptive] shrink prefill chunks only while decode is live"
 
 ANCHOR = (
     "                num_running = len(self.running) + self.num_waiting_for_streaming_input\n"
     "                if num_running >= self.max_num_running_reqs:\n"
     "                    break\n"
 )
-assert ANCHOR in src, "admission guard anchor not found; refusing to patch"
-
 INJECT = ANCHOR + (
     "\n"
     "                # [issue27-hotfix] enforce max_num_partial_prefills on admission.\n"
@@ -63,6 +68,137 @@ INJECT = ANCHOR + (
     "                ):\n"
     "                    break\n"
 )
-src = src.replace(ANCHOR, INJECT, 1)
-P.write_text(src)
-print(f"[issue27-hotfix] patched {P}")
+statuses = []
+if MARK not in src:
+    assert ANCHOR in src, "admission guard anchor not found; refusing to patch"
+    src = src.replace(ANCHOR, INJECT, 1)
+    statuses.append("admission")
+
+# Migrate the first adaptive revision. V2's async pipeline can have a live
+# decode request outside ``self.running`` during the next scheduler call.
+old_async_detector = (
+    "        # Keep the larger configured threshold for an idle/cold-prefill lane.\n"
+    "        active_prefill_threshold = (\n"
+    "            self.scheduler_config.long_prefill_token_threshold\n"
+    "        )\n"
+    "        if any(not req.is_prefill_chunk for req in self.running):\n"
+)
+new_async_detector = (
+    "        # Use the full live registry: async V2 scheduling can temporarily\n"
+    "        # remove an in-flight decode from self.running. Keep the larger\n"
+    "        # configured threshold only for a genuinely idle/prefill-only lane.\n"
+    "        active_prefill_threshold = (\n"
+    "            self.scheduler_config.long_prefill_token_threshold\n"
+    "        )\n"
+    "        if any(not req.is_prefill_chunk for req in self.requests.values()):\n"
+)
+if ADAPTIVE_MARK in src and old_async_detector in src:
+    src = src.replace(old_async_detector, new_async_detector, 1)
+    statuses.append("adaptive-async-registry")
+
+# ``is_prefill_chunk`` becomes true again while speculative decode has
+# uncomputed placeholders. Generated output is the durable signal that the
+# request owns an interactive decode lane.
+old_registry_detector = (
+    "        if any(not req.is_prefill_chunk for req in self.requests.values()):\n"
+)
+output_detector = (
+    "        decode_is_live = any(\n"
+    "            req.num_output_tokens > 0\n"
+    "            or (\n"
+    "                req.num_computed_tokens >= req.num_prompt_tokens\n"
+    "                and not req.is_prefill_chunk\n"
+    "            )\n"
+    "            for req in self.requests.values()\n"
+    "        )\n"
+    "        if decode_is_live:\n"
+)
+if ADAPTIVE_MARK in src and old_registry_detector in src:
+    src = src.replace(old_registry_detector, output_detector, 1)
+    statuses.append("adaptive-output-state")
+
+if ADAPTIVE_MARK not in src:
+    import_anchor = "import itertools\nimport time\n"
+    assert import_anchor in src, "scheduler import anchor not found"
+    src = src.replace(import_anchor, "import itertools\nimport os\nimport time\n", 1)
+
+    init_anchor = (
+        "        self.block_size = block_size\n"
+        "        self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size\n"
+    )
+    init_inject = (
+        "        self.block_size = block_size\n"
+        "        # [issue27-adaptive] mixed batches need a much smaller prefill\n"
+        "        # chunk than prefill-only batches to bound inter-token gaps.\n"
+        "        self._decode_active_prefill_threshold = int(\n"
+        "            os.getenv(\"DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD\", \"1024\")\n"
+        "        )\n"
+        "        if (\n"
+        "            self._decode_active_prefill_threshold < 0\n"
+        "            or self._decode_active_prefill_threshold % block_size != 0\n"
+        "        ):\n"
+        "            raise ValueError(\n"
+        "                \"DSPARK_DECODE_ACTIVE_PREFILL_THRESHOLD must be a \"\n"
+        "                f\"non-negative multiple of {block_size}\"\n"
+        "            )\n"
+        "        self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size\n"
+    )
+    assert init_anchor in src, "scheduler init anchor not found"
+    src = src.replace(init_anchor, init_inject, 1)
+
+    step_anchor = (
+        "        # Whether the running batch contains any prefill requests.\n"
+        "        prefill_scheduled = False\n"
+    )
+    step_inject = step_anchor + (
+        "\n"
+        "        # [issue27-adaptive] shrink prefill chunks only while decode is live.\n"
+        "        # Use the full live registry: async V2 scheduling can temporarily\n"
+        "        # remove an in-flight decode from self.running. Keep the larger\n"
+        "        # configured threshold only for a genuinely idle/prefill-only lane.\n"
+        "        active_prefill_threshold = (\n"
+        "            self.scheduler_config.long_prefill_token_threshold\n"
+        "        )\n"
+        "        decode_is_live = any(\n"
+        "            req.num_output_tokens > 0\n"
+        "            or (\n"
+        "                req.num_computed_tokens >= req.num_prompt_tokens\n"
+        "                and not req.is_prefill_chunk\n"
+        "            )\n"
+        "            for req in self.requests.values()\n"
+        "        )\n"
+        "        if decode_is_live:\n"
+        "            decode_threshold = self._decode_active_prefill_threshold\n"
+        "            if decode_threshold > 0 and (\n"
+        "                active_prefill_threshold <= 0\n"
+        "                or decode_threshold < active_prefill_threshold\n"
+        "            ):\n"
+        "                active_prefill_threshold = decode_threshold\n"
+    )
+    assert step_anchor in src, "scheduler step anchor not found"
+    src = src.replace(step_anchor, step_inject, 1)
+
+    running_threshold = (
+        "            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:\n"
+        "                num_new_tokens = self.scheduler_config.long_prefill_token_threshold\n"
+    )
+    adaptive_running = (
+        "            if 0 < active_prefill_threshold < num_new_tokens:\n"
+        "                num_new_tokens = active_prefill_threshold\n"
+    )
+    assert running_threshold in src, "running prefill threshold anchor not found"
+    src = src.replace(running_threshold, adaptive_running, 1)
+
+    waiting_threshold = (
+        "                    threshold = self.scheduler_config.long_prefill_token_threshold\n"
+    )
+    adaptive_waiting = "                    threshold = active_prefill_threshold\n"
+    assert waiting_threshold in src, "waiting prefill threshold anchor not found"
+    src = src.replace(waiting_threshold, adaptive_waiting, 1)
+    statuses.append("adaptive")
+
+if statuses:
+    P.write_text(src)
+    print(f"[issue27-hotfix] patched {','.join(statuses)}: {P}")
+else:
+    print(f"[issue27-hotfix] already applied to {P}")

--- a/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
+++ b/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
@@ -72,14 +72,21 @@ if MARK in src:
 
 # --- 0. import os (module-level diag gate) -----------------------------------
 A0_OLD = "import itertools\nimport time\n"
-assert A0_OLD in src, "issue43: import anchor not found; refusing to patch"
-src = src.replace(
-    A0_OLD,
-    A0_OLD
-    + "# [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate\n"
-    + "import os\n",
-    1,
-)
+A0_WITH_OS = "import itertools\nimport os\nimport time\n"
+if A0_OLD in src:
+    src = src.replace(
+        A0_OLD,
+        A0_OLD
+        + "# [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate\n"
+        + "import os\n",
+        1,
+    )
+else:
+    # The adaptive issue #27 revision already imports os for its environment
+    # threshold. Reuse it instead of failing or adding a duplicate import.
+    assert A0_WITH_OS in src, (
+        "issue43: import anchor not found; refusing to patch"
+    )
 
 # --- 1. module-level diag gate constant --------------------------------------
 A1_OLD = "logger = init_logger(__name__)\n"

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -30,6 +30,7 @@ echo "== python compile (patches + unit scripts) =="
 mapfile -t py_files < <(find patches -name '*.py' -not -path '*/__pycache__/*' | sort)
 py_files+=(
   scripts/test-issue26-swa-min-v2.py
+  scripts/test-issue27-adaptive-prefill.py
   scripts/test-encoding-dsv4-issue21.py
   scripts/test-suppress-stops-in-reasoning.py
   scripts/verify-dsv4-027-equality-gate.py
@@ -40,6 +41,8 @@ ok "py_compile ${#py_files[@]} files"
 echo "== unit tests (no GPU) =="
 python3 scripts/test-issue26-swa-min-v2.py -q
 ok "test-issue26-swa-min-v2"
+python3 scripts/test-issue27-adaptive-prefill.py -q
+ok "test-issue27-adaptive-prefill"
 python3 scripts/test-encoding-dsv4-issue21.py -q
 ok "test-encoding-dsv4-issue21"
 python3 scripts/test-suppress-stops-in-reasoning.py -q

--- a/scripts/test-issue27-adaptive-prefill.py
+++ b/scripts/test-issue27-adaptive-prefill.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""CPU guards for the adaptive issue-27 scheduler hotfix."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "patches" / "hotfix-dsv4-issue27-partial-prefill-concurrency.py"
+
+
+class AdaptivePrefillPatchTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = PATCH.read_text()
+
+    def test_detects_mtp_decode_from_output_not_transient_chunk_flag(self) -> None:
+        self.assertIn('"            req.num_output_tokens > 0\\n"', self.source)
+        self.assertIn('"            for req in self.requests.values()\\n"', self.source)
+        self.assertIn('"        if decode_is_live:\\n"', self.source)
+
+    def test_prompt_complete_fallback_covers_first_decode_step(self) -> None:
+        self.assertIn(
+            '"                req.num_computed_tokens >= req.num_prompt_tokens\\n"',
+            self.source,
+        )
+        self.assertIn('"                and not req.is_prefill_chunk\\n"', self.source)
+
+    def test_active_threshold_controls_running_and_waiting_prefills(self) -> None:
+        self.assertIn('"                num_new_tokens = active_prefill_threshold\\n"', self.source)
+        self.assertIn('"                    threshold = active_prefill_threshold\\n"', self.source)
+
+    def test_patch_remains_idempotent_and_migrates_old_revision(self) -> None:
+        self.assertIn("if ADAPTIVE_MARK not in src:", self.source)
+        self.assertIn("old_registry_detector", self.source)
+        self.assertIn('statuses.append("adaptive-output-state")', self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue43_patchapply.py
+++ b/tests/test_issue43_patchapply.py
@@ -32,7 +32,14 @@ def apply_hotfix_to_copy(src_path, hotfix_path):
     marker = 'Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")'
     txt = txt.replace(marker, f'Path({str(src_path)!r})')
     ns = {}
-    exec(compile(txt, str(hotfix_path), "exec"), ns)
+    # Local issue #27 revisions accept an optional target path for focused
+    # tests, while upstream #43 still hardcodes P. Support both interfaces.
+    old_argv = sys.argv
+    try:
+        sys.argv = [str(hotfix_path), str(src_path)]
+        exec(compile(txt, str(hotfix_path), "exec"), ns)
+    finally:
+        sys.argv = old_argv
 
 
 def main():


### PR DESCRIPTION
## Summary

- retain large prefill chunks for idle, prefill-only work
- switch to a configurable 1024-token chunk while a decode lane is live
- detect live speculative decode from durable output/request state across the async scheduler registry
- preserve compatibility with the existing issue #43 fairness/diagnostic hotfix
- add environment documentation and CPU regression guards

## Why

A single static chunk size forces a latency/throughput tradeoff: larger chunks improve isolated cold ingestion, but can create multi-second inter-token gaps when a long prompt arrives during active generation. This change selects the threshold from scheduler state so those two workloads can be tuned independently.

## Validation

- focused adaptive-prefill tests: 4/4 pass
- patch applies to the real scheduler from the pinned container image
- the issue #43 patch applies afterward and the combined scheduler compiles
- reapplying the issue #43 layer is idempotent
- measured cold 32K ingestion improved from about 18.4s to 16.2s; mixed-load p99 after initial tokenization stayed around 0.69-1.09s in the tested setup

The early tokenizer stall remains outside this scheduler change and is not claimed as fixed.