### PR TITLE
fix(status,smoke): derive probe endpoint from VLLM_HOST after sourcing .env

### DIFF
--- a/smoke-deepseek-v4-flash-dspark.sh
+++ b/smoke-deepseek-v4-flash-dspark.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.dspark}"
-CHAT_URL="${CHAT_URL:-http://127.0.0.1:8888/v1/chat/completions}"
+CHAT_URL="${CHAT_URL:-}"
 CONCURRENCY="${CONCURRENCY:-6}"
 
 if [ -f "$ENV_FILE" ]; then
@@ -12,6 +12,14 @@ if [ -f "$ENV_FILE" ]; then
   source "$ENV_FILE"
   set +a
 fi
+
+# Default the endpoint from the configured bind address. vLLM binds exactly
+# VLLM_HOST (README API note: HEAD_NODE_IP), so 127.0.0.1 is wrong for a
+# LAN-IP bind. A wildcard bind is probed on loopback. An explicit CHAT_URL
+# from the environment still wins.
+_dspark_host="${VLLM_HOST:-127.0.0.1}"
+case "$_dspark_host" in 0.0.0.0|::|"") _dspark_host=127.0.0.1 ;; esac
+CHAT_URL="${CHAT_URL:-http://${_dspark_host}:${VLLM_PORT:-8888}/v1/chat/completions}"
 
 MODEL="${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
 tmpdir="$(mktemp -d)"

--- a/status-deepseek-v4-flash-dspark.sh
+++ b/status-deepseek-v4-flash-dspark.sh
@@ -6,7 +6,7 @@ ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.dspark}"
 COMPOSE_FILE="${COMPOSE_FILE:-$SCRIPT_DIR/docker-compose.dspark.yml}"
 PROJECT_NAME="${PROJECT_NAME:-deepseek-v4-flash}"
 LEGACY_PROJECT_NAME="${LEGACY_PROJECT_NAME:-$(basename "$SCRIPT_DIR" | tr '[:upper:]' '[:lower:]')}"
-API_URL="${API_URL:-http://127.0.0.1:8888/v1/models}"
+API_URL="${API_URL:-}"
 PORT="${PORT:-8888}"
 
 if [ -f "$ENV_FILE" ]; then
@@ -15,6 +15,14 @@ if [ -f "$ENV_FILE" ]; then
   source "$ENV_FILE"
   set +a
 fi
+
+# Default the endpoint from the configured bind address. vLLM binds exactly
+# VLLM_HOST (README API note: HEAD_NODE_IP), so 127.0.0.1 is wrong for a
+# LAN-IP bind. A wildcard bind is probed on loopback. An explicit API_URL
+# from the environment still wins.
+_dspark_host="${VLLM_HOST:-127.0.0.1}"
+case "$_dspark_host" in 0.0.0.0|::|"") _dspark_host=127.0.0.1 ;; esac
+API_URL="${API_URL:-http://${_dspark_host}:${VLLM_PORT:-8888}/v1/models}"
 
 : "${WORKER_HOST:?WORKER_HOST must be set in $ENV_FILE or environment}"
 : "${DSPARK_VLLM_IMAGE:=vllm-dspark-runtime:dspark-nvfp4-stage-c}"


### PR DESCRIPTION
`status-deepseek-v4-flash-dspark.sh` and `smoke-deepseek-v4-flash-dspark.sh` default `API_URL` / `CHAT_URL` to `http://127.0.0.1:8888/…` **before** sourcing `.env.dspark`. Once the env file is sourced the defaults are already set, so they are never re-derived from `VLLM_HOST`.

On any deployment that binds vLLM to a concrete LAN IP (`VLLM_HOST=<ip>` — the documented multi-user setup, see README's `API: http://HEAD_NODE_IP:8888/v1`), vLLM listens **only** on that address. The scripts then probe `127.0.0.1:8888` → `curl: (7) Connection refused` against a healthy, serving cluster: `status` reports the API down and `smoke` fails 6/6.

### Why it matters

- False-negative health signals: an operator (or a supervisor wrapping these) sees "cluster down" while it is serving traffic.
- The repo already has the correct pattern — `start-…sh` derives `API_HOST` from `VLLM_HOST` (wildcard/`::` → loopback) *after* sourcing. `status`/`smoke` are the only scripts probing a hardcoded address.

### Changes

- `status-deepseek-v4-flash-dspark.sh` / `smoke-deepseek-v4-flash-dspark.sh`: start with `API_URL=`/`CHAT_URL=` empty; after sourcing `.env.dspark`, derive the probe URL from `VLLM_HOST`/`VLLM_PORT` with the same wildcard→loopback mapping `start` uses.
- Explicit `API_URL` / `CHAT_URL` in the environment still win.

### Verification

Against a live 2x DGX Spark TP=2 cluster (vLLM bound to `192.168.1.235:8888`):

| case | before | after |
|---|---|---|
| `status` LAN-IP bind | `curl: (7) Failed to connect to 127.0.0.1` | probes `192.168.1.235:8888` → `401` (API reachable, auth-gated) |
| `smoke` LAN-IP bind | fails 6/6 (refused) | probes `192.168.1.235:8888` (header shows correct URL) |
| `VLLM_HOST=0.0.0.0` (shipped default) | loopback | loopback (unchanged) |

No behavior change for the shipped default profile (`VLLM_HOST=0.0.0.0` still resolves to loopback).
