### PR TITLE
fix: bound opt-in Responses API store

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -143,6 +143,13 @@ DSPARK_ISSUE43_SCHED_DIAG=0
 # Unset/empty is not supported via compose default.
 VLLM_PREFIX_CACHE_RETENTION_INTERVAL=4096
 
+# Stateful Responses API continuation is disabled by default. Enable it when
+# clients use `store=true` plus `previous_response_id`. The pinned vLLM build's
+# native stores are otherwise unbounded; the bundled backport keeps at most
+# this many terminal responses and removes matching message/event state.
+VLLM_ENABLE_RESPONSES_API_STORE=0
+DSPARK_RESPONSES_STORE_MAX_ENTRIES=256
+
 # Keep client `stop` strings dormant until </think> (Anemll port of Tony /
 # Capicua25x Patch 5). Default on. Set 0 if a harness must bound reasoning
 # with a stop string. DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX=1 skips the patch.

--- a/README.md
+++ b/README.md
@@ -469,6 +469,23 @@ This is the **Stage C padded NVFP4** path (584-byte sparse-MLA envelope via
 Optional GB10 hybrid plugin: `ENABLE_VLLM_GB10_PATCH=1 ./start-…`
 (`--quantization modelopt_gb10_hybrid`). Default off.
 
+### Optional stateful Responses API
+
+The pinned vLLM build exposes `/v1/responses`, but ignores stored state by
+default and its native in-memory stores do not evict. To enable stateful
+`previous_response_id` continuation with bounded process-local storage:
+
+```env
+VLLM_ENABLE_RESPONSES_API_STORE=1
+DSPARK_RESPONSES_STORE_MAX_ENTRIES=256
+```
+
+The bundled exact-source backport evicts the oldest terminal responses and
+their matching rendered-message/event state; `previous_response_id` reuse
+refreshes that response's recency. Queued, in-progress, and foreground
+streaming requests are protected. State is process-local and is lost on
+restart; leave the feature disabled when no client needs continuation.
+
 CI on every push ([`.github/workflows/validate.yml`](.github/workflows/validate.yml))
 is **CPU-only** (`scripts/ci-validate.sh`). Live tok/s still needs the 2× Spark pair.
 

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -33,6 +33,8 @@ services:
       # Issue #55 tool-call truncation safety: finish_reason=length + drop
       # non-JSON-parseable args when max_tokens cuts a tool call mid-flight.
       - ${DSPARK_ISSUE55_HOTFIX:-./patches/hotfix-dsv4-issue55-tool-truncation.py}:/opt/hotfix-dsv4-issue55-tool-truncation.py:ro
+      # Optional Responses state: bound response/message/event stores together.
+      - ${DSPARK_RESPONSES_STORE_HOTFIX:-./patches/hotfix-dsv4-responses-store.py}:/opt/hotfix-dsv4-responses-store.py:ro
       # Issue #27 partial-prefill concurrency hotfix (enforce max_num_partial_prefills).
       - ${DSPARK_ISSUE27_HOTFIX:-./patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py}:/opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py:ro
       # Issue #43 bounded decode service during mixed prefill steps + scheduler diag.
@@ -59,6 +61,10 @@ services:
       # coordinator hotfix — SWA-min alone still 0/8 at 44K+ x8 because
       # dense SWA tails evict MLA prefix blocks.
       VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}"
+      # Stateful previous_response_id is opt-in. The backport bounds terminal
+      # response/message/event state and protects active work when enabled.
+      VLLM_ENABLE_RESPONSES_API_STORE: "${VLLM_ENABLE_RESPONSES_API_STORE:-0}"
+      DSPARK_RESPONSES_STORE_MAX_ENTRIES: "${DSPARK_RESPONSES_STORE_MAX_ENTRIES:-256}"
       # Issue #43 scheduler diagnostics: emit one compact per-step line
       # (scheduled prefill/decode tokens per request + zero-token decode
       # skips) when set to 1. Off by default (zero overhead).
@@ -154,7 +160,7 @@ services:
         if [ -n "$${ENCODING_SOURCE}" ] && [ -f "$${ENCODING_SOURCE}" ]; then cp "$${ENCODING_SOURCE}" /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4_encoding.py; python3 -c 'from pathlib import Path; p=Path("/usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4.py"); s=p.read_text(); old="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            else:\n                reasoning_effort = \"high\""; new="elif reasoning_effort in (\"max\", \"xhigh\"):\n                reasoning_effort = \"max\"\n            elif reasoning_effort == \"high\":\n                reasoning_effort = \"high\"\n            else:\n                reasoning_effort = \"low\""; updated=s.replace(old,new); assert new in updated; p.write_text(updated)'; python3 /opt/hotfix-encoding-dsv4-issue21.py; python3 /opt/hotfix-dsv4-issue31-v2-thinking-budget-gpu.py; python3 /opt/hotfix-dsv4-issue55-tool-truncation.py; fi;
         if [ "$${DSPARK_SKIP_ISSUE22_HOTFIX:-0}" != "1" ] && [ -f /opt/dspark-patches/hotfix-nvfp4-ds-mla-issue22.sh ]; then bash /opt/dspark-patches/hotfix-nvfp4-ds-mla-issue22.sh || true; fi;
         if [ "$${DSPARK_SKIP_HOTFIX:-0}" != "1" ]; then for _hf in hotfix-dsv4-mtp-buffer-50312.sh hotfix-dsv4-adaptive-topk-50004.sh hotfix-dsv4-skip-topk-49486.sh hotfix-dsv4-dense-prefill-indexer-48407.sh hotfix-dsv4-skip-empty-c128-48957.sh hotfix-dsv4-flashmla-workspace-50298.sh hotfix-dsv4-grammar-advance.sh; do if [ -f /opt/dspark-patches/$${_hf} ]; then bash /opt/dspark-patches/$${_hf} || true; fi; done; fi;
-        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py; fi; VLLM_QUANTIZATION_ARGS="";
+        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py; python3 /opt/hotfix-dsv4-responses-store.py; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py; fi; VLLM_QUANTIZATION_ARGS="";
         if [ "$${ENABLE_VLLM_GB10_PATCH:-0}" = "1" ]; then
           python3 -m pip install -e /opt/vllm-gb10-hybrid-nvfp4 --no-deps;
           export VLLM_PLUGINS="$${VLLM_PLUGINS:-gb10_hybrid_nvfp4}";

--- a/patches/hotfix-dsv4-responses-store.py
+++ b/patches/hotfix-dsv4-responses-store.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Bound vLLM 752a3's opt-in in-memory Responses API store.
+
+The pinned Anemll image supports ``VLLM_ENABLE_RESPONSES_API_STORE`` but keeps
+responses, rendered messages, and background events forever.  This exact-source
+backport adds a configurable bound while protecting active work. Stateful
+``previous_response_id`` reuse refreshes that response's recency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+
+
+DEFAULT_PATH = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/responses/serving.py"
+)
+PREIMAGE_SHA256 = "fe3a48ab09c516835ce6dd1471c06cc784ae7504eaa7af7f10574704106830d8"
+POSTIMAGE_SHA256 = "caeeb0ed55517f933def7ea0a590125d5c727369318ce20d4cc1821279fb864d"
+MARK = "# [dspark-responses-store] bounded active-safe store"
+
+INIT_ANCHOR = """        self.background_tasks: dict[str, asyncio.Task] = {}
+
+        self.tool_server = tool_server
+"""
+INIT_REPLACEMENT = """        self.background_tasks: dict[str, asyncio.Task] = {}
+        self.active_store_requests: set[str] = set()
+        self.responses_store_max_entries = int(
+            __import__("os").environ.get("DSPARK_RESPONSES_STORE_MAX_ENTRIES", "256")
+        )
+        if self.enable_store and self.responses_store_max_entries <= 0:
+            raise ValueError("DSPARK_RESPONSES_STORE_MAX_ENTRIES must be greater than 0")
+
+        self.tool_server = tool_server
+"""
+METHOD_ANCHOR = """        self.tool_server = tool_server
+
+    def _effective_chat_template_kwargs(
+"""
+METHOD_REPLACEMENT = f"""        self.tool_server = tool_server
+
+    {MARK}
+    def _prune_response_store_locked(self) -> None:
+        protected = self.active_store_requests | set(self.background_tasks)
+        for response_id in tuple(self.msg_store):
+            if response_id not in self.response_store and response_id not in protected:
+                self.msg_store.pop(response_id, None)
+        for response_id in tuple(self.event_store):
+            if response_id not in self.response_store and response_id not in protected:
+                self.event_store.pop(response_id, None)
+        terminal = [response_id for response_id, response in self.response_store.items()
+                    if response_id not in protected
+                    and response.status not in ("queued", "in_progress")]
+        excess = len(terminal) - self.responses_store_max_entries
+        for response_id in terminal[:max(0, excess)]:
+            self.response_store.pop(response_id, None)
+            self.msg_store.pop(response_id, None)
+            self.event_store.pop(response_id, None)
+
+    async def _background_store_task_done(self, response_id: str, task) -> None:
+        async with self.response_store_lock:
+            response = self.response_store.get(response_id)
+            if response is not None and response.status in ("queued", "in_progress"):
+                if task.cancelled():
+                    response.status = "cancelled"
+                else:
+                    task.exception()  # retrieve producer failure before cleanup
+                    response.status = "failed"
+            self.background_tasks.pop(response_id, None)
+            self.active_store_requests.discard(response_id)
+            self._prune_response_store_locked()
+
+    async def _stored_stream_lifecycle(self, request, generator):
+        try:
+            async for event in generator:
+                yield event
+        finally:
+            async with self.response_store_lock:
+                self.active_store_requests.discard(request.request_id)
+                self._prune_response_store_locked()
+
+    def _effective_chat_template_kwargs(
+"""
+PREVIOUS_ANCHOR = """            async with self.response_store_lock:
+                prev_response = self.response_store.get(prev_response_id)
+            if prev_response is None:
+"""
+PREVIOUS_REPLACEMENT = """            async with self.response_store_lock:
+                prev_response = self.response_store.pop(prev_response_id, None)
+                if prev_response is not None:
+                    self.response_store[prev_response_id] = prev_response
+            if prev_response is None:
+"""
+MESSAGE_ANCHOR = """        # Store the input messages.
+        if request.store:
+            self.msg_store[request.request_id] = messages
+
+        if request.background:
+"""
+MESSAGE_REPLACEMENT = """        # Store the input messages and protect the request until its
+        # terminal response or background task cleanup is durable.
+        if request.store:
+            async with self.response_store_lock:
+                self.active_store_requests.add(request.request_id)
+                self.msg_store[request.request_id] = messages
+
+        if request.background:
+"""
+BACKGROUND_ANCHOR = """            async with self.response_store_lock:
+                self.response_store[response.id] = response
+
+            # Run the request in the background.
+"""
+BACKGROUND_REPLACEMENT = """            async with self.response_store_lock:
+                self.response_store[response.id] = response
+                self._prune_response_store_locked()
+
+            # Run the request in the background.
+"""
+BACKGROUND_DONE_ANCHOR = """            self.background_tasks[response_id] = task
+            task.add_done_callback(
+                lambda _: self.background_tasks.pop(response_id, None)
+            )
+
+            if request.stream:
+"""
+BACKGROUND_DONE_REPLACEMENT = """            self.background_tasks[response_id] = task
+            task.add_done_callback(
+                lambda completed_task: asyncio.create_task(
+                    self._background_store_task_done(response_id, completed_task)
+                )
+            )
+            async with self.response_store_lock:
+                self.active_store_requests.discard(response_id)
+                self._prune_response_store_locked()
+
+            if request.stream:
+"""
+FOREGROUND_ANCHOR = """        if request.stream:
+            return self.responses_stream_generator(
+                request,
+                sampling_params,
+                result_generator,
+                context,
+                model_name,
+                tokenizer,
+                request_metadata,
+            )
+
+        return await self.responses_full_generator(
+            request,
+            sampling_params,
+            result_generator,
+            context,
+            model_name,
+            tokenizer,
+            request_metadata,
+        )
+"""
+FOREGROUND_REPLACEMENT = """        if request.stream:
+            generator = self.responses_stream_generator(
+                request,
+                sampling_params,
+                result_generator,
+                context,
+                model_name,
+                tokenizer,
+                request_metadata,
+            )
+            return self._stored_stream_lifecycle(request, generator)
+
+        try:
+            return await self.responses_full_generator(
+                request,
+                sampling_params,
+                result_generator,
+                context,
+                model_name,
+                tokenizer,
+                request_metadata,
+            )
+        finally:
+            if request.store:
+                async with self.response_store_lock:
+                    self.active_store_requests.discard(request.request_id)
+                    self._prune_response_store_locked()
+"""
+FINAL_ANCHOR = """                if stored_response is None or stored_response.status != "cancelled":
+                    self.response_store[response.id] = response
+        return response
+"""
+FINAL_REPLACEMENT = """                if stored_response is None or stored_response.status != "cancelled":
+                    self.response_store.pop(response.id, None)
+                    self.response_store[response.id] = response
+                self._prune_response_store_locked()
+        return response
+"""
+
+
+def sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def transformed(raw: bytes) -> bytes:
+    text = raw.decode("utf-8")
+    if MARK in text:
+        return raw
+    for name, old, new in (
+        ("init", INIT_ANCHOR, INIT_REPLACEMENT),
+        ("methods", METHOD_ANCHOR, METHOD_REPLACEMENT),
+        ("previous", PREVIOUS_ANCHOR, PREVIOUS_REPLACEMENT),
+        ("messages", MESSAGE_ANCHOR, MESSAGE_REPLACEMENT),
+        ("background", BACKGROUND_ANCHOR, BACKGROUND_REPLACEMENT),
+        ("background-done", BACKGROUND_DONE_ANCHOR, BACKGROUND_DONE_REPLACEMENT),
+        ("foreground", FOREGROUND_ANCHOR, FOREGROUND_REPLACEMENT),
+        ("final", FINAL_ANCHOR, FINAL_REPLACEMENT),
+    ):
+        if text.count(old) != 1:
+            raise RuntimeError(f"Responses store patch anchor drift: {name}")
+        text = text.replace(old, new)
+    return text.encode("utf-8")
+
+
+def write_atomic(path: Path, raw: bytes) -> None:
+    temporary = path.with_name(f".{path.name}.responses-store.{os.getpid()}")
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                 0o644)
+    try:
+        os.write(fd, raw)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(temporary, path)
+    directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def apply(path: Path) -> str:
+    raw = path.read_bytes()
+    current = sha256(raw)
+    if current == POSTIMAGE_SHA256:
+        return current
+    if current != PREIMAGE_SHA256:
+        raise RuntimeError("Responses serving source hash drift")
+    updated = transformed(raw)
+    updated_hash = sha256(updated)
+    if updated_hash != POSTIMAGE_SHA256:
+        raise RuntimeError("Responses serving postimage hash drift")
+    compile(updated, str(path), "exec")
+    write_atomic(path, updated)
+    return updated_hash
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_PATH)
+    args = parser.parse_args()
+    print(apply(args.path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -32,6 +32,7 @@ py_files+=(
   scripts/test-issue26-swa-min-v2.py
   scripts/test-issue31-thinking-budget-gpu.py
   scripts/test-issue55-tool-truncation.py
+  scripts/test-responses-store-hotfix.py
   scripts/test-encoding-dsv4-issue21.py
   scripts/test-suppress-stops-in-reasoning.py
   scripts/verify-dsv4-027-equality-gate.py
@@ -46,6 +47,8 @@ python3 scripts/test-issue31-thinking-budget-gpu.py -q
 ok "test-issue31-thinking-budget-gpu"
 python3 scripts/test-issue55-tool-truncation.py -q
 ok "test-issue55-tool-truncation"
+python3 scripts/test-responses-store-hotfix.py -q
+ok "test-responses-store-hotfix"
 python3 scripts/test-encoding-dsv4-issue21.py -q
 ok "test-encoding-dsv4-issue21"
 python3 scripts/test-suppress-stops-in-reasoning.py -q
@@ -138,6 +141,12 @@ if grep -q 'hotfix-dsv4-issue55-tool-truncation.py' docker-compose.dspark.yml \
 else
   bad "compose missing issue #55 tool-call truncation safety"
 fi
+if grep -q 'hotfix-dsv4-responses-store.py' docker-compose.dspark.yml \
+  && grep -q 'python3 /opt/hotfix-dsv4-responses-store.py' docker-compose.dspark.yml; then
+  ok "compose applies bounded Responses store backport"
+else
+  bad "compose missing bounded Responses store backport"
+fi
 if grep -q 'restart: ${DSPARK_RESTART_POLICY:-unless-stopped}' docker-compose.dspark.yml; then
   ok "compose restart unless-stopped"
 else
@@ -149,6 +158,7 @@ for p in \
   patches/hotfix-encoding-dsv4-issue21.py \
   patches/hotfix-dsv4-issue31-v2-thinking-budget-gpu.py \
   patches/hotfix-dsv4-issue55-tool-truncation.py \
+  patches/hotfix-dsv4-responses-store.py \
   patches/hotfix-dsv4-issue26-hybrid-swa-min.py \
   patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py \
   patches/hotfix-nvfp4-ds-mla-issue22.sh \

--- a/scripts/test-responses-store-hotfix.py
+++ b/scripts/test-responses-store-hotfix.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""CPU regression tests for the bounded Responses store backport."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+from pathlib import Path
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOTFIX = ROOT / "patches" / "hotfix-dsv4-responses-store.py"
+
+
+def load_hotfix():
+    spec = importlib.util.spec_from_file_location("responses_store_hotfix", HOTFIX)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def method_from_source(source: str, name: str):
+    tree = ast.parse(source)
+    owner = next(node for node in tree.body
+                 if isinstance(node, ast.ClassDef) and node.name == "OpenAIServingResponses")
+    method = next(node for node in owner.body
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                  and node.name == name)
+    namespace: dict[str, object] = {}
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, "<responses-store-method>", "exec"), namespace)
+    return namespace[name]
+
+
+class ResponsesStoreHotfixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.hotfix = load_hotfix()
+        fixture = '''class OpenAIServingResponses:
+    def __init__(self):
+        self.background_tasks: dict[str, asyncio.Task] = {}
+
+        self.tool_server = tool_server
+
+    def _effective_chat_template_kwargs(
+        self,
+    ):
+        pass
+
+    async def _prepare(self, request, messages, prev_response_id):
+        if prev_response_id is not None:
+            async with self.response_store_lock:
+                prev_response = self.response_store.get(prev_response_id)
+            if prev_response is None:
+                return None
+
+        # Store the input messages.
+        if request.store:
+            self.msg_store[request.request_id] = messages
+
+        if request.background:
+            async with self.response_store_lock:
+                self.response_store[response.id] = response
+
+            # Run the request in the background.
+            self.background_tasks[response_id] = task
+            task.add_done_callback(
+                lambda _: self.background_tasks.pop(response_id, None)
+            )
+
+            if request.stream:
+                return stream
+
+        if request.stream:
+            return self.responses_stream_generator(
+                request,
+                sampling_params,
+                result_generator,
+                context,
+                model_name,
+                tokenizer,
+                request_metadata,
+            )
+
+        return await self.responses_full_generator(
+            request,
+            sampling_params,
+            result_generator,
+            context,
+            model_name,
+            tokenizer,
+            request_metadata,
+        )
+
+    async def responses_full_generator(self, response, stored_response):
+        async with self.response_store_lock:
+                if stored_response is None or stored_response.status != "cancelled":
+                    self.response_store[response.id] = response
+        return response
+'''
+        cls.source = cls.hotfix.transformed(fixture.encode()).decode()
+
+    def test_prune_bounds_terminal_records_and_keeps_active_work(self):
+        prune = method_from_source(self.source, "_prune_response_store_locked")
+        probe = types.SimpleNamespace(
+            response_store={}, msg_store={}, event_store={}, background_tasks={},
+            active_store_requests=set(), responses_store_max_entries=3,
+            response_store_lock=asyncio.Lock(),
+        )
+        for index in range(5):
+            response_id = f"resp-{index}"
+            probe.response_store[response_id] = types.SimpleNamespace(status="completed")
+            probe.msg_store[response_id] = [response_id]
+            probe.event_store[response_id] = ([], None)
+        probe.response_store["active"] = types.SimpleNamespace(status="in_progress")
+        probe.msg_store["active"] = ["active"]
+        probe.active_store_requests.add("active")
+        prune(probe)
+        self.assertEqual(list(probe.response_store), ["resp-2", "resp-3", "resp-4", "active"])
+        self.assertEqual(set(probe.msg_store), set(probe.response_store))
+        self.assertEqual(set(probe.event_store), {"resp-2", "resp-3", "resp-4"})
+
+    def test_background_exception_and_cancel_reach_terminal_status(self):
+        done = method_from_source(self.source, "_background_store_task_done")
+        probe = types.SimpleNamespace(
+            response_store={}, msg_store={}, event_store={}, background_tasks={},
+            active_store_requests=set(), responses_store_max_entries=3,
+            response_store_lock=asyncio.Lock(),
+        )
+        prune = method_from_source(self.source, "_prune_response_store_locked")
+        probe._prune_response_store_locked = types.MethodType(prune, probe)
+
+        async def exercise():
+            async def raises():
+                raise RuntimeError("producer failed")
+
+            failed = asyncio.create_task(raises())
+            await asyncio.sleep(0)
+            probe.response_store["failed"] = types.SimpleNamespace(status="queued")
+            probe.background_tasks["failed"] = failed
+            await done(probe, "failed", failed)
+            self.assertEqual(probe.response_store["failed"].status, "failed")
+
+            cancelled = asyncio.create_task(asyncio.sleep(60))
+            probe.response_store["cancelled"] = types.SimpleNamespace(status="in_progress")
+            probe.background_tasks["cancelled"] = cancelled
+            cancelled.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await cancelled
+            await done(probe, "cancelled", cancelled)
+            self.assertEqual(probe.response_store["cancelled"].status, "cancelled")
+
+        asyncio.run(exercise())
+
+    def test_capacity_is_read_from_dspark_env_and_must_be_positive(self):
+        self.assertIn('DSPARK_RESPONSES_STORE_MAX_ENTRIES', self.source)
+        self.assertIn('responses_store_max_entries <= 0', self.source)
+
+    def test_anchor_drift_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "anchor drift"):
+            self.hotfix.transformed(b"class OpenAIServingResponses:\n    pass\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -577,6 +577,12 @@ if [ -f "$DSPARK_ISSUE55_HOTFIX" ]; then
   ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
   scp "$DSPARK_ISSUE55_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue55-tool-truncation.py"
 fi
+DSPARK_RESPONSES_STORE_HOTFIX="${DSPARK_RESPONSES_STORE_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-responses-store.py}"
+if [ -f "$DSPARK_RESPONSES_STORE_HOTFIX" ]; then
+  echo "Syncing bounded Responses store hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"
+  ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
+  scp "$DSPARK_RESPONSES_STORE_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-responses-store.py"
+fi
 DSPARK_ISSUE27_HOTFIX="${DSPARK_ISSUE27_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py}"
 if [ -f "$DSPARK_ISSUE27_HOTFIX" ]; then
   echo "Syncing Issue #27 partial-prefill hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"


### PR DESCRIPTION
## What changed

- add an exact-source backport for the pinned Anemll vLLM `752a3a504`
- bound terminal Responses records with `DSPARK_RESPONSES_STORE_MAX_ENTRIES`
- remove matching response/message/event state together
- protect queued, in-progress, background, and foreground-streaming work
- refresh recency when `previous_response_id` is reused
- converge successful, failed, and cancelled background tasks to terminal state
- expose the native store switch in compose, defaulting it to disabled
- sync and apply the patch on both ranks, with CPU regression and compose gates

## Why

The pinned vLLM build supports `VLLM_ENABLE_RESPONSES_API_STORE=1`, but its
`response_store`, `msg_store`, and `event_store` never evict. Stateful
`previous_response_id` is therefore unsafe for a long-lived server: enabling
it can grow process memory without bound.

Upstream vLLM PR https://github.com/vllm-project/vllm/pull/48454 addresses the
same root problem for future vLLM versions but is still open and currently
conflicted. This PR is a fail-closed compatibility backport for the exact image
this repository ships; it can be retired when the base image contains an
upstream store implementation.

## Operator impact

There is no behavior change with the default:

```env
VLLM_ENABLE_RESPONSES_API_STORE=0
DSPARK_RESPONSES_STORE_MAX_ENTRIES=256
```

Operators who need stateful Responses continuation opt in by setting the first
value to `1`. State remains process-local and is lost on restart.

## Validation

- `python3 scripts/test-responses-store-hotfix.py -v` — 4 passed
- exact `fe3a48ab...` preimage transformed to `caeeb0ed...`
- transformed `serving.py` compiled and a second apply was idempotent
- enabled compose render carried store=`1`, capacity=`17`, and the mounted patch
- `bash scripts/ci-validate.sh` — passed
- `git diff --check` — passed

Before extraction, the same lifecycle policy ran on a 2x DGX Spark deployment:
260 sequential stored responses evicted the oldest response while retaining
the newest; stateful tool continuation, streaming, structured output,
reasoning, and disconnect cleanup passed with both ranks restart=0/OOM=false.
