### PR TITLE
stability-quick: skip vision checks on the text-only serve profile

### DIFF
--- a/scripts/stability-quick.py
+++ b/scripts/stability-quick.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 import statistics
 import sys
 import time
@@ -155,6 +156,14 @@ def main() -> int:
     parser.add_argument("--model", default="deepseek-v4-flash-0731")
     parser.add_argument("--vl-model", default="qwen3-vl-4b")
     parser.add_argument(
+        "--skip-vl",
+        action="store_true",
+        default=os.environ.get("ENABLE_VL_SIDECAR", "0") != "1",
+        help="Skip vision-sidecar checks (readiness probe and phase 3). Defaults to "
+             "skipping unless ENABLE_VL_SIDECAR=1, so the text-only serve profile "
+             "runs out of the box.",
+    )
+    parser.add_argument(
         "--ladder",
         default="8192,32768,131072,262144",
         help="Comma-separated prompt token targets for the context ladder",
@@ -191,7 +200,7 @@ def main() -> int:
     log("Phase 0: readiness smoke")
     try:
         main_models = request_json(f"{args.base_url}/models", timeout=30)
-        vl_models = request_json(f"{args.vl_url}/models", timeout=30)
+        vl_models = {} if args.skip_vl else request_json(f"{args.vl_url}/models", timeout=30)
         smoke = chat_stream(
             args.base_url,
             args.model,
@@ -202,11 +211,14 @@ def main() -> int:
         )
         if not smoke["ok"] or "OK" not in smoke["preview"].upper():
             raise RuntimeError(f"text smoke bad: {smoke}")
-        img = ensure_image(Path(args.image))
-        b64 = base64.b64encode(img.read_bytes()).decode()
-        vsmoke = vision_chat(args.vl_url, args.vl_model, b64, "One word: what color is this solid square?")
-        if not vsmoke["ok"]:
-            raise RuntimeError(f"vision smoke failed: {vsmoke}")
+        if args.skip_vl:
+            vsmoke = {"ok": True, "skipped": True, "preview": "(skipped)", "elapsed_s": 0.0}
+        else:
+            img = ensure_image(Path(args.image))
+            b64 = base64.b64encode(img.read_bytes()).decode()
+            vsmoke = vision_chat(args.vl_url, args.vl_model, b64, "One word: what color is this solid square?")
+            if not vsmoke["ok"]:
+                raise RuntimeError(f"vision smoke failed: {vsmoke}")
         report["phases"]["readiness"] = {
             "main_model": (main_models.get("data") or [{}])[0].get("id"),
             "main_max_model_len": (main_models.get("data") or [{}])[0].get("max_model_len"),
@@ -334,65 +346,70 @@ def main() -> int:
         save()
 
     # --- Phase 3: vision while holding long 0731 prefix ---
-    log(f"Phase 3: vision mid-context (0731 prefix ~{args.vision_prefix_tokens})")
-    try:
-        prefix = build_prompt(
-            args.base_url, args.model, args.vision_prefix_tokens, "vision-prefix"
-        )
-        # Hold KV with a short decode first
-        hold = chat_stream(
-            args.base_url,
-            args.model,
-            [
-                {
-                    "role": "user",
-                    "content": prefix + "\n\nReply with exactly: PREFIX_HELD",
-                }
-            ],
-            max_tokens=32,
-            thinking=False,
-        )
-        img = ensure_image(Path(args.image))
-        b64 = base64.b64encode(img.read_bytes()).decode()
-        vmid = vision_chat(
-            args.vl_url,
-            args.vl_model,
-            b64,
-            "One word color of this solid square (expect Red).",
-        )
-        # Continue on 0731 after VL call (new request; proves API still healthy)
-        resume = chat_stream(
-            args.base_url,
-            args.model,
-            [
-                {
-                    "role": "user",
-                    "content": prefix + "\n\nReply with exactly: AFTER_VISION_OK",
-                }
-            ],
-            max_tokens=32,
-            thinking=False,
-        )
-        ok = (
-            hold.get("ok")
-            and "PREFIX_HELD" in hold.get("preview", "").upper()
-            and vmid.get("ok")
-            and resume.get("ok")
-            and "AFTER_VISION_OK" in resume.get("preview", "").upper()
-        )
-        phase = {"hold": hold, "vision": vmid, "resume": resume, "ok": ok}
-        if not ok:
-            report["failures"].append({"phase": "vision_mid", "detail": phase})
-        report["phases"]["vision_mid"] = phase
-        log(
-            f"  {'PASS' if ok else 'FAIL'} hold={hold.get('prompt_tokens')} "
-            f"vision='{vmid.get('preview')}' resume={resume.get('preview', '')[:40]!r}"
-        )
-    except Exception as exc:  # noqa: BLE001
-        report["phases"]["vision_mid"] = {"ok": False, "error": str(exc)}
-        report["failures"].append({"phase": "vision_mid", "error": str(exc)})
-        log(f"  FAIL vision_mid: {exc}")
-    save()
+    if args.skip_vl:
+        log("Phase 3: vision mid-context SKIPPED (no vision sidecar; --skip-vl)")
+        report["phases"]["vision_mid"] = {"skipped": True, "ok": True}
+        save()
+    else:
+        log(f"Phase 3: vision mid-context (0731 prefix ~{args.vision_prefix_tokens})")
+        try:
+            prefix = build_prompt(
+                args.base_url, args.model, args.vision_prefix_tokens, "vision-prefix"
+            )
+            # Hold KV with a short decode first
+            hold = chat_stream(
+                args.base_url,
+                args.model,
+                [
+                    {
+                        "role": "user",
+                        "content": prefix + "\n\nReply with exactly: PREFIX_HELD",
+                    }
+                ],
+                max_tokens=32,
+                thinking=False,
+            )
+            img = ensure_image(Path(args.image))
+            b64 = base64.b64encode(img.read_bytes()).decode()
+            vmid = vision_chat(
+                args.vl_url,
+                args.vl_model,
+                b64,
+                "One word color of this solid square (expect Red).",
+            )
+            # Continue on 0731 after VL call (new request; proves API still healthy)
+            resume = chat_stream(
+                args.base_url,
+                args.model,
+                [
+                    {
+                        "role": "user",
+                        "content": prefix + "\n\nReply with exactly: AFTER_VISION_OK",
+                    }
+                ],
+                max_tokens=32,
+                thinking=False,
+            )
+            ok = (
+                hold.get("ok")
+                and "PREFIX_HELD" in hold.get("preview", "").upper()
+                and vmid.get("ok")
+                and resume.get("ok")
+                and "AFTER_VISION_OK" in resume.get("preview", "").upper()
+            )
+            phase = {"hold": hold, "vision": vmid, "resume": resume, "ok": ok}
+            if not ok:
+                report["failures"].append({"phase": "vision_mid", "detail": phase})
+            report["phases"]["vision_mid"] = phase
+            log(
+                f"  {'PASS' if ok else 'FAIL'} hold={hold.get('prompt_tokens')} "
+                f"vision='{vmid.get('preview')}' resume={resume.get('preview', '')[:40]!r}"
+            )
+        except Exception as exc:  # noqa: BLE001
+            report["phases"]["vision_mid"] = {"ok": False, "error": str(exc)}
+            report["failures"].append({"phase": "vision_mid", "error": str(exc)})
+            log(f"  FAIL vision_mid: {exc}")
+        save()
 
     report["finished_at"] = datetime.now(timezone.utc).isoformat()
     report["ok"] = not report["failures"] and all(


### PR DESCRIPTION
`scripts/stability-quick.py` fails immediately on the recipe's **default** serve profile,
before any of its checks run.

### Reproduce

Default text-only deployment (`ENABLE_VL_SIDECAR` unset → 0), healthy 2× Spark cluster:

```console
$ python3 scripts/stability-quick.py
[11:55:31Z] Phase 0: readiness smoke
[11:55:31Z] FAIL readiness: <urlopen error [Errno 111] Connection refused>
```

The server is healthy; only the vision sidecar is absent — which is what the default profile
asks for:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8888/v1/models   # text
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8889/v1/models   # VL sidecar
000
```

### Cause

Phase 0 probes the sidecar unconditionally, and phase 3 is vision-only:

```python
main_models = request_json(f"{args.base_url}/models", timeout=30)
vl_models   = request_json(f"{args.vl_url}/models",   timeout=30)   # default :8889
```

`--vl-url` exists, but there is no way to express "there is no sidecar". The last commit to
touch this file is `2727c14` *"Ship text-only 0731 default; defer vision to experimental
path"* — the change that made text-only the default left this script requiring vision.

### Fix

Adds `--skip-vl`, defaulting to **on unless `ENABLE_VL_SIDECAR=1`**, so the default profile
works with no arguments and vision deployments are unaffected:

- phase 0 skips the sidecar `/models` probe and the vision smoke
- phase 3 records `{"skipped": true, "ok": true}` instead of failing
- text phases (readiness smoke, context ladder, soak) are untouched

18 added lines, 1 changed; the rest of the diff is re-indenting phase 3 under the new
`else:` — review with `git diff -w`.

### Verified

2× DGX Spark (GB10), TP=2 over RoCEv2, recipe `103af68`, image
`ghcr.io/anemll/dspark-vllm-gx10:0.1.1`, checkpoint 0731, text-only profile:

| case | result |
|---|---|
| unpatched, no sidecar | `FAIL readiness` at phase 0 |
| patched, default (env unset) | **PASS overall**; `vision '(skipped)'`, phase 3 skipped |
| patched, `ENABLE_VL_SIDECAR=1` | still probes VL and fails — no silent skip |
| patched, `--skip-vl` with `ENABLE_VL_SIDECAR=1` | explicit flag wins, skips |

Patched default-profile run reached every text phase:
`Phase 1 PASS 8192 (76.7 tok/s)` → `Phase 2 PASS round 1 (median 35.2 tok/s)` →
`Phase 3 SKIPPED` → `PASS overall`.