### PR TITLE
fix(spec-acceptance): per-position parse dropped every position, so the curve never printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **Speculative-acceptance per-position curve was always empty ([PR #91](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/pull/91))**: the parser assumed `position` was followed by another label, but Anemll `0.1.1` emits it last, so every sample raised inside a swallowed exception. The parser now matches the label independent of order, excludes the sibling `_created` timestamp gauge, and reports this measurement window as accepted tokens per draft rather than container-lifetime totals.
+
 - **RULER-lite never reached its advertised context lengths ([Issue #81](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/81))**: `pad_to_length` appended one haystack sentence per loop with `guard < 200`, so every cell capped at ~4.8k tokens while still exiting 0. It now bulk-pads and `run_case` fails if `/tokenize` is under 97% of the target.
 
 - **RULER-lite scored its own client timeout as a model FAIL past ~790k tokens ([PR #85](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/pull/85))**: `request_json` pinned `timeout=900`, but the recorded 899,994-token acceptance run needs 1,028.85 s to first token at ~874.8 prefill tok/s, so 900 s only covers ~787k tokens of prefill — the client hung up mid-prefill and the case was reported as a model failure. Adds `--request-timeout` (default unchanged at 900 s; must be finite and > 0), plumbed through `scripts/run-audit.sh` so a raised `--lengths` can be paired with it. Only the timeout half of PR #85 was taken: its `pad_to_length` rewrite duplicated `8997d41`, cost an extra `/tokenize` round trip at every depth, and dropped the `haystack_reps` test seam.

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -36,6 +36,8 @@ py_files+=(
   scripts/test-encoding-dsv4-issue21.py
   scripts/test-suppress-stops-in-reasoning.py
   scripts/test-assistant-final-continuation.py
+  scripts/spec-acceptance.py
+  scripts/test-spec-acceptance.py
   scripts/test-ruler-lite-pad.py
   scripts/ruler-lite.py
   scripts/verify-dsv4-027-equality-gate.py
@@ -58,6 +60,8 @@ python3 scripts/test-suppress-stops-in-reasoning.py -q
 ok "test-suppress-stops-in-reasoning"
 python3 scripts/test-assistant-final-continuation.py -q
 ok "test-assistant-final-continuation"
+python3 scripts/test-spec-acceptance.py -q
+ok "test-spec-acceptance"
 python3 scripts/test-ruler-lite-pad.py -q
 ok "test-ruler-lite-pad"
 python3 tests/test_issue27_inflight_cap.py -q

--- a/scripts/spec-acceptance.py
+++ b/scripts/spec-acceptance.py
@@ -18,29 +18,37 @@ Usage:
 """
 import argparse
 import json
+import re
 import statistics
 import subprocess
 import sys
 import time
 import urllib.request
 
+POSITION_RE = re.compile(r'position="(\d+)"')
+
 
 def get_metrics(base_url: str) -> dict:
     url = base_url.removesuffix("/v1") + "/metrics"
     with urllib.request.urlopen(url, timeout=30) as r:
         txt = r.read().decode()
-    out = {"drafted": None, "accepted": None, "per_pos": {}}
+    out = {"drafted": None, "accepted": None, "drafts": None, "per_pos": {}}
     for line in txt.splitlines():
         if line.startswith("vllm:spec_decode_num_draft_tokens_total"):
             out["drafted"] = float(line.split()[-1])
         elif line.startswith("vllm:spec_decode_num_accepted_tokens_total"):
             out["accepted"] = float(line.split()[-1])
-        elif "accepted_tokens_per_pos" in line and "{" in line:
-            try:
-                pos = int(line.split("position=")[1].split(",")[0].strip('"'))
-                out["per_pos"][pos] = float(line.split()[-1])
-            except Exception:
-                pass
+        elif line.startswith("vllm:spec_decode_num_drafts_total"):
+            out["drafts"] = float(line.split()[-1])
+        # Anchor on _total: the sibling _created gauge carries a Unix timestamp.
+        elif line.startswith("vllm:spec_decode_num_accepted_tokens_per_pos_total"):
+            # Match the label directly. Splitting on "," assumes position= is
+            # followed by another label, but this build emits it last, so the old
+            # parse produced '0"} 40263.0' and the bare except dropped every
+            # position — leaving the curve permanently empty.
+            hit = POSITION_RE.search(line)
+            if hit:
+                out["per_pos"][int(hit.group(1))] = float(line.split()[-1])
     return out
 
 
@@ -74,12 +82,15 @@ def main() -> int:
     if d > 0:
         rate = a / d * 100
         print(f"OVERALL ACCEPTANCE = {rate:.1f}%")
-        print(f"tokens accepted per draft = {a/d:.3f} (k=5 -> max 5)")
-        # per-position acceptance curve
-        print("\nper-position acceptance (pos0..pos4):")
+        n_drafts = (m2["drafts"] or 0.0) - (m1["drafts"] or 0.0)
+        # Per-position curve over THIS window. Reporting m2 alone would print the
+        # container's lifetime totals, which no longer describe the burst above.
+        print("\nper-position acceptance (this window):")
         for pos in sorted(m2["per_pos"]):
-            v = m2["per_pos"][pos]
-            if v:
+            v = m2["per_pos"][pos] - m1["per_pos"].get(pos, 0.0)
+            if n_drafts > 0:
+                print(f"  pos{pos}: {v / n_drafts:.3f}  ({v:.0f}/{n_drafts:.0f})")
+            elif v:
                 print(f"  pos{pos}: {v:.0f} accepted")
     else:
         print("NO draft activity in window — is spec-decode on? (check MTP_NUM_TOKENS)")

--- a/scripts/test-spec-acceptance.py
+++ b/scripts/test-spec-acceptance.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""CPU regressions for spec-acceptance metric parsing and window reporting."""
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "scripts" / "spec-acceptance.py"
+FIXTURE = ROOT / "results" / "dspark-metrics.txt"
+SPEC = importlib.util.spec_from_file_location("spec_acceptance", SRC)
+sa = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(sa)
+
+
+class _Response:
+    def __init__(self, text: str):
+        self.data = text.encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def read(self):
+        return self.data
+
+
+class MetricParsingTest(unittest.TestCase):
+    def parse(self, text: str) -> dict:
+        original = sa.urllib.request.urlopen
+        sa.urllib.request.urlopen = lambda *_a, **_k: _Response(text)
+        try:
+            return sa.get_metrics("http://unused/v1")
+        finally:
+            sa.urllib.request.urlopen = original
+
+    def test_real_fixture_reads_last_position_label_and_ignores_created_gauges(self):
+        metrics = self.parse(FIXTURE.read_text())
+        self.assertEqual(metrics["drafts"], 105.0)
+        self.assertEqual(metrics["per_pos"], {
+            0: 84.0, 1: 63.0, 2: 1.0, 3: 1.0, 4: 0.0, 5: 0.0,
+        })
+
+    def test_position_label_order_does_not_matter(self):
+        metrics = self.parse(
+            'vllm:spec_decode_num_accepted_tokens_per_pos_total{position="7",engine="0"} 9\n'
+        )
+        self.assertEqual(metrics["per_pos"], {7: 9.0})
+
+
+class WindowReportingTest(unittest.TestCase):
+    def run_main(self, before: dict, after: dict) -> str:
+        snapshots = iter((before, after))
+        original_metrics = sa.get_metrics
+        original_run = sa.subprocess.run
+        original_argv = sys.argv
+        sa.get_metrics = lambda _url: next(snapshots)
+        sa.subprocess.run = lambda *_a, **_k: None
+        sys.argv = ["spec-acceptance.py", "--trials", "2"]
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(sa.main(), 0)
+            return output.getvalue()
+        finally:
+            sa.get_metrics = original_metrics
+            sa.subprocess.run = original_run
+            sys.argv = original_argv
+
+    def test_reports_window_rates_from_counter_deltas(self):
+        output = self.run_main(
+            {"drafted": 500.0, "accepted": 300.0, "drafts": 100.0,
+             "per_pos": {0: 90.0, 1: 70.0}},
+            {"drafted": 550.0, "accepted": 334.0, "drafts": 110.0,
+             "per_pos": {0: 99.0, 1: 77.0}},
+        )
+        self.assertIn("OVERALL ACCEPTANCE = 68.0%", output)
+        self.assertIn("pos0: 0.900  (9/10)", output)
+        self.assertIn("pos1: 0.700  (7/10)", output)
+
+    def test_without_draft_count_falls_back_to_window_counts(self):
+        output = self.run_main(
+            {"drafted": 10.0, "accepted": 5.0, "drafts": None,
+             "per_pos": {0: 4.0}},
+            {"drafted": 15.0, "accepted": 8.0, "drafts": None,
+             "per_pos": {0: 7.0}},
+        )
+        self.assertIn("pos0: 3 accepted", output)
+        self.assertNotIn("pos0: 0.", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`spec-acceptance.py`'s per-position curve has never printed anything. Three problems, all in that one feature:

**1. The parse drops every position (the reason nothing prints).**

On the vLLM build in the pinned `ghcr.io/anemll/dspark-vllm-gx10:0.1.1` image, `position` is emitted as the *last* label:

```
vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="deepseek-v4-flash-0731",position="0"} 40263.0
```

so `line.split("position=")[1].split(",")[0].strip('"')` yields `0"} 40263.0`, `int()` raises `ValueError`, and the bare `except: pass` swallows it. `per_pos` is empty on every run. Fixed by matching the label directly with a regex, which is also order-independent if a future build reorders labels.

**2. Anchored the per-position branch on `_total`.** The old condition (`"accepted_tokens_per_pos" in line`) also matches the sibling `_created` gauge, whose value is a Unix timestamp (`1.787e9`). That was harmless only because the parse failed; with the parse fixed it would have contaminated the counts.

**3. The curve is now a window delta, and expressed as a rate.** It read `m2` alone — `m1["per_pos"]` was collected but never used — so even when populated it would have reported the container's lifetime totals rather than the burst just run. `drafts_total` is now read so counts can be divided into the rates `EVAL.md` already documents (`pos0 ~0.93 -> pos4 ~0.33`). The hardcoded `(k=5 -> max 5)` line is dropped; it printed the same value as the acceptance rate directly above it.

## Verified

Live 2x DGX Spark, TP=2, pinned `0.1.1` image, `MTP_NUM_TOKENS=5`:

- before: `per_pos` = `{}` (empty)
- after: `per_pos` = `{0: 44086, 1: 34923, 2: 26651, 3: 19687, 4: 14456}`
- **per-position values sum to `accepted_tokens_total` exactly** (139,803 == 139,803)
- derived draft width from `draft_tokens_total / drafts_total` = 5.00, matching `MTP_NUM_TOKENS=5`
- old parse reproduced independently: `ValueError: invalid literal for int() with base 10: '0"} 40263.0'`
- `python3 -m py_compile` clean

Sample output on that cluster (a real mixed agentic workload, not a synthetic burst — noting it only to show the shape, not as an expected value):

```
per-position acceptance (this window):
  pos0: 0.850
  pos1: 0.673
  pos2: 0.514
  pos3: 0.379
  pos4: 0.279
```

## Scope / non-goals

- **No behaviour change outside the per-position curve.** Overall acceptance is untouched.
- **Not a general Prometheus parser.** This keeps the existing simple line parsing and stays scoped to the pinned Anemll/vLLM output. Timestamped samples and OpenMetrics exemplars are out of scope, as they are for the rest of the file.
- **Counter reset is not addressed.** If the server restarts mid-window, `m2 < m1` and the run falls back to raw counts. That is a pre-existing property of the overall delta too, so it is left for a separate change rather than widened here.
- **Backwards compatible.** If a build does not expose `drafts_total`, the curve falls back to printing counts as before.
- **No doc changes.** `EVAL.md` and `AUDIT.md` already promise a per-position acceptance curve with rates; this makes the tool match what they describe.

`run-audit.sh` pipes this script's stdout to a log file and does not parse it, so the changed output format is not breaking.
