### PR TITLE
fix(prepare): pass HF hub timeouts into the download containers

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -64,6 +64,10 @@ WORKER_HF_CACHE=
 HF_HUB_OFFLINE=1
 TRANSFORMERS_OFFLINE=1
 HF_HUB_DISABLE_XET=1
+# Hub HTTP timeouts used by prepare-dspark-model-cache.sh. hf_hub defaults to
+# 10s/10s, which aborts multi-GB shard downloads on a slow or proxied link.
+# HF_HUB_DOWNLOAD_TIMEOUT=120
+# HF_HUB_ETAG_TIMEOUT=30
 # Checkpoint flag: 0 = official 0731, 1 = abliterated (Keys).
 # start- / prepare- resolve DSPARK_MODEL from this — do not set DSPARK_MODEL by hand.
 ABLITERATED=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-20
+
+### Fixed
+
+- **Hub timeouts abort large-shard downloads in `prepare-dspark-model-cache.sh`**: both `docker run` blocks (`run_download` and `verify_cache`) now pass `HF_HUB_DOWNLOAD_TIMEOUT` (default `120`) and `HF_HUB_ETAG_TIMEOUT` (default `30`). `huggingface_hub` defaults both to 10s, which is short enough that a slow or proxied link kills a multi-GB shard mid-transfer rather than riding it out. Override in `.env.dspark`.
+
 ## 2026-08-19
 
 ### Changed

--- a/prepare-dspark-model-cache.sh
+++ b/prepare-dspark-model-cache.sh
@@ -197,6 +197,8 @@ run_download() {
     -e HF_HUB_OFFLINE=0 \
     -e TRANSFORMERS_OFFLINE=0 \
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
+    -e HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-120}" \
+    -e HF_HUB_ETAG_TIMEOUT="${HF_HUB_ETAG_TIMEOUT:-30}" \
     -e DSPARK_MODEL="$model" \
     -e DSPARK_REVISION="$revision" \
     -e HF_DOWNLOAD_WORKERS="$HF_DOWNLOAD_WORKERS" \
@@ -237,6 +239,8 @@ verify_cache() {
     -e HF_HUB_OFFLINE=1 \
     -e TRANSFORMERS_OFFLINE=1 \
     -e HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
+    -e HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-120}" \
+    -e HF_HUB_ETAG_TIMEOUT="${HF_HUB_ETAG_TIMEOUT:-30}" \
     -e DSPARK_MODEL="$model" \
     -e DSPARK_REVISION="$revision" \
     --entrypoint "$IMAGE_PYTHON" \


### PR DESCRIPTION
## Issue

`prepare-dspark-model-cache.sh` runs `snapshot_download` inside a throwaway container and forwards a curated set of `-e HF_*` variables. Two are missing:

- `HF_HUB_DOWNLOAD_TIMEOUT` — per-chunk read timeout on the file transfer
- `HF_HUB_ETAG_TIMEOUT` — timeout on the metadata/HEAD request

`huggingface_hub` defaults both to **10 seconds**. DeepSeek-V4-Flash-0731 is many multi-GB safetensors shards, and on a slow or proxied link a single stall past 10s aborts the transfer, so cache prep dies partway through a shard rather than riding it out. Because the values are not in the `-e` list, setting them in `.env.dspark` (which the script already sources) has no effect — they never reach the container.

## Change

Two lines in each of the two `docker run` blocks, after the existing `-e HF_HUB_DISABLE_XET=…`:

```sh
    -e HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-120}" \
    -e HF_HUB_ETAG_TIMEOUT="${HF_HUB_ETAG_TIMEOUT:-30}" \
```

in `run_download` and in `verify_cache`. `verify_cache` runs `local_files_only=True` with `HF_HUB_OFFLINE=1`, so the values are inert there — they are included only so the two blocks stay identical and no one has to reason about which one got the fix.

Defaults are 120s/30s rather than the hub's 10s/10s. These are timeouts, not retries: a healthy link is unaffected, and a genuinely dead link still fails, just not on a transient 10-second stall. Override either in `.env.dspark`.

Plus commented entries in `.env.dspark.example` and a CHANGELOG line. No retry/backoff logic, no other behavior change.

## Evidence

Motivated by cache prep on our own 2× DGX Spark GB10 cluster (Anemll `0.1.1`, official `deepseek-ai/DeepSeek-V4-Flash-0731`, from checkout `f752cd0` with this diff applied locally), where the stock 10s timeouts aborted large-shard downloads over a proxied link and the raised values let the same prep complete.

**Not claimed:** this is not a fix for a broken network, and we did not run this exact branch (rebased on current `main`) — only `ci-validate.sh` ran on the branch.

## Validation

`bash scripts/ci-validate.sh` on this branch: pass (includes `bash -n prepare-dspark-model-cache.sh`).
