### PR TITLE
fix(patches): give issue22 hotfix a --status mode, and honour VLLM_ROOT

### DIFF
--- a/patches/hotfix-nvfp4-ds-mla-issue22.sh
+++ b/patches/hotfix-nvfp4-ds-mla-issue22.sh
@@ -9,24 +9,55 @@
 #   docker exec <container> bash /path/to/hotfix-nvfp4-ds-mla-issue22.sh
 #   # Then restart the vLLM process inside the container.
 #
+#   docker exec <container> bash /path/to/hotfix-nvfp4-ds-mla-issue22.sh --status
+#   # Report patch state only; makes no changes.
+#
 # Safe to re-run (idempotent — skips already-applied patches).
 set -euo pipefail
 
 VLLM_ROOT="${VLLM_ROOT:-/usr/local/lib/python3.12/dist-packages/vllm}"
+ACTION="${1:-}"
 
 if [ ! -d "$VLLM_ROOT" ]; then
   echo "ERROR: vLLM not found at $VLLM_ROOT" >&2
   exit 1
 fi
 
-echo "=== Hotfix: nvfp4_ds_mla long-context decode (Issue #22) ==="
-echo "vLLM root: $VLLM_ROOT"
-
-python3 <<'PYEOF'
+# Report patch state without touching the tree, in the same
+# "<label> : APPLIED|NOT APPLIED" form the other hotfixes here use, so tooling
+# can compare status text across ranks.
+status() {
+  python3 - "$VLLM_ROOT" <<'PY'
 import sys
 from pathlib import Path
 
-root = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+root = Path(sys.argv[1])
+target = root / "v1" / "attention" / "backends" / "mla" / "flashmla_sparse.py"
+text = target.read_text() if target.exists() else ""
+
+
+def chk(label, cond):
+    print(f"{label:44} :", "APPLIED" if cond else "NOT APPLIED")
+
+
+chk("nvfp4_ds_mla routed to fast FP8 path",
+    'self.kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")' in text)
+PY
+  exit 0
+}
+
+if [ "$ACTION" = "--status" ]; then
+  status
+fi
+
+echo "=== Hotfix: nvfp4_ds_mla long-context decode (Issue #22) ==="
+echo "vLLM root: $VLLM_ROOT"
+
+python3 <<PYEOF
+import sys
+from pathlib import Path
+
+root = Path("$VLLM_ROOT")
 applied = 0
 skipped = 0
 errors = []
@@ -83,13 +114,4 @@ PYEOF
 
 echo ""
 echo "=== Verification ==="
-python3 <<'PYEOF'
-p = __import__("pathlib").Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/mla/flashmla_sparse.py")
-text = p.read_text()
-if 'self.kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")' in text:
-    print("[OK] nvfp4_ds_mla routed to fast FP8 kernel path")
-elif 'self.kv_cache_dtype == "fp8_ds_mla"' in text:
-    print("[FAIL] Still using slow BF16 path for nvfp4_ds_mla")
-else:
-    print("[WARN] Could not verify patch state")
-PYEOF
+bash "$0" --status


### PR DESCRIPTION
`patches/hotfix-nvfp4-ds-mla-issue22.sh` is the only hotfix in `patches/` that doesn't implement the `"<label> : APPLIED|NOT APPLIED"` `--status` contract its siblings (`hotfix-dsv4-*.sh`) all provide. It parses no arguments at all, so `--status` is silently ignored and the script runs its normal apply path instead.

### Why it matters

**1. A status query performs a write.** On an already-patched tree the patch is a no-op, so it's harmless in practice — but `--status` shouldn't mutate.

**2. Parity tooling can't cover this hotfix.** Anything that gates hotfix parity by comparing `--status` text between ranks gets no `APPLIED`/`NOT APPLIED` token here, so a `grep -oE '(APPLIED|NOT APPLIED)'` matches nothing and the hotfix is skipped — *silently*, which is the exact failure mode such a gate exists to prevent. Under TP=2, a hotfix applied on one rank and not the other leaves the ranks running different attention code, and that doesn't necessarily crash — it can just serve subtly wrong output.

We hit this on a 2x DGX Spark deployment: our runtime gate reported the other hotfixes in `patches/` fine and quietly ignored this one.

### A second, unrelated bug in the same file

Both embedded Python heredocs hardcode `/usr/local/lib/python3.12/dist-packages/vllm`, ignoring the `VLLM_ROOT` that the shell half already respects:

```bash
VLLM_ROOT="${VLLM_ROOT:-/usr/local/lib/python3.12/dist-packages/vllm}"   # respected
...
root = Path("/usr/local/lib/python3.12/dist-packages/vllm")              # hardcoded
```

So `VLLM_ROOT=/custom bash hotfix-nvfp4-ds-mla-issue22.sh` prints the custom root in its banner while patching and verifying the *default* tree. A `--status` implementation reading a hardcoded path would be wrong for the same reason, so it's fixed here too. The siblings already do this correctly (`root = Path("$VLLM_ROOT")`).

### Changes

- add `ACTION="${1:-}"` and a `status()` function that reports state and exits without touching the tree, matching the sibling format and label padding
- handle `--status` before any write happens
- pass `$VLLM_ROOT` into the apply heredoc instead of hardcoding
- replace the bespoke `=== Verification ===` block with `bash "$0" --status`, which is what the siblings do and keeps one source of truth for the check

No change to the fix itself — the `use_fp8_cache` dispatch patch is untouched.

### Verification

Against `ghcr.io/anemll/dspark-vllm-gx10:0.1.1` and a synthetic tree:

| case | result |
|---|---|
| `--status` on pristine tree | `nvfp4_ds_mla routed to fast FP8 path : NOT APPLIED` |
| `--status` leaves file byte-identical | `cmp` clean — read-only confirmed |
| apply with `VLLM_ROOT` set | patches the tree it names |
| `--status` after apply | `... : APPLIED` |
| re-apply | idempotent, `Skipped: 1` |
| patched module imports | `imports OK` |
