### PR TITLE
feat(serve): bind-mount local model dir, bypass HF hub cache

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -22,6 +22,10 @@ services:
 
     volumes:
       - ${HF_CACHE:-${HOME}/.cache/huggingface}:/cache/huggingface
+      # Local model served directly (bypass HF hub cache): each node binds its
+      # own on-disk model copy at a fixed container path chosen by
+      # DSPARK_MODEL. Set LOCAL_MODEL_DIR to the parent dir of the model.
+      - ${LOCAL_MODEL_DIR:-${HOME}/Model}/SuperDeepseek-V4-MQ:/models/SuperDeepseek-V4-MQ
       # Optional Stage-C overlay: host proposer only when path exists on the
       # Anemll layout (vLLM ships DSpark under v1/worker/gpu/spec_decode).
       # GB10 hybrid plugin tree for ENABLE_VLLM_GB10_PATCH=1 only.

--- a/docs/native-rollback-20260813.txt
+++ b/docs/native-rollback-20260813.txt
@@ -1,0 +1,8 @@
+# Native .venv rollback commands (pre-migration capture 2026-08-13)
+# Head (spark-8012, user mattw):
+vllm serve /home/mattw/Model/SuperDeepseek-V4-MQ --served-model-name SuperDeepseek-V4-Flash-abliterated-MQ-2xDGX --tensor-parallel-size 2 --nnodes 2 --node-rank 0 --master-addr 192.168.100.1 --master-port 25001 --max-model-len 1048576 --kv-cache-dtype nvfp4_ds_mla --moe-backend flashinfer_b12x --enable-prefix-caching --async-scheduling --enable-chunked-prefill --max-num-seqs 6 --max-num-batched-tokens 8192 --gpu-memory-utilization 0.835 --enable-auto-tool-choice --tool-call-parser deepseek_v4 --speculative-config '{"method":"dspark","num_speculative_tokens":1,"draft_sample_method":"greedy"}' --host 0.0.0.0 --port 8888
+#   venv: /home/mattw/vllm-dspark/.venv/bin/vllm
+
+# Worker (spark-137f, user admin):
+vllm serve /home/admin/Model/SuperDeepseek-V4-MQ --tensor-parallel-size 2 --nnodes 2 --node-rank 1 --master-addr 192.168.100.1 --master-port 25001 --max-model-len 1048576 --kv-cache-dtype nvfp4_ds_mla --moe-backend flashinfer_b12x --enable-prefix-caching --async-scheduling --enable-chunked-prefill --max-num-seqs 6 --max-num-batched-tokens 8192 --gpu-memory-utilization 0.835 --speculative-config '{"method":"dspark","num_speculative_tokens":1,"draft_sample_method":"greedy"}' --headless
+#   venv: /home/admin/vllm-dspark/.venv/bin/vllm


### PR DESCRIPTION
## What
Serve the on-disk model copy directly via `LOCAL_MODEL_DIR` in `docker-compose.dspark.yml`, bypassing HF hub cache resolution inside the container.

## Why
Root cause of the 2026-08-13 broken-symlink start failure: the HF cache model tree and its blob store can be separated by a bind-mount boundary. Binding the model parent dir directly keeps model + blobs under one bind-mount boundary, and removes network/cache lookup from the start path (`HF_HUB_OFFLINE=1` already assumed).

Per repo defaults: `DSPARK_MODEL_ABLITERATED=/models/SuperDeepseek-V4-MQ`, each node binds its own host copy via `LOCAL_MODEL_DIR`.

## Notes
- Default `LOCAL_MODEL_DIR=${HOME}/Model` mirrors repo-agnostic home layout; override per node.
- Includes `docs/native-rollback-20260813.txt` capturing native `.venv` rollback commands for head/worker.