### PR TITLE
fix(spec-acceptance): handle disabled speculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Hub timeouts abort large-shard downloads in `prepare-dspark-model-cache.sh`**: both `docker run` blocks (`run_download` and `verify_cache`) now pass `HF_HUB_DOWNLOAD_TIMEOUT` (default `120`) and `HF_HUB_ETAG_TIMEOUT` (default `30`). `huggingface_hub` defaults both to 10s, which is short enough that a slow or proxied link kills a multi-GB shard mid-transfer rather than riding it out. Override in `.env.dspark`.
 
+- **`spec-acceptance.py` no longer crashes on serves without spec-decode ([Issue #92](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/92), reported by [@wbaguley](https://github.com/wbaguley))**: it formatted missing `drafted`/`accepted` counters before its no-spec guard, so `run-audit.sh` reported FAIL on a valid non-speculative serve. The guard now exits 0 before formatting either counter or starting the benchmark burst. The same report's parser/window items were already handled by [PR #91](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/pull/91) and are not re-claimed here.
+
 ## 2026-08-19
 
 ### Changed

--- a/scripts/spec-acceptance.py
+++ b/scripts/spec-acceptance.py
@@ -63,6 +63,9 @@ def main() -> int:
     args = ap.parse_args()
 
     m1 = get_metrics(args.base_url)
+    if m1["drafted"] is None or m1["accepted"] is None:
+        print("NO draft counters in /metrics — is spec-decode on? (check MTP_NUM_TOKENS)")
+        return 0
     print(f"before: drafted={m1['drafted']:.0f} accepted={m1['accepted']:.0f}", file=sys.stderr)
 
     cmd = [sys.executable, args.bench_script, "--base-url", args.base_url,
@@ -71,7 +74,7 @@ def main() -> int:
     subprocess.run(cmd, capture_output=True)
 
     m2 = get_metrics(args.base_url)
-    if m1["drafted"] is None or m2["drafted"] is None:
+    if m2["drafted"] is None or m2["accepted"] is None:
         print("NO draft counters in /metrics — is spec-decode on? (check MTP_NUM_TOKENS)")
         return 0
     d = m2["drafted"] - (m1["drafted"] or 0)

--- a/scripts/test-spec-acceptance.py
+++ b/scripts/test-spec-acceptance.py
@@ -59,8 +59,9 @@ class WindowReportingTest(unittest.TestCase):
         original_metrics = sa.get_metrics
         original_run = sa.subprocess.run
         original_argv = sys.argv
+        self.bench_calls = []
         sa.get_metrics = lambda _url: next(snapshots)
-        sa.subprocess.run = lambda *_a, **_k: None
+        sa.subprocess.run = lambda *_a, **_k: self.bench_calls.append(_a)
         sys.argv = ["spec-acceptance.py", "--trials", "2"]
         try:
             output = io.StringIO()
@@ -92,6 +93,21 @@ class WindowReportingTest(unittest.TestCase):
         )
         self.assertIn("pos0: 3 accepted", output)
         self.assertNotIn("pos0: 0.", output)
+
+    def test_spec_decode_off_reports_without_running_benchmark(self):
+        absent = {"drafted": None, "accepted": None, "drafts": None, "per_pos": {}}
+        output = self.run_main(absent, absent)
+        self.assertIn("NO draft counters", output)
+        self.assertEqual(self.bench_calls, [])
+
+    def test_counters_vanishing_after_burst_reports_instead_of_crashing(self):
+        output = self.run_main(
+            {"drafted": 500.0, "accepted": 300.0, "drafts": 100.0,
+             "per_pos": {0: 90.0}},
+            {"drafted": None, "accepted": None, "drafts": None, "per_pos": {}},
+        )
+        self.assertIn("NO draft counters", output)
+        self.assertEqual(len(self.bench_calls), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- return success with the existing no-counter message when speculative decoding is disabled, before formatting missing counters or starting the benchmark burst
- keep the same safe behavior when counters disappear between the two metric reads
- add focused CPU regressions for the initial no-spec path and the mid-window disappearance path
- document the fix without re-claiming work already merged in PR #91

Fixes #92

## Contributor credit

Thank you **@wbaguley** for reporting #92, isolating the format-before-guard failure, supplying live `MTP_NUM_TOKENS=7` metrics evidence, and attaching a patch against the pre-#91 script.

Thank you **@msdjzmst** for PR #91, which already fixed the same report's per-position parser, window-delta reporting, and hardcoded-label scope. This PR intentionally handles only the remaining no-speculation guard.

## Verification

- `python3 scripts/test-spec-acceptance.py -q` — 6 tests PASS
- `python3 -m py_compile scripts/spec-acceptance.py scripts/test-spec-acceptance.py` — PASS
- `bash scripts/ci-validate.sh` — PASS
- exact commit-range scope, secret, public-identifier, whitespace, and contributor-credit checks — PASS

## Limits

CPU-only change. No GPU, live serve, model-quality, throughput, or cluster claim.