### PR TITLE
ci: restore hosted validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run CPU recipe gates
+        run: bash scripts/ci-validate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Changed
 
-- **GitHub Actions `validate` workflow**: on every push/PR, `scripts/ci-validate.sh` runs CPU-only recipe gates (shell syntax, patch compile, #21/#26 v2 unit tests, #49486/#48407 equality gate, overlay COPY check) and refuses to re-ship the withdrawn #31/#34 thinking-budget hook or a #26 v1 coordinator. This does **not** replace a live 2× Spark decode or tool-eval run.
+- **GitHub Actions `validate` workflow**: on every pull request and push to `main`, `scripts/ci-validate.sh` runs CPU-only recipe gates (shell syntax, patch compile, #21/#26 v2 unit tests, #49486/#48407 equality gate, overlay COPY check) and refuses to re-ship the withdrawn #31/#34 thinking-budget hook or a #26 v1 coordinator. This does **not** replace a live 2× Spark decode or tool-eval run.
 
 - **Reverted the #31/#34 `thinking_token_budget` patch (bug + hotfix)**: the V2 sampler hook, `ThinkingBudgetState` O(n) per-step scan, and omit-field defaults (`DEFAULT_THINKING_TOKEN_BUDGET=32768`, `DEFAULT_MAX_TOKENS=131072`) are **fully removed** from compose, start, and `patches/`. That path was the [#39](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/39) **~4.7× decode tok/s cliff** at long context (Python scan × MTP rows on every request after #34). It is not incremental-scanned and left in; it is gone. Stock Anemll V2 again rejects `thinking_token_budget` (HTTP 400). Size client `max_tokens` (or set `DEFAULT_THINKING` below `max`) so a long think cannot empty `content`.
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ This is the **Stage C padded NVFP4** path (584-byte sparse-MLA envelope via
 Optional GB10 hybrid plugin: `ENABLE_VLLM_GB10_PATCH=1 ./start-…`
 (`--quantization modelopt_gb10_hybrid`). Default off.
 
-CI on every push ([`.github/workflows/validate.yml`](.github/workflows/validate.yml))
+CI on every pull request and push to `main` ([`.github/workflows/validate.yml`](.github/workflows/validate.yml))
 is **CPU-only** (`scripts/ci-validate.sh`). Live tok/s still needs the 2× Spark pair.
 
 ### Strict Responses API verification


### PR DESCRIPTION
## Summary

- add the missing hosted `validate` workflow for pull requests, pushes to `main`, and manual current-main runs
- keep execution least-privilege: read-only contents, SHA-pinned checkout, no persisted credentials, GitHub-hosted runner, bounded timeout and concurrency
- correct README and CHANGELOG trigger wording so repository claims match the workflow

The workflow delegates all validation logic to the existing `bash scripts/ci-validate.sh`; it does not duplicate the gates or use the 2× Spark cluster.

Closes #93

## Local verification

- `bash scripts/ci-validate.sh` — PASS
- 20 Python files compiled; all CPU unit suites passed
- DSv4 equality/dormancy gate — 24 passed, 0 failed
- workflow YAML structure, triggers, permissions, runner, action pin, credential handling, timeout, concurrency, and command — PASS
- exact commit-range scope, secret, public-identifier, and whitespace scans — PASS

## Limits

This remains CPU-only validation. Live model quality, GPU throughput, NCCL, and two-node serving still require the separate cluster gates.