### PR TITLE
fix(patches): add a read-only --status mode to the seven .py hotfixes

### DIFF
--- a/patches/hotfix-dsv4-issue26-hybrid-swa-min.py
+++ b/patches/hotfix-dsv4-issue26-hybrid-swa-min.py
@@ -20,6 +20,7 @@ entrypoint before ``exec vllm serve``.
 """
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 P = Path(
@@ -28,6 +29,16 @@ P = Path(
 
 MARK_V2 = "# [issue26-hotfix-v2] SWA may shrink the common hit (#36)"
 MARK_V1 = "# [issue26-hotfix] SWA groups must not shrink the hybrid common hit"
+
+if len(sys.argv) > 1 and sys.argv[1] == "--status":
+    status_src = P.read_text(encoding="utf-8") if P.is_file() else ""
+    if MARK_V2 in status_src:
+        print("issue26 hybrid-SWA-min v2         : APPLIED")
+    elif MARK_V1 in status_src:
+        print("issue26 hybrid-SWA-min v2         : NOT APPLIED (v1 inject present)")
+    else:
+        print("issue26 hybrid-SWA-min v2         : NOT APPLIED")
+    raise SystemExit(0)
 
 STOCK = (
     "                _new_hit_length = len(hit_blocks[0]) * spec.block_size\n"

--- a/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
+++ b/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
@@ -31,10 +31,16 @@ in-place inside the container (called from the compose entrypoint before
 ``exec vllm serve``).
 """
 from pathlib import Path
+import sys
 
 P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")
-src = P.read_text()
 MARK = "# [issue27-hotfix] enforce max_num_partial_prefills on admission"
+if len(sys.argv) > 1 and sys.argv[1] == "--status":
+    status_src = P.read_text() if P.is_file() else ""
+    print("issue27 partial-prefill cap        :",
+          "APPLIED" if MARK in status_src else "NOT APPLIED")
+    raise SystemExit(0)
+src = P.read_text()
 if MARK in src:
     print(f"[issue27-hotfix] already applied to {P}")
     raise SystemExit(0)

--- a/patches/hotfix-dsv4-issue31-v2-thinking-budget-gpu.py
+++ b/patches/hotfix-dsv4-issue31-v2-thinking-budget-gpu.py
@@ -27,8 +27,34 @@ import sys
 from pathlib import Path
 
 DEFAULT_VLLM = Path("/usr/local/lib/python3.12/dist-packages/vllm")
-VLLM = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VLLM
 MARK = "# [issue31-gpu-hotfix] V2 thinking_token_budget"
+
+
+def _issue31_status() -> None:
+    root = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_VLLM
+    checks = (
+        ("thinking_budget_gpu.py", root / "v1/worker/gpu/sample/thinking_budget_gpu.py", False),
+        ("input_processor.py", root / "v1/engine/input_processor.py", True),
+        ("config/vllm.py", root / "config/vllm.py", True),
+        ("sampler.py", root / "v1/worker/gpu/sample/sampler.py", True),
+        ("model_runner.py", root / "v1/worker/gpu/model_runner.py", True),
+    )
+    for label, p, needs_mark in checks:
+        if not p.is_file():
+            print(f"{'issue31 ' + label:44} :", "NOT APPLIED")
+            continue
+        if needs_mark:
+            applied = MARK in p.read_text(encoding="utf-8")
+        else:
+            applied = True  # written verbatim by the hotfix; existence is the signal
+        print(f"{'issue31 ' + label:44} :", "APPLIED" if applied else "NOT APPLIED")
+    raise SystemExit(0)
+
+
+if len(sys.argv) > 1 and sys.argv[1] == "--status":
+    _issue31_status()
+
+VLLM = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VLLM
 
 THINKING_BUDGET_PY = r'''# SPDX-License-Identifier: Apache-2.0
 # [issue31-gpu-hotfix] V2 thinking_token_budget (DSpark)

--- a/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
+++ b/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
@@ -61,11 +61,16 @@ in-place inside the container (called from the compose entrypoint before
 ``exec vllm serve``).
 """
 from pathlib import Path
+import sys
 
 P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")
-src = P.read_text()
-
 MARK = "# [issue43-hotfix]"
+if len(sys.argv) > 1 and sys.argv[1] == "--status":
+    status_src = P.read_text() if P.is_file() else ""
+    print("issue43 decode-fairness + diag     :",
+          "APPLIED" if MARK in status_src else "NOT APPLIED")
+    raise SystemExit(0)
+src = P.read_text()
 if MARK in src:
     print(f"[issue43-hotfix] already applied to {P}")
     raise SystemExit(0)

--- a/patches/hotfix-dsv4-issue55-tool-truncation.py
+++ b/patches/hotfix-dsv4-issue55-tool-truncation.py
@@ -147,6 +147,12 @@ def _patch_file(path: Path, old: str, new: str, what: str) -> str:
 
 
 def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--status":
+        root = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_VLLM
+        p = root / SERVING
+        applied = p.is_file() and MARK in p.read_text(encoding="utf-8")
+        print("issue55 tool-call truncation    :", "APPLIED" if applied else "NOT APPLIED")
+        return 0
     vllm_root = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VLLM
     path = vllm_root / SERVING
     if not path.is_file():

--- a/patches/hotfix-dsv4-suppress-stops-in-reasoning.py
+++ b/patches/hotfix-dsv4-suppress-stops-in-reasoning.py
@@ -199,6 +199,11 @@ def apply_file(path: Path) -> str:
 
 
 def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--status":
+        target = Path(argv[2]) if len(argv) > 2 else P
+        applied = target.is_file() and MARK in target.read_text()
+        print("suppress-stops-in-reasoning    :", "APPLIED" if applied else "NOT APPLIED")
+        return 0
     target = Path(argv[1]) if len(argv) > 1 else P
     if not target.is_file():
         print(f"[suppress-stops-in-reasoning] missing {target}", file=sys.stderr)

--- a/patches/hotfix-encoding-dsv4-issue21.py
+++ b/patches/hotfix-encoding-dsv4-issue21.py
@@ -54,6 +54,14 @@ def patch_file(path: Path) -> str:
 
 
 def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--status":
+        target = Path(argv[2]) if len(argv) > 2 else DEFAULT_TARGET
+        if not target.is_file():
+            print("issue21 encoder dict-args fix  : NOT APPLIED (encoder file missing)")
+            return 0
+        _, st = patch_text(target.read_text(encoding="utf-8"))
+        print("issue21 encoder dict-args fix  :", "APPLIED" if st != "missing" else "NOT APPLIED")
+        return 0
     target = Path(argv[1]) if len(argv) > 1 else DEFAULT_TARGET
     if not target.is_file():
         print(f"[FAIL] encoding file not found: {target}", file=sys.stderr)


### PR DESCRIPTION
The always-on `.py` hotfixes (`hotfix-encoding-dsv4-issue21.py`, `hotfix-dsv4-issue26-hybrid-swa-min.py`, `hotfix-dsv4-issue27-partial-prefill-concurrency.py`, `hotfix-dsv4-issue31-v2-thinking-budget-gpu.py`, `hotfix-dsv4-issue43-decode-fairness-and-diag.py`, `hotfix-dsv4-issue55-tool-truncation.py`, `hotfix-dsv4-suppress-stops-in-reasoning.py`) had no way to report their applied state — unlike the `.sh` hotfixes, which all expose a `<label> : APPLIED|NOT APPLIED` `--status` mode (see #73). The compose entrypoint runs them chained with `;` and no `set -e`, so a hotfix whose anchor drifts (e.g. after an image bump) prints a traceback and vLLM boots unpatched with nothing recording what happened — and any parity tooling that greps for `APPLIED|NOT APPLIED` (as the `.sh` contract documents) cannot cover these seven scripts at all.

### Changes

Each of the seven `.py` hotfixes gains a read-only `--status` mode that:

- reads the same marker(s) the apply path writes and prints `<label> : APPLIED|NOT APPLIED` (same token format as the `.sh` hotfixes),
- mutates nothing and exits 0,
- degrades gracefully when the target file is absent (`NOT APPLIED`, exit 0),
- keeps its existing positional-arg behavior (`--status` is consumed before any path argument; issue31 reports per-artifact across its 5 patched files).

### Contract rationale

Same spirit as #73: a status query is a query — it must not write, must be parseable, and must operate inside the container where the hotfixes run.

### Verification

Inside `ghcr.io/anemll/dspark-vllm-gx10:0.1.1` (throwaway containers, no GPU):

| state | result |
|---|---|
| pristine image, `--status` | `NOT APPLIED` for all seven |
| apply then `--status` | `APPLIED` for all seven (issue21 correctly reports `NOT APPLIED` on the pristine image: its encoder does not carry the broken anchor there) |
| host without the vLLM tree | clean `NOT APPLIED`, exit 0 |
