### PR TITLE
fix(issue26 repro): honour DSPARK_API / DSPARK_MODEL, matching the issue43 repro

### DIFF
--- a/scripts/reproduce-issue26-live.py
+++ b/scripts/reproduce-issue26-live.py
@@ -12,10 +12,14 @@ Protocol from issue #26:
 
 Reports per-wave aggregate cache-hit ratio and per-lane cached_tokens.
 """
-import json, time, urllib.request, sys, threading, statistics
+import json, os, time, urllib.request, sys, threading, statistics
 
-API = "http://127.0.0.1:8888"
-MODEL = "deepseek-v4-flash-0731"
+# Endpoint/model are overridable the same way reproduce-issue43-live.py already
+# does it; the hardcoded defaults only match a deployment served on 8888 under
+# the recipe's default model name, so a rig serving on another port or with a
+# custom SERVED_MODEL_NAME could not run this repro at all.
+API = os.environ.get("DSPARK_API", "http://127.0.0.1:8888")
+MODEL = os.environ.get("DSPARK_MODEL", "deepseek-v4-flash-0731")
 N_LANES = int(sys.argv[1]) if len(sys.argv) > 1 else 8
 TARGET_IN = int(sys.argv[2]) if len(sys.argv) > 2 else 32768
 OUT = 256


### PR DESCRIPTION
`scripts/reproduce-issue26-live.py` hardcodes its endpoint and model at module scope:

```python
API = "http://127.0.0.1:8888"
MODEL = "deepseek-v4-flash-0731"
```

There is no CLI flag or env override, so the repro cannot run against any deployment that sets a different `VLLM_PORT` or `SERVED_MODEL_NAME` — both of which `.env.dspark` exposes as first-class settings. The only workaround is editing the script.

`scripts/reproduce-issue43-live.py` already does the right thing:

```python
API = os.environ.get("DSPARK_API", "http://127.0.0.1:8888")
MODEL = os.environ.get("DSPARK_MODEL", "deepseek-v4-flash-0731")
CONTAINER = os.environ.get("DSPARK_CONTAINER", "deepseek-v4-flash-vllm-dspark-1")
```

This change makes the two consistent. **Defaults are unchanged**, so existing invocations behave identically.

Verified against a 2× DGX Spark deployment serving on port 18888 under a custom model name:

```
DSPARK_API=http://127.0.0.1:18888 DSPARK_MODEL=<served-name> \
  python3 scripts/reproduce-issue26-live.py 8 32768
```

cold wave aggregate hit ratio `0.0000` (as the protocol requires), warm1 and warm2 both **8/8 lanes** with aggregate hit ratio **0.9735** and per-lane `cached_tokens` uniform at 86016.