### PR TITLE
Add optional VLLM_API_KEY bearer auth for the OpenAI endpoint

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -81,6 +81,11 @@ SERVED_MODEL_NAME=deepseek-v4-flash-0731
 VLLM_HOST=0.0.0.0
 # API listen port. The launcher also accepts a temporary --port override.
 VLLM_PORT=8888
+# Optional API key for the OpenAI endpoint. Empty = no auth (default).
+# Set in .env.dspark; do not commit the real secret. When set, the startup
+# probe, minimal chat request, smoke and status scripts send it as a
+# bearer token.
+# VLLM_API_KEY=
 # Explicit per-node host IPs prevent distributed vLLM/ZeroMQ from binding the
 # worker to the head node's fabric address. Set these to each node's RoCE IP.
 VLLM_HOST_IP=head-roce-ip

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -66,6 +66,8 @@ services:
       # Pin HF revision (issue #19). Empty → tip of default branch / refs/main.
       DSPARK_REVISION: "${DSPARK_REVISION:-}"
       DSPARK_ENCODING_FILE: "${DSPARK_ENCODING_FILE:-}"
+      # Optional API key for the OpenAI endpoint. Empty = no auth (default).
+      VLLM_API_KEY: "${VLLM_API_KEY:-}"
       VLLM_CACHE_ROOT: /cache/huggingface/vllm-cache
       VLLM_HOST_IP: "${VLLM_HOST_IP:-}"
 

--- a/smoke-deepseek-v4-flash-dspark.sh
+++ b/smoke-deepseek-v4-flash-dspark.sh
@@ -14,6 +14,10 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 MODEL="${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
+AUTH_HEADER_ARGS=()
+if [ -n "${VLLM_API_KEY:-}" ]; then
+  AUTH_HEADER_ARGS=(-H "Authorization: Bearer $VLLM_API_KEY")
+fi
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -21,7 +25,7 @@ echo "Running ${CONCURRENCY}-way smoke test against ${CHAT_URL}"
 
 for i in $(seq 1 "$CONCURRENCY"); do
   (
-    curl -fsS --max-time 180 "$CHAT_URL" \
+    curl -fsS --max-time 180 "${AUTH_HEADER_ARGS[@]}" "$CHAT_URL" \
       -H "Content-Type: application/json" \
       -d '{"model":"'"$MODEL"'","messages":[{"role":"user","content":"Reply with OK and the number '"$i"'."}],"temperature":0.0}' \
       >"$tmpdir/$i.json"

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -150,6 +150,10 @@ if [[ "$URL_HOST" == *:* && "$URL_HOST" != \[*\] ]]; then
 fi
 API_URL="${API_URL:-http://$URL_HOST:$VLLM_PORT/v1/models}"
 CHAT_URL="${CHAT_URL:-http://$URL_HOST:$VLLM_PORT/v1/chat/completions}"
+AUTH_HEADER_ARGS=()
+if [ -n "${VLLM_API_KEY:-}" ]; then
+  AUTH_HEADER_ARGS=(-H "Authorization: Bearer $VLLM_API_KEY")
+fi
 
 : "${WORKER_HOST:?WORKER_HOST must be set in $ENV_FILE}"
 : "${MASTER_ADDR:?MASTER_ADDR must be set in $ENV_FILE}"
@@ -635,7 +639,7 @@ echo "Issue #22 / v0.27 .sh hotfixes run in the compose entrypoint before vllm (
 echo "Waiting for DSpark vLLM API..."
 print_initial_startup_logs
 for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
-  if curl -fsS --max-time 5 "$API_URL" >/dev/null 2>&1; then
+  if curl -fsS --max-time 5 "${AUTH_HEADER_ARGS[@]}" "$API_URL" >/dev/null 2>&1; then
     echo "DeepSeek V4 Flash DSpark is running: $API_URL"
     compose_base 0 "" ps
     remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml ps"
@@ -681,7 +685,7 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
       fi
     fi
     echo "Running minimal OpenAI-compatible thinking-budget chat request..."
-    curl -fsS --max-time 60 "$CHAT_URL" \
+    curl -fsS --max-time 60 "${AUTH_HEADER_ARGS[@]}" "$CHAT_URL" \
       -H "Content-Type: application/json" \
       -d '{"model":"'"${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"thinking_token_budget":1,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
     echo "Minimal thinking-budget chat request succeeded."

--- a/status-deepseek-v4-flash-dspark.sh
+++ b/status-deepseek-v4-flash-dspark.sh
@@ -8,12 +8,17 @@ PROJECT_NAME="${PROJECT_NAME:-deepseek-v4-flash}"
 LEGACY_PROJECT_NAME="${LEGACY_PROJECT_NAME:-$(basename "$SCRIPT_DIR" | tr '[:upper:]' '[:lower:]')}"
 API_URL="${API_URL:-http://127.0.0.1:8888/v1/models}"
 PORT="${PORT:-8888}"
+AUTH_HEADER_ARGS=()
 
 if [ -f "$ENV_FILE" ]; then
   set -a
   # shellcheck disable=SC1090
   source "$ENV_FILE"
   set +a
+fi
+
+if [ -n "${VLLM_API_KEY:-}" ]; then
+  AUTH_HEADER_ARGS=(-H "Authorization: Bearer $VLLM_API_KEY")
 fi
 
 : "${WORKER_HOST:?WORKER_HOST must be set in $ENV_FILE or environment}"
@@ -51,5 +56,5 @@ echo "== port/API =="
 if command -v ss >/dev/null 2>&1; then
   ss -ltn "( sport = :$PORT )" || true
 fi
-curl -fsS --max-time 5 "$API_URL" || true
+curl -fsS --max-time 5 "${AUTH_HEADER_ARGS[@]}" "$API_URL" || true
 echo


### PR DESCRIPTION
## Motivation

The recipe exposes the vLLM OpenAI API on `0.0.0.0:8888` by default and the README documents remote/TLS access (Caddy). There is currently **no way to protect the endpoint**: anyone who can reach the port can send inference requests. This PR adds an optional API key.

## Changes

- `docker-compose.dspark.yml`: passes `VLLM_API_KEY` through to the container (`${VLLM_API_KEY:-}`). vLLM registers it natively (`--api-key`), so a non-empty value enforces bearer auth.
- `start-deepseek-v4-flash-dspark.sh`: builds `AUTH_HEADER_ARGS` when the key is set and uses it for the startup API probe and the minimal chat request (which would otherwise fail with 401 and break the launch wait loop).
- `smoke-deepseek-v4-flash-dspark.sh` and `status-deepseek-v4-flash-dspark.sh`: send the bearer token when configured.
- `.env.dspark.example`: documents the knob (commented, empty default).

**Default is empty = no auth**, so behavior is unchanged for existing deployments.

## Testing

- `bash -n` on all touched scripts.
- `docker compose config` with `VLLM_API_KEY=test-secret` → the key is injected into the container env.
- Verified end-to-end on a 2x DGX Spark cluster: with the key set, `/v1/models` returns 401 without the header and 200 with it; the startup wait loop completes correctly.