### PR TITLE
docs(fabric): measured dual-HCA + MTU 9000 guidance for the NCCL passthrough

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -314,26 +314,41 @@ NCCL_NVLS_ENABLE=0
 # MEASURED (2026-08-21, two independent 2x GB10 TP=2 pairs, direct QSFP):
 # the GB10 QSFP port enumerates as TWO virtual NICs (2x PCIe Gen5 x4
 # controllers, ~100G each). With only one HCA in NCCL_IB_HCA the link runs
-# at half the port. Listing BOTH controllers (merging is NCCL's default):
+# at half the port. List both controllers with the deterministic exact-selector
+# form (merging is NCCL's default):
 #
-#   NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0        # map names: ibdev2netdev
+#   NCCL_IB_HCA==rocep1s0f0,roceP2p1s0f0       # map names: ibdev2netdev
 #
-# plus MTU 9000 on both interfaces (host netplan; RoCE derives its IB MTU
-# from the netdev MTU, so the stock 1500 caps frame size) measured, at
-# ~224K-token prompts, prefill 1311 -> 1343 tok/s from MTU alone and
-# -> 1410-1422 tok/s with both HCAs (+7.6-8.5% end-to-end). Decode was
-# unchanged on the same runs (latency-bound all-reduces; no GDR on GB10),
-# and the KV pool was unchanged — merged controllers are one logical NIC,
-# unlike unmerged dual-HCA channel splitting, which costs KV buffer memory
-# for ~nothing (+3% measured 2026-08-06). Do not expect nccl-tests busbw
-# deltas (+64% here) end-to-end: the all-reduce is a slice of prefill step
-# time. Prerequisites: both interfaces UP with IPs in distinct subnets;
+# On the measured direct-QSFP path, MTU 9000 was configured on both controller
+# interfaces at both endpoints. On switched or shared paths, use jumbo frames
+# only when every endpoint and intervening L2 hop is verified at the same MTU;
+# otherwise retain the existing path MTU. RoCE derives its IB MTU from the
+# netdev MTU, so the stock 1500 caps frame size.
+#
+# Pair 1 measured 1311 tok/s at MTU 1500 with one HCA, 1343 at MTU 9000
+# with one HCA, and 1410 with both HCAs: +7.6% end-to-end from its baseline.
+# Pair 2 reproduced a 1422 tok/s dual-HCA final rate but has no same-pair
+# single-HCA baseline, so it is not used to claim an uplift percentage.
+# Separate engine-counter probes found no material decode change on the
+# measured stack (code 76.0 tok/s at 73.3% acceptance; prose 37.3 at 25.7%;
+# 14-15 steps/s), and the KV pool was unchanged. That result is consistent
+# with latency-bound all-reduces; no GDR was observed on this measured stack.
+# Merged controllers are one logical NIC, unlike unmerged dual-HCA channel
+# splitting, which cost KV buffer memory for ~nothing (+3%, measured
+# 2026-08-06). Do not apply the nccl-tests busbw delta (+64% here) directly to
+# end-to-end throughput: the all-reduce is only a slice of prefill step time.
+#
+# Prerequisites: both interfaces UP with IPs in distinct subnets and
 # per-controller PCIe width x4 (check current_link_width in sysfs — early
-# BIOS wires the second controller x2); and until the multi-HCA GID
-# resolver fix lands (PR #95), pin the GID explicitly:
+# BIOS wires the second controller x2). Current main includes PR #95's
+# multi-HCA resolver: leave NCCL_IB_GID_AUTO=1 (the default) and verify startup
+# logs list every selected HCA/port plus one shared RoCE v2 index on each rank.
+# On revisions older than PR #95, the comma selector fails in auto mode; the
+# temporary fallback is an explicit pin, but only after confirming every
+# selected HCA/port exposes the same index as RoCE v2:
 #
 #   NCCL_IB_GID_AUTO=0
-#   NCCL_IB_GID_INDEX=3          # verify: gid_attrs/types/3 == "RoCE v2"
+#   NCCL_IB_GID_INDEX=3
 #   WORKER_NCCL_IB_GID_INDEX=3
 #
 # GPUDirect RDMA controls, passed through as upstream overrides. No effect was

--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -311,6 +311,31 @@ NCCL_NVLS_ENABLE=0
 # disable merging.
 # NCCL_IB_MERGE_NICS=0
 #
+# MEASURED (2026-08-21, two independent 2x GB10 TP=2 pairs, direct QSFP):
+# the GB10 QSFP port enumerates as TWO virtual NICs (2x PCIe Gen5 x4
+# controllers, ~100G each). With only one HCA in NCCL_IB_HCA the link runs
+# at half the port. Listing BOTH controllers (merging is NCCL's default):
+#
+#   NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0        # map names: ibdev2netdev
+#
+# plus MTU 9000 on both interfaces (host netplan; RoCE derives its IB MTU
+# from the netdev MTU, so the stock 1500 caps frame size) measured, at
+# ~224K-token prompts, prefill 1311 -> 1343 tok/s from MTU alone and
+# -> 1410-1422 tok/s with both HCAs (+7.6-8.5% end-to-end). Decode was
+# unchanged on the same runs (latency-bound all-reduces; no GDR on GB10),
+# and the KV pool was unchanged — merged controllers are one logical NIC,
+# unlike unmerged dual-HCA channel splitting, which costs KV buffer memory
+# for ~nothing (+3% measured 2026-08-06). Do not expect nccl-tests busbw
+# deltas (+64% here) end-to-end: the all-reduce is a slice of prefill step
+# time. Prerequisites: both interfaces UP with IPs in distinct subnets;
+# per-controller PCIe width x4 (check current_link_width in sysfs — early
+# BIOS wires the second controller x2); and until the multi-HCA GID
+# resolver fix lands (PR #95), pin the GID explicitly:
+#
+#   NCCL_IB_GID_AUTO=0
+#   NCCL_IB_GID_INDEX=3          # verify: gid_attrs/types/3 == "RoCE v2"
+#   WORKER_NCCL_IB_GID_INDEX=3
+#
 # GPUDirect RDMA controls, passed through as upstream overrides. No effect was
 # demonstrated on the stack this was submitted from. Contributor-reported
 # observation, that stack only: on GB10 driver 580.173.02 the container


### PR DESCRIPTION
PR #94 added the NCCL fabric passthrough with deliberately no tuning claim. This fills in the measurement, from two independent 2x GB10 TP=2 pairs (direct QSFP, no switch), so the knobs ship with evidence:

**Method.** ~224K-token fresh-random prompts, 3-4 reps per config, cluster drained from serving during probes, first rep discarded (cold-JIT). Decode checked separately via engine-counter probes (acceptance / tok-per-step / steps-per-s), NIAH at 262144 for correctness after each change.

| config | pair 1 | pair 2 |
|---|---|---|
| MTU 1500, single HCA | 1311 tok/s | — |
| MTU 9000, single HCA | 1343 tok/s | — |
| MTU 9000 + both controllers in NCCL_IB_HCA | **1410 tok/s** | **1422 tok/s** |

**Pair 1 prefill improved 7.6% end-to-end** (1311 → 1410 tok/s). Pair 2 reproduced a **1422 tok/s dual-HCA final rate** but has no same-pair single-HCA baseline, so it is not used for an uplift percentage. Separate engine-counter probes found no material decode change on the measured stack (code 76.0 tok/s @ 73.3% accept, prose 37.3 @ 25.7%, 14-15 steps/s); **KV pool unchanged**. Merged controllers are one logical NIC, unlike unmerged dual-HCA channel splitting, which cost KV buffer memory for ~nothing (+3%, measured 2026-08-06). nccl-tests busbw increased 64% on this stack, but all-reduce is only a slice of prefill step time, so that number is not an end-to-end throughput claim.

Operational prerequisites: use the deterministic exact selector (`NCCL_IB_HCA==dev0,dev1`), verify both controller links are PCIe x4 (early BIOS wires the second controller Gen5 x2), and use MTU 9000 only when both endpoints and every intervening L2 hop support it. These measurements used an explicit index-3 GID pin because the pre-fix multi-HCA resolver FATALed; that deployment field-validates #95's failure mode and older-revision workaround. PR #95 is now merged: current main should keep `NCCL_IB_GID_AUTO=1` and verify the startup member/index audit. The manual pin is fallback guidance for older revisions, not the current default.

All measurements from the pinned image (`3430d661`) at a462a9e.
