### PR TITLE
feat: DEFAULT_THINKING_TOKEN_BUDGET — server-side fallback for thinking_token_budget (follow-up to #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 2026-08-13
 
+### Added
+
+- **Server-side default for `thinking_token_budget`**: the [Issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31) hotfix bounds reasoning only when the request carries the field, and most OpenAI-compatible agent harnesses have no way to set it — so a `DEFAULT_THINKING=max` deployment stays exposed to the empty-`content` case.
+
+  **Change:** `DEFAULT_THINKING_TOKEN_BUDGET` supplies the value when the request omits it. Unset (the default) preserves the request-only behaviour exactly; a request can still opt out with a negative budget. Set the same value on both nodes.
+
+  Live (TP=2, `reasoning_effort=max`, `temperature=0`, `max_tokens=12000`, client sending **no** budget field): before `finish_reason: length`, 12,000 tokens, ~50k chars of reasoning, `content: null`; after (`DEFAULT_THINKING_TOKEN_BUDGET=4000`) `finish_reason: stop`, ~5.1k tokens, ~17k chars of reasoning, **non-null `content`** (~4.9k chars).
+
 ### Fixed
 
 - **`thinking_token_budget` rejected on DSpark / V2 ([Issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31))**: with `DEFAULT_THINKING=max`, a reply that hits `max_tokens` while still inside `<think>` returns `content: null` and `finish_reason: length`. Stock Anemll `0.1.1` rejects `thinking_token_budget` with HTTP 400 (`not yet supported by the V2 model runner`); `VLLM_USE_V2_MODEL_RUNNER=0` cannot be used because DSpark exists only on V2.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ logic ships inside the image rather than as a host bind-mount.
 - **Available KV (text-only, this cluster @ util 0.835):** ~**18.08 GiB** → **GPU KV cache size ~2,493,464 tokens** (~2.38× concurrency at 1M; trust the live boot log)
 - `MTP_NUM_TOKENS=5` (checkpoint `dspark_block_size` is 5; k must be ≥ 5)
 - `DEFAULT_THINKING=max` (`off`, `low`, `high`, or `max`; request-level overrides still win)
-- `thinking_token_budget` is supported on this DSpark/V2 serve ([Issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31)). **Clients still have to send `thinking_token_budget`.** If they don’t, a reply that hits `max_tokens` mid-reasoning still returns `content: null` (`finish_reason: length`); the thoughts are only in `message.reasoning`.
+- `thinking_token_budget` is supported on this DSpark/V2 serve ([Issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31)). If a client neither sends it nor a server default is configured, a reply that hits `max_tokens` mid-reasoning returns `content: null` (`finish_reason: length`); the thoughts are only in `message.reasoning`. Set **`DEFAULT_THINKING_TOKEN_BUDGET`** to cover clients that cannot send the field — it applies only when the request omits it.
 - `VLLM_USE_BREAKABLE_CUDAGRAPH=0` (keep regular CUDA graphs; Anemll auto-enables the slower breakable path when unset)
 - API bind address `0.0.0.0:8888`
 
@@ -755,7 +755,7 @@ recipe default):
 - `MAX_NUM_BATCHED_TOKENS=8192`
 - `GPU_MEMORY_UTILIZATION_TEXT=0.835`
 - `MTP_NUM_TOKENS=5`
-- `DEFAULT_THINKING=max` — send `thinking_token_budget` on each request or issue #31 empty-`content` still happens
+- `DEFAULT_THINKING=max` — send `thinking_token_budget` on each request, or set `DEFAULT_THINKING_TOKEN_BUDGET` server-side, or issue #31 empty-`content` still happens
 - `VLLM_USE_BREAKABLE_CUDAGRAPH=0`
 - `HF_HUB_OFFLINE=1` after both nodes have a full model cache
 - `VLLM_USE_FLASHINFER_SAMPLER=1`
@@ -874,7 +874,7 @@ still send an explicit request-level override when they require deterministic
 behavior.
 
 > [!IMPORTANT]
-> **Clients still have to send `thinking_token_budget`.** If they don’t, [issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31)’s empty-`content` case is still there: thinking stays `max`, fills `max_tokens`, and the API returns `content: null` with `finish_reason: "length"`. OpenAI-style harnesses that only render `content` then show a blank turn. Pass a budget (for example `128` or `256`) on the chat-completions request so the server can close `</think>` and leave tokens for the answer. Omitting the field leaves the old behaviour unchanged.
+> **A budget has to come from somewhere.** Without one, [issue #31](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/31)’s empty-`content` case is still there: thinking stays `max`, fills `max_tokens`, and the API returns `content: null` with `finish_reason: "length"`. OpenAI-style harnesses that only render `content` then show a blank turn. Either pass a budget (for example `128` or `256`) on the chat-completions request, or set **`DEFAULT_THINKING_TOKEN_BUDGET`** so the server supplies one whenever the request omits the field — the OpenAI SDK can pass it via `extra_body`, but many agent harnesses and most chat UIs never expose it. A request can still opt out with a negative budget. Leaving both unset preserves the old behaviour exactly.
 
 A ready-to-copy pi configuration is provided in
 [`pi-models.dspark.example.json`](pi-models.dspark.example.json):

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -104,6 +104,13 @@ services:
       # Checkpoint dspark_block_size is 5; k<5 truncates draft blocks (silent on 0.25.2 image).
       MTP_NUM_TOKENS: "${MTP_NUM_TOKENS:-5}"
       DEFAULT_THINKING: "${DEFAULT_THINKING:-low}"
+      # Server-side fallback for thinking_token_budget, applied only when the
+      # request omits it. Empty keeps the current request-only behaviour.
+      # Set the same value on both nodes. The OpenAI SDK can pass the field via
+      # extra_body, but many agent harnesses never expose it, leaving a
+      # DEFAULT_THINKING=max deployment exposed to reasoning that fills
+      # max_tokens and returns content: null.
+      DEFAULT_THINKING_TOKEN_BUDGET: "${DEFAULT_THINKING_TOKEN_BUDGET:-}"
 
     command:
       - bash

--- a/patches/hotfix-dsv4-issue31-v2-thinking-budget.py
+++ b/patches/hotfix-dsv4-issue31-v2-thinking-budget.py
@@ -12,8 +12,10 @@ This patch:
      next sampled token(s) to the reasoning-end sequence (</think>).
   3. Threads ReasoningConfig into the V2 Sampler so start/end ids are known.
 
-No-op when the request does not set thinking_token_budget. DSpark rejection
-sampling still runs; forcing is applied to processed logits before top-k.
+When the request omits thinking_token_budget, DEFAULT_THINKING_TOKEN_BUDGET
+supplies a server-side fallback; unset (the default) keeps the request-only
+behaviour. DSpark rejection sampling still runs; forcing is applied to
+processed logits before top-k.
 
 Idempotent. Patches files under
 /usr/local/lib/python3.12/dist-packages/vllm/
@@ -29,10 +31,37 @@ THINKING_BUDGET_PY = r'''# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import torch
 
 from vllm.sampling_params import SamplingParams
+
+
+def _default_budget() -> int | None:
+    """Server-side fallback for clients that cannot send the field.
+
+    The OpenAI SDK can pass thinking_token_budget via extra_body, but many
+    agent harnesses and most chat UIs never expose it, so a request-only knob
+    leaves those deployments unprotected.
+    Empty, unparseable, or <= 0 means no default, i.e. previous behaviour.
+
+    A request can still opt out explicitly with a negative budget, which
+    apply() already treats as unlimited. JSON null is indistinguishable from
+    an omitted field and therefore takes the default.
+    """
+    raw = os.environ.get("DEFAULT_THINKING_TOKEN_BUDGET", "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+DEFAULT_BUDGET = _default_budget()
 
 
 def _last_subseq(seq: list[int], pat: list[int]) -> int:
@@ -61,6 +90,8 @@ class ThinkingBudgetState:
 
     def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:
         b = getattr(sampling_params, "thinking_token_budget", None)
+        if b is None:
+            b = DEFAULT_BUDGET
         self.budget[req_idx] = -1 if b is None else int(b)
 
     def apply(


### PR DESCRIPTION
## Summary

The issue #31 hotfix bounds reasoning only when a request carries `thinking_token_budget`. The OpenAI SDK can pass that field via `extra_body`, but many agent harnesses and most chat UIs never expose it, so a `DEFAULT_THINKING=max` deployment stays exposed: reasoning fills `max_tokens` inside `<think>`, `</think>` is never emitted, and the turn comes back with `content: null`.

This adds `DEFAULT_THINKING_TOKEN_BUDGET`, a server-side fallback applied **only when the request omits the field**. Unset — the default — preserves current behaviour exactly.

Thanks for landing #31; the forcing mechanism works well. This just makes it reachable for clients that cannot send the parameter. The README already anticipates the gap ("Clients still have to send `thinking_token_budget`"), so this closes it and refreshes those three passages.

## Why `max` runs so long

The length is not a sampling artifact. `REASONING_EFFORT_PROMPTS` in the checkpoint's `encoding/encoding_dsv4.py` (lines 67–79, at the recipe's pinned revision `9e165c30…`) gives `max` an explicit anti-termination directive, line 77:

> "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered."

`high` (lines 69–73) has no comparable stop condition — its strongest language is "Reasoning Effort: Absolute maximum with no shortcuts permitted" plus thoroughness demands. `low` injects an empty string. In thinking mode the generation prompt is seeded with `<think>` and nothing closes it, so the only exit is the model emitting `</think>` — which that sentence directly discourages.

Worth noting: `DEFAULT_REASONING_EFFORT = "low"` (line 80) is DeepSeek's own default.

That prompt text ships **with the checkpoint**, not with this repo. The repo *could* patch it — there is precedent in `patches/hotfix-encoding-dsv4-issue21.py` and the compose tokenizer remap — but this PR deliberately chooses mitigation over rewriting a vendor prompt.

## Measurements

2x DGX Spark, TP=2 over RoCEv2, image `ghcr.io/anemll/dspark-vllm-gx10:0.1.1`, vLLM `0.25.2.dev0+g752a3a504.d20260714`, `kv_cache_dtype=nvfp4_ds_mla`, `MTP_NUM_TOKENS=5`, `MAX_NUM_SEQS=4`.

Prompt: *"Design a small in-memory rate limiter supporting both a token bucket and a sliding window, with a shared interface. Give the Python code, then compare the two strategies' memory and burst behaviour."* — `temperature=0`, `max_tokens=12000`, no `repetition_penalty`.

| effort | finish | reasoning chars | content |
|---|---|---|---|
| max | `length` | ~50,000 | **null** |
| high | `stop` | ~31,300 | 3,779 |
| low | `stop` | ~5,300–5,800 | 4,966 |

Each row was measured twice, on different days and slightly different server configurations. **Reasoning-character counts reproduced within ~1%; `finish_reason` and null-ness were stable.** Repetition scores were *not* stable run-to-run (a 6-gram repeat metric moved 0.45 → 0.79 for the `max` row across two runs), so I've left them out — the claim here is about termination, not a repetition number.

Two caveats I'd rather state than have you discover:

- **This is one deployment, small samples.** Treat the table as indicative and confirm with the repro below.
- **`max` termination is marginal, not impossible.** At `temperature=0` with no repetition penalty it consistently ran out the 12k budget. With a `repetition_penalty` of 1.05 applied server-side, the same request *did* terminate (`stop`, ~11,800 tokens — right at the edge). At `temperature=0.6` it also terminated once. So `max` sits near the boundary of a 12k budget rather than being unable to stop.

## With this change

Client sends **no** `thinking_token_budget`; `reasoning_effort=max`, `temperature=0`, `max_tokens=12000`; server configured `DEFAULT_THINKING_TOKEN_BUDGET=4000`:

| | finish | tokens | reasoning chars | content |
|---|---|---|---|---|
| before | `length` | 12,000 | ~50,000 | **null** |
| after | `stop` | ~5,100 | ~17,300 | **~4,900 chars** |

Reproduced independently on the same server configuration. The effect is also independent of `repetition_penalty` — with the penalty neutralised per-request, an explicit `thinking_token_budget=4000` gives `stop` at ~4,950 tokens.

### Opting out per request

A client wanting unbounded reasoning despite a server default can send a **negative** `thinking_token_budget`, which the existing code already treats as unlimited (`budget < 0` short-circuits in `apply()`). Verified against a running server. JSON `null` is indistinguishable from an omitted field and therefore takes the default.

`thinking_token_budget: 0` is accepted but forces `</think>` on the first generated token, so reasoning-style text lands in `content` — possibly worth rejecting or documenting separately.

### Trade-off

The default applies to **all** efforts, not just `max`. A 4000-token budget will truncate `high`-effort reasoning, which naturally ran ~8,200 tokens on this prompt. Operators should size it against the effort they actually serve. It also adds the existing per-step token scan in `apply()` to every thinking request rather than only budgeted ones.

## What I checked and ruled out

**Tested** — each reproduced the failure, so none of these is the cause:

- `kv_cache_dtype`: reproduces on both `fp8_ds_mla` and `nvfp4_ds_mla`
- the 2026-08-13 update, including `hotfix-dsv4-grammar-advance.sh` (#44993)
- the six v0.27 perf backports — `DSPARK_SKIP_HOTFIX=1` still reproduces
- `--generation-config vllm`: the checkpoint's `generation_config.json` is `do_sample: true, temperature: 1.0, top_p: 1.0`, i.e. vLLM's own defaults, so nothing meaningful is discarded
- the compose tokenizer remap: it only maps unknown efforts to `low`, leaving `max` untouched

**Argued from code, not tested** — DSpark speculative decoding: rejection sampling is distribution-preserving, so it should make a long run faster rather than more likely to overrun. I did not isolate it experimentally.

## Reproducing

```bash
curl -s http://127.0.0.1:8888/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"<served-name>",
       "messages":[{"role":"user","content":"Design a small in-memory rate limiter supporting both a token bucket and a sliding window, with a shared interface. Give the Python code, then compare the two strategies memory and burst behaviour."}],
       "temperature":0,"max_tokens":12000,
       "chat_template_kwargs":{"thinking":true,"reasoning_effort":"max"}}' \
  | python3 -c 'import json,sys; d=json.load(sys.stdin); c=d["choices"][0]; print(c["finish_reason"], len(c["message"].get("reasoning") or ""), c["message"].get("content") is None)'
```

`length <large> True` is the failure. With `DEFAULT_THINKING_TOKEN_BUDGET` set, the same request returns `stop` and non-null content.

## Suggestion beyond this PR

Consider whether `DEFAULT_THINKING=max` is right for `.env.dspark.example` (raised from `low` in a4ce87a). The compose fallback and `start-deepseek-v4-flash-dspark.sh` both still default to `low`, but the example is what people copy — and `max` is the only level carrying the anti-termination clause.

Happy to test any patch on this hardware.


---

Related: #52 / #53 (a separate prompt-rendering bug found while investigating an agent-loop failure on the same deployment). Independent of this change.
