### PR TITLE
test: add strict live Responses API verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,16 @@ is **CPU-only** (`scripts/ci-validate.sh`). Live tok/s still needs the 2× Spark
 
 ### Strict Responses API verification
 
+Stateful `previous_response_id` continuation requires starting vLLM with
+`VLLM_ENABLE_RESPONSES_API_STORE=1`. vLLM keeps the Responses API store off
+by default; when enabled, stored response state consumes memory and is retained
+until the server restarts. A continuation `response_id` 404 while the other
+gates pass indicates this configuration is off, not a verifier regression.
+
+Existing live evidence: the stock configuration passed 3/4 gates, with only
+the known configuration 404; a controlled
+`VLLM_ENABLE_RESPONSES_API_STORE=1` run passed all four gates.
+
 After the server is ready, run the dependency-free live verifier to check
 Responses text/SSE, stateful tool continuation, strict JSON schema, reasoning,
 invalid-field errors, appended multi-turn prefix reuse, and disconnect cleanup:

--- a/README.md
+++ b/README.md
@@ -472,6 +472,23 @@ Optional GB10 hybrid plugin: `ENABLE_VLLM_GB10_PATCH=1 ./start-…`
 CI on every push ([`.github/workflows/validate.yml`](.github/workflows/validate.yml))
 is **CPU-only** (`scripts/ci-validate.sh`). Live tok/s still needs the 2× Spark pair.
 
+### Strict Responses API verification
+
+After the server is ready, run the dependency-free live verifier to check
+Responses text/SSE, stateful tool continuation, strict JSON schema, reasoning,
+invalid-field errors, appended multi-turn prefix reuse, and disconnect cleanup:
+
+```bash
+python3 scripts/verify-responses-api-live.py \
+  --base-url http://127.0.0.1:8888/v1 \
+  --model deepseek-v4-flash-0731 \
+  --output results/responses-api-live.json
+```
+
+The full run intentionally creates a ~21K-token appended conversation and a
+forced client disconnect. Use `--skip-multiturn` or `--skip-disconnect` only
+when the corresponding live behavior is outside the test scope.
+
 ---
 
 ## Files
@@ -484,6 +501,7 @@ is **CPU-only** (`scripts/ci-validate.sh`). Live tok/s still needs the 2× Spark
 | `start-` / `stop-` / `status-` / `logs-` / `smoke-*.sh` | Two-node ops |
 | `prepare-dspark-model-cache.sh` | 0731 (and optional VL) on head **and** worker |
 | `scripts/benchmark-0731.py` | Prompt × concurrency sweep |
+| `scripts/verify-responses-api-live.py` | Strict Responses, multi-turn cache, and disconnect gates |
 | [docs/ENVS.md](docs/ENVS.md) | Anemll vs Stage-C env matrix |
 | [docs/PATCHES.md](docs/PATCHES.md) | Keys / #27 / #22 notes |
 | `patches/` | Issue hotfixes applied at container start |

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -32,6 +32,7 @@ py_files+=(
   scripts/test-issue26-swa-min-v2.py
   scripts/test-issue31-thinking-budget-gpu.py
   scripts/test-issue55-tool-truncation.py
+  scripts/test-responses-api-live.py
   scripts/test-encoding-dsv4-issue21.py
   scripts/test-suppress-stops-in-reasoning.py
   scripts/verify-dsv4-027-equality-gate.py
@@ -46,6 +47,8 @@ python3 scripts/test-issue31-thinking-budget-gpu.py -q
 ok "test-issue31-thinking-budget-gpu"
 python3 scripts/test-issue55-tool-truncation.py -q
 ok "test-issue55-tool-truncation"
+python3 scripts/test-responses-api-live.py -q
+ok "test-responses-api-live"
 python3 scripts/test-encoding-dsv4-issue21.py -q
 ok "test-encoding-dsv4-issue21"
 python3 scripts/test-suppress-stops-in-reasoning.py -q

--- a/scripts/test-responses-api-live.py
+++ b/scripts/test-responses-api-live.py
@@ -21,6 +21,50 @@ def load_target():
     return module
 
 
+class ContinuationFailureClient:
+    api_path = "/v1"
+
+    def __init__(self, error):
+        self.error = error
+        self.json_calls = 0
+
+    def json(self, method, path, body=None):
+        self.json_calls += 1
+        if self.json_calls == 1:
+            return {
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "output": [{"type": "message", "content": [
+                    {"type": "output_text", "text": "RESPONSES"},
+                ]}],
+            }
+        if self.json_calls == 2:
+            return {
+                "id": "resp-1",
+                "output": [{"type": "function_call", "name": "ping",
+                            "call_id": "call-1", "arguments": "{}"}],
+            }
+        if self.json_calls == 3:
+            raise self.error
+        raise AssertionError("unexpected JSON request")
+
+    def request(self, method, path, body=None):
+        frames = [
+            ("response.output_text.delta", {
+                "type": "response.output_text.delta", "delta": "RESPONSES",
+            }),
+            ("response.completed", {
+                "type": "response.completed",
+                "response": {
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            }),
+        ]
+        return 200, b"".join(
+            f"event: {name}\ndata: {json.dumps(value)}\n\n".encode()
+            for name, value in frames
+        )
+
+
 class ResponsesApiLiveTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -110,6 +154,29 @@ vllm:prefix_cache_hits_total{model_name="x"} 80
         self.assertTrue(self.module.disconnect_counter_chain_valid(before, opened, [idle, idle]))
         completed = {**idle, "successful_requests": 3.0}
         self.assertFalse(self.module.disconnect_counter_chain_valid(before, opened, [completed, completed]))
+
+    def test_continuation_404_names_store_remediation(self):
+        original = self.module.ResponseHTTPError(
+            "POST", "/v1/responses", 404, b'{"error":"missing"}')
+        client = ContinuationFailureClient(original)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "previous_response_id.*VLLM_ENABLE_RESPONSES_API_STORE=1") as caught:
+            self.module.check_responses(client, "model")
+        self.assertIs(caught.exception.__cause__, original)
+
+    def test_unrelated_continuation_http_failure_is_unchanged(self):
+        original = self.module.ResponseHTTPError(
+            "POST", "/v1/responses", 500, b"upstream")
+        client = ContinuationFailureClient(original)
+        with self.assertRaises(self.module.ResponseHTTPError) as caught:
+            self.module.check_responses(client, "model")
+        self.assertIs(caught.exception, original)
+        self.assertEqual(
+            str(caught.exception),
+            "POST /v1/responses returned HTTP 500: b'upstream'")
+        self.assertNotIn(
+            "VLLM_ENABLE_RESPONSES_API_STORE", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/scripts/test-responses-api-live.py
+++ b/scripts/test-responses-api-live.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""CPU tests for the live Responses API verifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET = ROOT / "scripts" / "verify-responses-api-live.py"
+
+
+def load_target():
+    spec = importlib.util.spec_from_file_location("responses_live", TARGET)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class ResponsesApiLiveTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_target()
+
+    def test_extracts_only_output_text_parts(self):
+        value = {
+            "output": [
+                {"type": "reasoning", "content": []},
+                {"type": "message", "content": [
+                    {"type": "output_text", "text": "RES"},
+                    {"type": "refusal", "refusal": "ignored"},
+                    {"type": "output_text", "text": "PONSES"},
+                ]},
+            ]
+        }
+        self.assertEqual(self.module.responses_output_text(value), "RESPONSES")
+        with self.assertRaisesRegex(ValueError, "output text missing"):
+            self.module.responses_output_text({"output": []})
+
+    def test_sse_requires_exact_terminal_completed_event_and_usage(self):
+        frames = [
+            ("response.created", {"type": "response.created"}),
+            ("response.output_text.delta", {
+                "type": "response.output_text.delta", "delta": "RESPONSES",
+            }),
+            ("response.completed", {
+                "type": "response.completed",
+                "response": {
+                    "usage": {"input_tokens": 3, "output_tokens": 1},
+                },
+            }),
+        ]
+        raw = b"".join(
+            f"event: {name}\ndata: {json.dumps(value)}\n\n".encode()
+            for name, value in frames
+        )
+        self.assertEqual(self.module.parse_responses_sse(raw), "RESPONSES")
+        with self.assertRaises(ValueError):
+            self.module.parse_responses_sse(raw.replace(b"response.completed", b"response.evil", 1))
+        with self.assertRaises(ValueError):
+            self.module.parse_responses_sse(raw.rsplit(b"\n\n", 2)[0] + b"\n\n")
+        with self.assertRaises(ValueError):
+            self.module.parse_responses_sse(b"garbage\n\n" + raw)
+
+    def test_function_call_requires_exact_name_and_json_arguments(self):
+        value = {
+            "id": "resp-1",
+            "output": [{
+                "type": "function_call", "name": "ping",
+                "call_id": "call-1", "arguments": "{}",
+            }],
+        }
+        self.assertEqual(
+            self.module.response_function_call(value, "ping"),
+            ("call-1", "resp-1"),
+        )
+        value["output"][0]["arguments"] = "{"
+        with self.assertRaises(json.JSONDecodeError):
+            self.module.response_function_call(value, "ping")
+
+    def test_safe_prefix_floor_respects_swa_and_block_size(self):
+        self.assertEqual(self.module.safe_cached_floor(21_000), 16_896)
+        self.assertEqual(self.module.safe_cached_floor(4_000), 0)
+
+    def test_metrics_parser_handles_labelled_prometheus_rows(self):
+        text = """
+vllm:num_requests_running{model_name="x"} 1
+vllm:num_requests_waiting{model_name="x"} 0
+vllm:generation_tokens_total{model_name="x"} 12
+vllm:request_success_total{finished_reason="stop"} 3
+vllm:request_success_total{finished_reason="abort"} 2
+vllm:prefix_cache_queries_total{model_name="x"} 100
+vllm:prefix_cache_hits_total{model_name="x"} 80
+"""
+        self.assertEqual(self.module.metric_snapshot(text), {
+            "running": 1.0, "waiting": 0.0, "generation_tokens": 12.0,
+            "successful_requests": 5.0, "cache_queries": 100.0,
+            "cache_hits": 80.0,
+        })
+
+    def test_disconnect_counter_chain_requires_running_then_idle_without_success(self):
+        before = {"running": 0.0, "waiting": 0.0, "generation_tokens": 10.0,
+                  "successful_requests": 2.0, "cache_queries": 0.0, "cache_hits": 0.0}
+        opened = {**before, "running": 1.0, "generation_tokens": 11.0}
+        idle = {**before, "generation_tokens": 15.0}
+        self.assertTrue(self.module.disconnect_counter_chain_valid(before, opened, [idle, idle]))
+        completed = {**idle, "successful_requests": 3.0}
+        self.assertFalse(self.module.disconnect_counter_chain_valid(before, opened, [completed, completed]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-responses-api-live.py
+++ b/scripts/verify-responses-api-live.py
@@ -163,6 +163,16 @@ def disconnect_counter_chain_valid(before: dict[str, float],
                     for row in samples[idle_index:]))
 
 
+class ResponseHTTPError(RuntimeError):
+    def __init__(self, method: str, path: str, status: int, body: bytes):
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body
+        super().__init__(
+            f"{method} {path} returned HTTP {status}: {body[:300]!r}")
+
+
 class Client:
     def __init__(self, base_url: str, timeout: float):
         parsed = urllib.parse.urlparse(base_url.rstrip("/"))
@@ -191,7 +201,7 @@ class Client:
              body: dict[str, Any] | None = None) -> dict[str, Any]:
         status, raw = self.request(method, path, body)
         if status != 200:
-            raise RuntimeError(f"{method} {path} returned HTTP {status}: {raw[:300]!r}")
+            raise ResponseHTTPError(method, path, status, raw)
         value = json.loads(raw)
         if not isinstance(value, dict):
             raise RuntimeError(f"{method} {path} did not return an object")
@@ -255,14 +265,23 @@ def check_responses(client: Client, model: str) -> dict[str, Any]:
         "tool_choice": {"type": "function", "name": "ping"}}
     tool = client.json("POST", client.api_path + "/responses", tool_request)
     call_id, response_id = response_function_call(tool, "ping")
-    continuation = client.json("POST", client.api_path + "/responses", {
-        "model": model, "previous_response_id": response_id,
-        "input": [{"type": "function_call_output", "call_id": call_id,
-                   "output": '{"ok":true}'},
-                  {"role": "user", "content": "Reply with exactly TOOL_OK."}],
-        "max_output_tokens": 64, "temperature": 0,
-        "reasoning": {"effort": "none"}, "store": False,
-    })
+    try:
+        continuation = client.json("POST", client.api_path + "/responses", {
+            "model": model, "previous_response_id": response_id,
+            "input": [{"type": "function_call_output", "call_id": call_id,
+                       "output": '{"ok":true}'},
+                      {"role": "user", "content": "Reply with exactly TOOL_OK."}],
+            "max_output_tokens": 64, "temperature": 0,
+            "reasoning": {"effort": "none"}, "store": False,
+        })
+    except ResponseHTTPError as error:
+        if error.status == 404:
+            raise RuntimeError(
+                "Responses stateful continuation returned HTTP 404 for "
+                "previous_response_id; vLLM disables the Responses API store "
+                "by default. Restart vLLM with "
+                "VLLM_ENABLE_RESPONSES_API_STORE=1.") from error
+        raise
     if responses_output_text(continuation).strip() != "TOOL_OK":
         raise RuntimeError("Responses stateful tool continuation failed")
 

--- a/scripts/verify-responses-api-live.py
+++ b/scripts/verify-responses-api-live.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Strict live verification for OpenAI-compatible Chat and Responses APIs.
+
+The verifier is intentionally dependency-free.  It checks semantic output,
+SSE framing, stateful ``previous_response_id`` tool continuation, strict JSON
+schema output, reasoning, invalid-field errors, appended multi-turn prefix
+reuse, and client-disconnect cleanup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import re
+import secrets
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_RESPONSE_EVENTS = {
+    "response.created", "response.in_progress", "response.output_item.added",
+    "response.output_item.done", "response.content_part.added",
+    "response.content_part.done", "response.output_text.delta",
+    "response.output_text.done", "response.completed",
+}
+
+
+def has_usage(value: dict[str, Any]) -> bool:
+    usage = value.get("usage")
+    return (isinstance(usage, dict)
+            and type(usage.get("input_tokens")) is int
+            and type(usage.get("output_tokens")) is int)
+
+
+def responses_output_text(value: dict[str, Any]) -> str:
+    pieces: list[str] = []
+    output = value.get("output")
+    if not isinstance(output, list):
+        raise ValueError("responses output missing")
+    for item in output:
+        content = item.get("content") if isinstance(item, dict) else None
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if (isinstance(part, dict) and part.get("type") == "output_text"
+                    and isinstance(part.get("text"), str)):
+                pieces.append(part["text"])
+    if not pieces:
+        raise ValueError("responses output text missing")
+    return "".join(pieces)
+
+
+def parse_responses_sse(raw: bytes) -> str:
+    normalized = raw.replace(b"\r\n", b"\n")
+    if not normalized.endswith(b"\n\n"):
+        raise ValueError("responses SSE is not frame-terminated")
+    events: list[str] = []
+    deltas: list[str] = []
+    completed: list[dict[str, Any]] = []
+    for frame in normalized.split(b"\n\n")[:-1]:
+        lines = frame.split(b"\n")
+        if (not lines or any(not line or not (
+                line.startswith(b"event: ") or line.startswith(b"data: "))
+                for line in lines)):
+            raise ValueError("invalid Responses SSE frame")
+        event_lines = [line[7:].decode("ascii", "strict")
+                       for line in lines if line.startswith(b"event: ")]
+        data_lines = [line[6:] for line in lines if line.startswith(b"data: ")]
+        if len(event_lines) > 1 or len(data_lines) != 1 or data_lines[0] == b"[DONE]":
+            raise ValueError("invalid Responses SSE event/data cardinality")
+        value = json.loads(data_lines[0])
+        event_type = value.get("type") if isinstance(value, dict) else None
+        if (not isinstance(event_type, str) or event_type not in ALLOWED_RESPONSE_EVENTS
+                or (event_lines and event_lines[0] != event_type)):
+            raise ValueError("unknown or mismatched Responses SSE event")
+        events.append(event_type)
+        if event_type == "response.output_text.delta":
+            delta = value.get("delta")
+            if not isinstance(delta, str):
+                raise ValueError("Responses text delta is not a string")
+            deltas.append(delta)
+        if event_type == "response.completed":
+            completed.append(value)
+    if len(completed) != 1 or not events or events[-1] != "response.completed":
+        raise ValueError("Responses SSE must end in exactly one completed event")
+    response = completed[0].get("response")
+    if not isinstance(response, dict) or not has_usage(response):
+        raise ValueError("Responses completed event has no usage")
+    return "".join(deltas)
+
+
+def response_function_call(value: dict[str, Any], name: str) -> tuple[str, str]:
+    calls = [item for item in value.get("output", [])
+             if isinstance(item, dict) and item.get("type") == "function_call"]
+    if len(calls) != 1 or calls[0].get("name") != name:
+        raise ValueError("expected Responses function call missing")
+    call_id, arguments, response_id = (
+        calls[0].get("call_id"), calls[0].get("arguments"), value.get("id"))
+    if not all(isinstance(item, str) and item
+               for item in (call_id, arguments, response_id)):
+        raise ValueError("Responses function call identity invalid")
+    if json.loads(arguments) != {}:
+        raise ValueError("Responses function arguments must be an empty object")
+    return call_id, response_id
+
+
+def safe_cached_floor(prompt_tokens: int, swa_window: int = 4096,
+                      block_size: int = 256) -> int:
+    return max(0, ((prompt_tokens - swa_window) // block_size) * block_size)
+
+
+def metric_snapshot(text: str) -> dict[str, float]:
+    names = {
+        "vllm:generation_tokens_total": "generation_tokens",
+        "vllm:request_success_total": "successful_requests",
+        "vllm:prefix_cache_queries_total": "cache_queries",
+        "vllm:prefix_cache_hits_total": "cache_hits",
+    }
+    result = {short: 0.0 for short in names.values()}
+    result.update({"running": 0.0, "waiting": 0.0})
+    for line in (row.strip() for row in text.splitlines()):
+        for full, short in names.items():
+            if line.startswith(full + " ") or line.startswith(full + "{"):
+                result[short] += float(line.rsplit(" ", 1)[1])
+        if (line.startswith("vllm:num_requests_running ")
+                or line.startswith("vllm:num_requests_running{")):
+            result["running"] += float(line.rsplit(" ", 1)[1])
+        if (line.startswith("vllm:num_requests_waiting ")
+                or line.startswith("vllm:num_requests_waiting{")):
+            result["waiting"] += float(line.rsplit(" ", 1)[1])
+    return result
+
+
+def disconnect_counter_chain_valid(before: dict[str, float],
+                                   opened: dict[str, float],
+                                   samples: list[dict[str, float]]) -> bool:
+    if not samples or opened["running"] < 1:
+        return False
+    previous = opened
+    idle_index = None
+    counters = ("generation_tokens", "successful_requests",
+                "cache_queries", "cache_hits")
+    for index, current in enumerate(samples):
+        if any(current[name] < previous[name] for name in counters):
+            return False
+        if current["running"] == 0 and current["waiting"] == 0:
+            idle_index = index
+            break
+        previous = current
+    if idle_index is None:
+        return False
+    idle = samples[idle_index]
+    return (idle["successful_requests"] == before["successful_requests"]
+            and idle["generation_tokens"] - opened["generation_tokens"] <= 32
+            and all(row["generation_tokens"] == idle["generation_tokens"]
+                    and row["successful_requests"] == idle["successful_requests"]
+                    for row in samples[idle_index:]))
+
+
+class Client:
+    def __init__(self, base_url: str, timeout: float):
+        parsed = urllib.parse.urlparse(base_url.rstrip("/"))
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("base URL must be HTTP(S)")
+        path = parsed.path.rstrip("/")
+        self.api_path = path if path.endswith("/v1") else path + "/v1"
+        self.server_path = self.api_path[:-3]
+        self.origin = f"{parsed.scheme}://{parsed.netloc}"
+        self.parsed = parsed
+        self.timeout = timeout
+
+    def request(self, method: str, path: str,
+                body: dict[str, Any] | None = None) -> tuple[int, bytes]:
+        raw = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(
+            self.origin + path, data=raw,
+            headers={"Content-Type": "application/json"}, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as error:
+            return error.code, error.read()
+
+    def json(self, method: str, path: str,
+             body: dict[str, Any] | None = None) -> dict[str, Any]:
+        status, raw = self.request(method, path, body)
+        if status != 200:
+            raise RuntimeError(f"{method} {path} returned HTTP {status}: {raw[:300]!r}")
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise RuntimeError(f"{method} {path} did not return an object")
+        return value
+
+    def open_stream(self, path: str, body: dict[str, Any]):
+        connection_type = (http.client.HTTPSConnection if self.parsed.scheme == "https"
+                           else http.client.HTTPConnection)
+        connection = connection_type(self.parsed.hostname, self.parsed.port,
+                                     timeout=self.timeout)
+        connection.request("POST", path, body=json.dumps(body),
+                           headers={"Content-Type": "application/json"})
+        return connection, connection.getresponse()
+
+
+def chat_content(value: dict[str, Any]) -> str:
+    choices = value.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise ValueError("Chat response choice cardinality invalid")
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str):
+        raise ValueError("Chat content missing")
+    return content
+
+
+def cached_tokens(value: dict[str, Any]) -> int:
+    usage = value.get("usage")
+    details = usage.get("prompt_tokens_details") if isinstance(usage, dict) else None
+    cached = details.get("cached_tokens") if isinstance(details, dict) else None
+    if type(cached) is not int:
+        raise ValueError("usage.prompt_tokens_details.cached_tokens missing")
+    return cached
+
+
+def check_catalog(client: Client, model: str) -> dict[str, Any]:
+    models = client.json("GET", client.api_path + "/models")
+    ids = [item.get("id") for item in models.get("data", []) if isinstance(item, dict)]
+    if ids.count(model) != 1:
+        raise RuntimeError(f"served model alias {model!r} is not unique: {ids!r}")
+    return {"model_present_once": True}
+
+
+def check_responses(client: Client, model: str) -> dict[str, Any]:
+    base = {"model": model, "input": "Reply with exactly RESPONSES.",
+            "max_output_tokens": 64, "temperature": 0,
+            "reasoning": {"effort": "none"}, "store": False}
+    text = client.json("POST", client.api_path + "/responses", base)
+    if not has_usage(text) or responses_output_text(text).strip() != "RESPONSES":
+        raise RuntimeError("Responses text contract failed")
+
+    status, stream_raw = client.request(
+        "POST", client.api_path + "/responses", {**base, "stream": True})
+    if status != 200 or parse_responses_sse(stream_raw).strip() != "RESPONSES":
+        raise RuntimeError("Responses SSE contract failed")
+
+    tool_request = {**base, "input": "Call ping.", "store": True,
+        "tools": [{"type": "function", "name": "ping", "description": "ping",
+                   "parameters": {"type": "object", "properties": {},
+                                  "additionalProperties": False}}],
+        "tool_choice": {"type": "function", "name": "ping"}}
+    tool = client.json("POST", client.api_path + "/responses", tool_request)
+    call_id, response_id = response_function_call(tool, "ping")
+    continuation = client.json("POST", client.api_path + "/responses", {
+        "model": model, "previous_response_id": response_id,
+        "input": [{"type": "function_call_output", "call_id": call_id,
+                   "output": '{"ok":true}'},
+                  {"role": "user", "content": "Reply with exactly TOOL_OK."}],
+        "max_output_tokens": 64, "temperature": 0,
+        "reasoning": {"effort": "none"}, "store": False,
+    })
+    if responses_output_text(continuation).strip() != "TOOL_OK":
+        raise RuntimeError("Responses stateful tool continuation failed")
+
+    structured = client.json("POST", client.api_path + "/responses", {
+        **base, "input": "Return JSON integer value 7.",
+        "text": {"format": {"type": "json_schema", "name": "value",
+            "strict": True, "schema": {"type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"], "additionalProperties": False}}},
+    })
+    if json.loads(responses_output_text(structured)) != {"value": 7}:
+        raise RuntimeError("Responses strict structured output failed")
+
+    reasoning = client.json("POST", client.api_path + "/responses", {
+        **base, "input": "Think briefly, then reply with exactly REASONED.",
+        "reasoning": {"effort": "low"},
+    })
+    output = reasoning.get("output")
+    usage = reasoning.get("usage")
+    details = usage.get("output_tokens_details") if isinstance(usage, dict) else None
+    reasoning_seen = (
+        any(isinstance(item, dict) and item.get("type") == "reasoning"
+            for item in (output if isinstance(output, list) else []))
+        or (isinstance(details, dict)
+            and type(details.get("reasoning_tokens")) is int
+            and details["reasoning_tokens"] > 0))
+    if responses_output_text(reasoning).strip() != "REASONED" or not reasoning_seen:
+        raise RuntimeError("Responses reasoning contract failed")
+
+    bad_status, bad_raw = client.request("POST", client.api_path + "/responses",
+                                         {**base, "include": ["not_supported"]})
+    try:
+        bad_value = json.loads(bad_raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("unsupported-field response is not JSON") from error
+    if bad_status < 400 or not isinstance(bad_value.get("error"), dict):
+        raise RuntimeError("unsupported-field error contract failed")
+    return {"text": True, "stream": True, "stateful_tool": True,
+            "structured": True, "reasoning": True, "invalid_field": True}
+
+
+def build_prefix(client: Client, model: str, target: int, nonce: str) -> str:
+    unit = "append-only cache datum alpha beta gamma delta epsilon "
+    text = f"unique verifier nonce {nonce}\n" + unit * max(1, target // 3)
+    while True:
+        value = client.json("POST", client.server_path + "/tokenize", {
+            "model": model, "messages": [{"role": "user", "content": text}],
+            "chat_template_kwargs": {"thinking": False},
+        })
+        count = value.get("count")
+        if type(count) is not int:
+            raise RuntimeError("/tokenize count missing")
+        if count >= target:
+            return text
+        text += unit * max(1, (target - count) // 3)
+
+
+def check_appended_multiturn(client: Client, model: str, target: int,
+                             turns: int) -> dict[str, Any]:
+    nonce = secrets.token_hex(8)
+    prefix = build_prefix(client, model, target, nonce)
+    messages: list[dict[str, str]] = [{"role": "user", "content":
+        prefix + "\nReply with exactly READY."}]
+    ratios: list[float] = []
+    for index in range(turns):
+        expected = "READY" if index == 0 else f"ACK{index + 1}"
+        value = client.json("POST", client.api_path + "/chat/completions", {
+            "model": model, "messages": messages, "max_tokens": 128,
+            "temperature": 0, "chat_template_kwargs": {"thinking": False},
+        })
+        if chat_content(value).strip() != expected:
+            raise RuntimeError(f"appended turn {index + 1} semantic output failed")
+        usage = value.get("usage")
+        prompt_tokens = usage.get("prompt_tokens") if isinstance(usage, dict) else None
+        if type(prompt_tokens) is not int:
+            raise RuntimeError("Chat prompt token usage missing")
+        cached = cached_tokens(value)
+        floor = safe_cached_floor(prompt_tokens)
+        if index and cached < floor:
+            raise RuntimeError(
+                f"appended turn {index + 1} cache hit {cached} below safe floor {floor}")
+        if index:
+            ratios.append(cached / prompt_tokens)
+        if index + 1 < turns:
+            messages.append({"role": "assistant", "content": expected})
+            messages.append({"role": "user", "content":
+                f"Appended turn {index + 2}; reply with exactly ACK{index + 2}."})
+    return {"turns": turns, "cached_token_ratios": ratios}
+
+
+def read_metrics(client: Client) -> dict[str, float]:
+    status, raw = client.request("GET", client.server_path + "/metrics")
+    if status != 200:
+        raise RuntimeError("metrics endpoint unavailable")
+    return metric_snapshot(raw.decode("utf-8", "replace"))
+
+
+def check_disconnect(client: Client, model: str) -> dict[str, Any]:
+    before = read_metrics(client)
+    if before["running"] or before["waiting"]:
+        raise RuntimeError("disconnect gate requires an idle server")
+    payload = {"model": model, "messages": [{"role": "user", "content":
+        "Produce a long numbered list until stopped. " + secrets.token_hex(8)}],
+        "stream": True, "max_tokens": 4096, "ignore_eos": True,
+        "temperature": 0, "chat_template_kwargs": {"thinking": False}}
+    connection, response = client.open_stream(client.api_path + "/chat/completions", payload)
+    if response.status != 200:
+        connection.close()
+        raise RuntimeError(f"disconnect stream returned HTTP {response.status}")
+    deadline = time.monotonic() + 10
+    opened = read_metrics(client)
+    while opened["running"] < 1 and time.monotonic() < deadline:
+        time.sleep(0.1)
+        opened = read_metrics(client)
+    if opened["running"] < 1:
+        connection.close()
+        raise RuntimeError("disconnect request was never observed running")
+    prefix = b""
+    while len(prefix) < 65_536:
+        line = response.readline()
+        if not line:
+            break
+        prefix += line
+        if re.search(rb'"id"\s*:\s*"[^"]+"', prefix):
+            break
+    connection.close()
+    if not re.search(rb'"id"\s*:\s*"[^"]+"', prefix):
+        raise RuntimeError("disconnect stream request id missing")
+    samples: list[dict[str, float]] = []
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        current = read_metrics(client)
+        samples.append(current)
+        if current["running"] == 0 and current["waiting"] == 0:
+            time.sleep(2)
+            samples.append(read_metrics(client))
+            if not disconnect_counter_chain_valid(before, opened, samples):
+                raise RuntimeError("disconnect counter chain invalid")
+            return {"client_disconnected": True, "server_idle": True,
+                    "counter_chain_valid": True}
+        time.sleep(2)
+    raise RuntimeError("server did not become idle after disconnect")
+
+
+def run_gate(report: dict[str, Any], name: str, function, *args) -> None:
+    try:
+        report["gates"][name] = {"status": "PASS", "value": function(*args)}
+    except Exception as error:  # continue collecting independent gates
+        report["gates"][name] = {
+            "status": "FAIL", "error": f"{type(error).__name__}: {error}"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8888/v1")
+    parser.add_argument("--model", default="deepseek-v4-flash-0731")
+    parser.add_argument("--timeout", type=float, default=1800)
+    parser.add_argument("--multiturn-prefix-tokens", type=int, default=21_000)
+    parser.add_argument("--multiturn-turns", type=int, default=6)
+    parser.add_argument("--skip-multiturn", action="store_true")
+    parser.add_argument("--skip-disconnect", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.multiturn_prefix_tokens < 4096 or args.multiturn_turns < 2:
+        parser.error("multiturn prefix must be >=4096 and turns must be >=2")
+    client = Client(args.base_url, args.timeout)
+    report: dict[str, Any] = {
+        "schema_version": 1, "base_url": args.base_url, "model": args.model,
+        "started_at": datetime.now(timezone.utc).isoformat(), "gates": {},
+    }
+    run_gate(report, "catalog", check_catalog, client, args.model)
+    run_gate(report, "responses", check_responses, client, args.model)
+    if not args.skip_multiturn:
+        run_gate(report, "appended_multiturn", check_appended_multiturn,
+                 client, args.model, args.multiturn_prefix_tokens,
+                 args.multiturn_turns)
+    if not args.skip_disconnect:
+        run_gate(report, "disconnect", check_disconnect, client, args.model)
+    report["completed_at"] = datetime.now(timezone.utc).isoformat()
+    report["status"] = ("PASS" if all(gate["status"] == "PASS"
+                                      for gate in report["gates"].values())
+                        else "FAIL")
+    raw = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(raw)
+    print(raw, end="")
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add a dependency-free live verifier for native `/v1/responses`
- validate exact text output, strict SSE framing, stateful tool continuation,
  JSON schema, reasoning, and invalid-field errors
- validate appended multi-turn prefix reuse against the safe hybrid SWA floor
- validate client-disconnect cleanup with labelled Prometheus counters
- keep independent gates collecting after a failure and emit a JSON report
- add focused CPU tests and wire them into `scripts/ci-validate.sh`

## Why

The existing issue #26 reproducer replays identical payloads, which cannot
detect semantic corruption at moving multi-turn boundaries. A server can also
expose `/v1/responses` while stateful continuation, SSE termination, structured
output, or cancellation is broken. This verifier makes those contracts
explicit and reproducible on the live two-Spark deployment.

## Impact

This changes no serve configuration and applies no runtime hotfix. Operators
opt in by running the script after the server is ready. The default full run
creates a roughly 21K-token appended conversation and one forced disconnect;
both expensive gates have explicit skip flags.

## Validation

- `python3 scripts/test-responses-api-live.py -v` — 6 passed
- `bash scripts/ci-validate.sh` — passed
- `git diff --check` — passed

The corresponding protocol matrix was also exercised on a 2x DGX Spark
deployment before extraction: text, SSE, stateful tool continuation, strict
schema, reasoning, error contract, six appended turns, and disconnect cleanup
all passed. This PR intentionally contains only the reusable verifier and CPU
tests, not deployment-specific receipts.
