### PR TITLE
fix(sched): overlap two chunked prefills (DSPARK_MAX_INFLIGHT_PREFILLS=2)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -125,13 +125,15 @@ LONG_PREFILL_TOKEN_THRESHOLD=1024
 
 # Issue #43: max concurrent in-flight partial prefills. Raising to 2/3
 # overlaps prefills and is the lever that improves the whole-request min/max
-# decode rate #43 reports. NOTE: NOT available on the dspark-vllm-gx10:0.1.1
-# base image — vLLM's _check_feature_supported() rejects Concurrent Partial
-# Prefill before engine init (it is genuinely not implemented upstream in
-# this build, only guarded out), and even an explicit --max-num-partial-prefills
-# 1 trips the guard. Needs a vLLM base-image upgrade to enable; track in a
-# follow-up issue. Do NOT pass --max-num-partial-prefills on this image.
-# MAX_NUM_PARTIAL_PREFILLS=1
+# decode rate #43 reports. NOTE: --max-num-partial-prefills is NOT available
+# on dspark-vllm-gx10:0.1.1 — vLLM's _check_feature_supported() rejects
+# Concurrent Partial Prefill before engine init. Do NOT pass that flag.
+# The #27 hotfix instead reads DSPARK_MAX_INFLIGHT_PREFILLS (clamped 1-3).
+# Default 2: live 32K×c4 decode left the ~8 tok/s floor (~25 tok/s) with
+# #43 floor on and LONG_PREFILL_TOKEN_THRESHOLD=1024. Set 1 to restore the
+# original serialize-one-prefill gate. Image upgrade for real concurrent
+# partial prefill is issue #45.
+DSPARK_MAX_INFLIGHT_PREFILLS=2
 
 # Issue #43: bounded decode service during mixed prefill steps + scheduler
 # diagnostics. The hotfix layers on #27 and guarantees no decode-active lane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2026-08-19
 
+### Changed
+
+- **#27 hotfix: allow 2 overlapping chunked prefills via `DSPARK_MAX_INFLIGHT_PREFILLS` (default 2).** Anemll `0.1.1` still rejects `--max-num-partial-prefills` (issue #45). The shipped #27 gate therefore read `SchedulerConfig.max_num_partial_prefills` (always 1) and serialized every long prefill — 32K×c4 decode sat on the ~8 tok/s floor. The hotfix now honors `DSPARK_MAX_INFLIGHT_PREFILLS` (clamped 1–3) from compose. Live A/B on this 2× Spark stack (`thinking=false`, `LONG_PREFILL_TOKEN_THRESHOLD=1024`, #43 floor on): 32K×c4 per-stream decode **8.2 → 24.6 tok/s**; 256×c6 aggregate unchanged (~175); 12 min 32K×c2 soak 21/21 pass; preemptions 0. Set `1` to restore the old serial gate. Does not implement real Concurrent Partial Prefill.
+
 ### Fixed
 
 - **RULER-lite never reached its advertised context lengths ([Issue #81](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/81))**: `pad_to_length` appended one haystack sentence per loop with `guard < 200`, so every cell capped at ~4.8k tokens while still exiting 0. It now bulk-pads and `run_case` fails if `/tokenize` is under 97% of the target.

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -67,6 +67,9 @@ services:
       # (scheduled prefill/decode tokens per request + zero-token decode
       # skips) when set to 1. Off by default (zero overhead).
       DSPARK_ISSUE43_SCHED_DIAG: "${DSPARK_ISSUE43_SCHED_DIAG:-0}"
+      # In-flight partial-prefill cap for the #27 hotfix (1-3, default 2).
+      # Do NOT pass --max-num-partial-prefills (Anemll 0.1.1 rejects it).
+      DSPARK_MAX_INFLIGHT_PREFILLS: "${DSPARK_MAX_INFLIGHT_PREFILLS:-2}"
       # Pin HF revision (issue #19). Empty → tip of default branch / refs/main.
       DSPARK_REVISION: "${DSPARK_REVISION:-}"
       DSPARK_ENCODING_FILE: "${DSPARK_ENCODING_FILE:-}"

--- a/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
+++ b/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
@@ -15,7 +15,10 @@ grows with prompt length. (Issue #27.)
 
 Fix: at the top of the waiting-admission loop, break (don't admit a new
 prefill request) once the number of in-flight partial prefills has reached
-``max_num_partial_prefills``. ``self._inflight_prefills`` is maintained by
+the cap. The cap is ``DSPARK_MAX_INFLIGHT_PREFILLS`` (1-3, default 2 via
+compose) because this image rejects ``--max-num-partial-prefills``; if that
+env is unset/0 the hotfix falls back to ``SchedulerConfig.max_num_partial_prefills``
+(stock 1). ``self._inflight_prefills`` is maintained by
 ``_update_after_schedule`` (populated for requests still needing more prefill
 chunks, discarded when they finish prefilling), so it correctly reflects the
 currently-prefilling set. This restores the documented concurrency cap of 1
@@ -62,10 +65,18 @@ INJECT = ANCHOR + (
     "                # them get num_new_tokens==0 and are skipped (continue, not preempt)\n"
     "                # -> zero-preemption decode starvation (issue #27). _inflight_prefills\n"
     "                # is the set of running requests still needing prefill chunks.\n"
+    "                # DSPARK_MAX_INFLIGHT_PREFILLS (1-3) overrides the config field\n"
+    "                # because this image rejects --max-num-partial-prefills.\n"
+    "                _pp_cap = int((__import__('os').environ.get(\n"
+    "                    'DSPARK_MAX_INFLIGHT_PREFILLS') or '0') or 0)\n"
+    "                if _pp_cap <= 0:\n"
+    "                    _pp_cap = self.scheduler_config.max_num_partial_prefills\n"
+    "                if _pp_cap > 3:\n"
+    "                    _pp_cap = 3\n"
     "                if (\n"
-    "                    self.scheduler_config.max_num_partial_prefills > 0\n"
+    "                    _pp_cap > 0\n"
     "                    and len(self._inflight_prefills)\n"
-    "                    >= self.scheduler_config.max_num_partial_prefills\n"
+    "                    >= _pp_cap\n"
     "                ):\n"
     "                    break\n"
 )

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -60,6 +60,8 @@ python3 scripts/test-assistant-final-continuation.py -q
 ok "test-assistant-final-continuation"
 python3 scripts/test-ruler-lite-pad.py -q
 ok "test-ruler-lite-pad"
+python3 tests/test_issue27_inflight_cap.py -q
+ok "test_issue27_inflight_cap"
 python3 scripts/verify-dsv4-027-equality-gate.py
 ok "verify-dsv4-027-equality-gate"
 bash scripts/verify-overlay-sources.sh

--- a/tests/test_issue27_inflight_cap.py
+++ b/tests/test_issue27_inflight_cap.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""The shipped #27 hotfix must honor DSPARK_MAX_INFLIGHT_PREFILLS (clamped 1–3)
+because this image rejects --max-num-partial-prefills. Applies the real hotfix
+entry point to a fixture copy of the admission-loop anchor.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOTFIX = ROOT / "patches" / "hotfix-dsv4-issue27-partial-prefill-concurrency.py"
+
+FIXTURE = (
+    "                num_running = len(self.running) + self.num_waiting_for_streaming_input\n"
+    "                if num_running >= self.max_num_running_reqs:\n"
+    "                    break\n"
+    "                leftover = True\n"
+)
+
+
+def _apply_to(path: Path) -> None:
+    txt = HOTFIX.read_text()
+    marker = 'Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")'
+    txt = txt.replace(marker, f"Path({str(path)!r})")
+    ns: dict = {}
+    exec(compile(txt, str(HOTFIX), "exec"), ns)
+
+
+class Issue27InflightCapTest(unittest.TestCase):
+    def test_hotfix_source_has_env_override(self):
+        src = HOTFIX.read_text()
+        self.assertIn("DSPARK_MAX_INFLIGHT_PREFILLS", src)
+        self.assertIn("if _pp_cap > 3:", src)
+        env_at = src.find("'DSPARK_MAX_INFLIGHT_PREFILLS'")
+        # fallback to SchedulerConfig still present after the env read
+        self.assertIn("self.scheduler_config.max_num_partial_prefills", src)
+        self.assertGreater(env_at, 0)
+
+    def test_apply_injects_env_cap_into_admission_loop(self):
+        tmp = Path(tempfile.mkdtemp()) / "scheduler.py"
+        tmp.write_text(FIXTURE)
+        try:
+            _apply_to(tmp)
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        patched = tmp.read_text()
+        self.assertIn("# [issue27-hotfix]", patched)
+        self.assertIn("DSPARK_MAX_INFLIGHT_PREFILLS", patched)
+        self.assertIn("_pp_cap", patched)
+        self.assertIn("len(self._inflight_prefills)", patched)
+        try:
+            _apply_to(tmp)
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        self.assertEqual(patched, tmp.read_text())
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(verbosity=2) else 1)


### PR DESCRIPTION
## Issue

On Anemll `dspark-vllm-gx10:0.1.1`, `--max-num-partial-prefills` is rejected (`_check_feature_supported` — Concurrent Partial Prefill is not implemented; tracked as #45).

The shipped **#27 hotfix** therefore always gated admission at `SchedulerConfig.max_num_partial_prefills` (**1**). One long chunked prefill ran at a time. Decode lanes that had already started generating sat at about **8 tok/s** whenever several 32K+ prompts were in flight (32K×c4 in the Rank-2 matrix). Zero preemptions — this is serialization, not KV pressure.

#27 itself is **closed** (N=1 was the right first fix). #43 / PR #44 already keeps decode from being skipped *per step*. This PR does not reopen those. It only raises the #27 admission cap without waiting for a new vLLM image.

## Fix

`patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py` now reads **`DSPARK_MAX_INFLIGHT_PREFILLS`** (clamped 1–3). Compose injects it; default **2**. Unset/0 falls back to the stock config field (1).

Still **do not** pass `--max-num-partial-prefills` on this image.

`LONG_PREFILL_TOKEN_THRESHOLD` stays **1024**. The #43 decode floor stays on (two 1024-token prefill chunks plus decode reservations still fit in `max_num_batched_tokens=8192`). Set the env to `1` to restore the old serial gate.

## Verification (live 2× DGX Spark TP=2, `thinking=false`)

Same serving profile as `main` except this knob: `MAX_NUM_SEQS=6`, batched 8192, long-prefill 1024, #43 on, MTP=5.

**Throughput** (`scripts/bench-miaai.py`, min=max=128):

| Cell | N=1 (before) | N=2 (this PR) |
|---|---:|---:|
| 32K×c4 decode /stream | **8.2** | **24.6** |
| 32K×c4 TTFT | 47.6 s | 52.8 s (not faster) |
| 256×c6 /stream | 38.2 | 39.2 |
| 256×c6 aggregate | 174 | 175 |

**Stability / no-regression** (`scripts/stability-quick.py --skip-vl` + issue #43 cells):

- Smoke + context ladder 8K / 32K / 128K / **256K**: all PASS (`LADDER_OK`)
- 12 min soak, 32K × c=2: **21/21 PASS**, median decode stuck at 31–35 tok/s (no droop)
- Issue #43 32K×2: whole-request min/max **0.996**, post-TTFT **0.999**, preempts +0
- Issue #43 32K×4: whole-request min/max **0.959**; post-TTFT spread 0.118 (two lanes ~12 tok/s while the other pair still prefills, two ~100 after) — expected N=2 sharing, not the old all-lanes-at-8 freeze
- Preemptions **0** before and after; no NCCL / OOM / traceback
- CPU: `tests/test_issue27_inflight_cap.py` + `tests/test_issue43_patchapply.py` (hotfix still applies on the real scheduler.py, still idempotent)

**Not claimed:** first-token wait on a 4-wide 32K wave is not shorter; N=3 untested; this is not real Concurrent Partial Prefill (#45).

## Related

- Parent behavior: #27 (closed, N=1 gate)
- Decode floor: #43 / #44
- Real upstream feature: #45
