### PR TITLE
fix(scheduler): cache validated partial-prefill cap

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -195,11 +195,15 @@ LONG_PREFILL_TOKEN_THRESHOLD=1024
 # decode rate #43 reports. NOTE: --max-num-partial-prefills is NOT available
 # on dspark-vllm-gx10:0.1.1 — vLLM's _check_feature_supported() rejects
 # Concurrent Partial Prefill before engine init. Do NOT pass that flag.
-# The #27 hotfix instead reads DSPARK_MAX_INFLIGHT_PREFILLS (clamped 1-3).
-# Default 2: live 32K×c4 decode left the ~8 tok/s floor (~25 tok/s) with
-# #43 floor on and LONG_PREFILL_TOKEN_THRESHOLD=1024. Set 1 to restore the
-# original serialize-one-prefill gate. Image upgrade for real concurrent
-# partial prefill is issue #45.
+# The #27 hotfix instead reads DSPARK_MAX_INFLIGHT_PREFILLS once during
+# Scheduler construction. Values 1-3 are accepted; values above 3 clamp to 3.
+# Blank, whitespace-only, nonpositive, or malformed values fall back to
+# SchedulerConfig.max_num_partial_prefills (stock 1); malformed values warn
+# once instead of crashing admission. Default 2: live 32K×c4 decode left the
+# ~8 tok/s floor (~25 tok/s) with #43 floor on and
+# LONG_PREFILL_TOKEN_THRESHOLD=1024. Set 1 to restore the original
+# serialize-one-prefill gate. Image upgrade for real concurrent partial
+# prefill is issue #45.
 DSPARK_MAX_INFLIGHT_PREFILLS=2
 
 # Issue #43: bounded decode service during mixed prefill steps + scheduler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- **Malformed `DSPARK_MAX_INFLIGHT_PREFILLS` no longer crashes scheduler admission after startup ([Issue #105](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/105))**: the #27 hotfix previously converted the environment value with bare `int(...)` inside every waiting-admission iteration, so values such as `two`, `2.0`, `1x`, or whitespace raised `ValueError` only after traffic reached the waiting queue. Scheduler construction now parses and caches the cap once. Blank, nonpositive, or malformed values use `SchedulerConfig.max_num_partial_prefills`; malformed values emit one warning; values above 3 retain the existing clamp. The scheduling hot loop no longer reads process environment.
+
 - **Start normalizes BOM/CRLF env files and atomically publishes the worker copy ([PR #98](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/pull/98), reported and initially implemented by [@hecisaza](https://github.com/hecisaza))**: the operator file stays byte-identical while one private `0600` snapshot feeds the head, Compose, and worker. Worker credentials are staged privately and renamed atomically, so a failed transfer cannot expose or truncate the previous env file. The resolved-profile banner now reports the actual `MAX_NUM_SEQS=6` default.
 
 ## 2026-08-20

--- a/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
+++ b/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
@@ -16,15 +16,16 @@ grows with prompt length. (Issue #27.)
 Fix: at the top of the waiting-admission loop, break (don't admit a new
 prefill request) once the number of in-flight partial prefills has reached
 the cap. The cap is ``DSPARK_MAX_INFLIGHT_PREFILLS`` (1-3, default 2 via
-compose) because this image rejects ``--max-num-partial-prefills``; if that
-env is unset/0 the hotfix falls back to ``SchedulerConfig.max_num_partial_prefills``
-(stock 1). ``self._inflight_prefills`` is maintained by
-``_update_after_schedule`` (populated for requests still needing more prefill
-chunks, discarded when they finish prefilling), so it correctly reflects the
-currently-prefilling set. This restores the documented concurrency cap of 1
-by default, so at most one request prefill-chunks per step and decode lanes
-behind it in ``self.running`` always receive budget (chunk cap via
-``--long-prefill-token-threshold`` keeps that one chunk below
+compose) because this image rejects ``--max-num-partial-prefills``. It is
+parsed once during ``Scheduler`` construction; unset, blank, nonpositive, or
+malformed values fall back to ``SchedulerConfig.max_num_partial_prefills``
+(stock 1), and malformed values emit one warning. ``self._inflight_prefills``
+is maintained by ``_update_after_schedule`` (populated for requests still
+needing more prefill chunks, discarded when they finish prefilling), so it
+correctly reflects the currently-prefilling set. This restores the documented
+concurrency cap of 1 by default, so at most one request prefill-chunks per
+step and decode lanes behind it in ``self.running`` always receive budget
+(chunk cap via ``--long-prefill-token-threshold`` keeps that one chunk below
 ``max_num_batched_tokens`` leaving room for decode tokens).
 
 Idempotent: re-applying is a no-op once the marker is present.
@@ -48,14 +49,39 @@ if MARK in src:
     print(f"[issue27-hotfix] already applied to {P}")
     raise SystemExit(0)
 
-ANCHOR = (
+INIT_ANCHOR = (
+    "        # In-flight requests still prefilling (prefill chunks + in-progress\n"
+    "        # async KV loads). Their remaining-block reservation gates async loads.\n"
+    "        self._inflight_prefills: set[Request] = set()\n"
+)
+ADMISSION_ANCHOR = (
     "                num_running = len(self.running) + self.num_waiting_for_streaming_input\n"
     "                if num_running >= self.max_num_running_reqs:\n"
     "                    break\n"
 )
-assert ANCHOR in src, "admission guard anchor not found; refusing to patch"
+assert INIT_ANCHOR in src, "scheduler init anchor not found; refusing to patch"
+assert ADMISSION_ANCHOR in src, "admission guard anchor not found; refusing to patch"
 
-INJECT = ANCHOR + (
+INIT_INJECT = INIT_ANCHOR + (
+    "\n"
+    "        # [issue27-hotfix] parse the admission cap once, outside schedule().\n"
+    "        _pp_cap_raw = __import__('os').environ.get(\n"
+    "            'DSPARK_MAX_INFLIGHT_PREFILLS', ''\n"
+    "        ).strip()\n"
+    "        try:\n"
+    "            _pp_cap = int(_pp_cap_raw, 10) if _pp_cap_raw else 0\n"
+    "        except ValueError:\n"
+    "            logger.warning(\n"
+    "                'Invalid DSPARK_MAX_INFLIGHT_PREFILLS; using '\n"
+    "                'SchedulerConfig.max_num_partial_prefills'\n"
+    "            )\n"
+    "            _pp_cap = 0\n"
+    "        if _pp_cap <= 0:\n"
+    "            _pp_cap = self.scheduler_config.max_num_partial_prefills\n"
+    "        self._dspark_max_inflight_prefills = min(_pp_cap, 3)\n"
+)
+
+INJECT = ADMISSION_ANCHOR + (
     "\n"
     "                # [issue27-hotfix] enforce max_num_partial_prefills on admission.\n"
     "                # Upstream defines this field but the v1 scheduler never reads\n"
@@ -65,21 +91,16 @@ INJECT = ANCHOR + (
     "                # them get num_new_tokens==0 and are skipped (continue, not preempt)\n"
     "                # -> zero-preemption decode starvation (issue #27). _inflight_prefills\n"
     "                # is the set of running requests still needing prefill chunks.\n"
-    "                # DSPARK_MAX_INFLIGHT_PREFILLS (1-3) overrides the config field\n"
-    "                # because this image rejects --max-num-partial-prefills.\n"
-    "                _pp_cap = int((__import__('os').environ.get(\n"
-    "                    'DSPARK_MAX_INFLIGHT_PREFILLS') or '0') or 0)\n"
-    "                if _pp_cap <= 0:\n"
-    "                    _pp_cap = self.scheduler_config.max_num_partial_prefills\n"
-    "                if _pp_cap > 3:\n"
-    "                    _pp_cap = 3\n"
+    "                # DSPARK_MAX_INFLIGHT_PREFILLS is parsed and cached once\n"
+    "                # during Scheduler construction, never in this hot loop.\n"
     "                if (\n"
-    "                    _pp_cap > 0\n"
+    "                    self._dspark_max_inflight_prefills > 0\n"
     "                    and len(self._inflight_prefills)\n"
-    "                    >= _pp_cap\n"
+    "                    >= self._dspark_max_inflight_prefills\n"
     "                ):\n"
     "                    break\n"
 )
-src = src.replace(ANCHOR, INJECT, 1)
+src = src.replace(INIT_ANCHOR, INIT_INJECT, 1)
+src = src.replace(ADMISSION_ANCHOR, INJECT, 1)
 P.write_text(src)
 print(f"[issue27-hotfix] patched {P}")

--- a/tests/test_issue27_inflight_cap.py
+++ b/tests/test_issue27_inflight_cap.py
@@ -1,61 +1,154 @@
 #!/usr/bin/env python3
-"""The shipped #27 hotfix must honor DSPARK_MAX_INFLIGHT_PREFILLS (clamped 1–3)
-because this image rejects --max-num-partial-prefills. Applies the real hotfix
-entry point to a fixture copy of the admission-loop anchor.
-"""
+"""Behavioral tests for the #27 partial-prefill admission-cap hotfix."""
 from __future__ import annotations
 
+import contextlib
+import io
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 HOTFIX = ROOT / "patches" / "hotfix-dsv4-issue27-partial-prefill-concurrency.py"
+ENV_NAME = "DSPARK_MAX_INFLIGHT_PREFILLS"
 
-FIXTURE = (
-    "                num_running = len(self.running) + self.num_waiting_for_streaming_input\n"
-    "                if num_running >= self.max_num_running_reqs:\n"
-    "                    break\n"
-    "                leftover = True\n"
-)
+FIXTURE = """\
+class Request:
+    pass
+
+
+class _Logger:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+logger = _Logger()
+
+
+class Scheduler:
+    def __init__(self, config_cap=1):
+        self.scheduler_config = type(
+            "SchedulerConfig",
+            (),
+            {"max_num_partial_prefills": config_cap},
+        )()
+        self.max_num_running_reqs = 8
+        self.num_waiting_for_streaming_input = 0
+        self.running = []
+        self.waiting = [object()]
+
+        # In-flight requests still prefilling (prefill chunks + in-progress
+        # async KV loads). Their remaining-block reservation gates async loads.
+        self._inflight_prefills: set[Request] = set()
+
+    def schedule(self):
+        token_budget = 1
+        admitted = 0
+        can_schedule_waiting = True
+        if can_schedule_waiting:
+            while self.waiting and token_budget > 0:
+                num_running = len(self.running) + self.num_waiting_for_streaming_input
+                if num_running >= self.max_num_running_reqs:
+                    break
+
+                self.waiting.pop()
+                admitted += 1
+        return admitted
+"""
 
 
 def _apply_to(path: Path) -> None:
     txt = HOTFIX.read_text()
     marker = 'Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")'
     txt = txt.replace(marker, f"Path({str(path)!r})")
-    ns: dict = {}
-    exec(compile(txt, str(HOTFIX), "exec"), ns)
+    with contextlib.redirect_stdout(io.StringIO()):
+        try:
+            exec(compile(txt, str(HOTFIX), "exec"), {})
+        except SystemExit as exc:
+            if exc.code not in (None, 0):
+                raise
+
+
+def _load_scheduler(raw: str | None, config_cap: int = 1):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "scheduler.py"
+        path.write_text(FIXTURE)
+        _apply_to(path)
+        patched = path.read_text()
+
+    namespace: dict = {}
+    exec(compile(patched, str(path), "exec"), namespace)
+    with mock.patch.dict(os.environ, {}, clear=False):
+        if raw is None:
+            os.environ.pop(ENV_NAME, None)
+        else:
+            os.environ[ENV_NAME] = raw
+        scheduler = namespace["Scheduler"](config_cap)
+    return scheduler, namespace["logger"], patched
 
 
 class Issue27InflightCapTest(unittest.TestCase):
-    def test_hotfix_source_has_env_override(self):
-        src = HOTFIX.read_text()
-        self.assertIn("DSPARK_MAX_INFLIGHT_PREFILLS", src)
-        self.assertIn("if _pp_cap > 3:", src)
-        env_at = src.find("'DSPARK_MAX_INFLIGHT_PREFILLS'")
-        # fallback to SchedulerConfig still present after the env read
-        self.assertIn("self.scheduler_config.max_num_partial_prefills", src)
-        self.assertGreater(env_at, 0)
+    def test_valid_and_fallback_values_are_cached(self):
+        cases = (
+            (None, 1),
+            ("", 1),
+            ("   ", 1),
+            ("0", 1),
+            ("-1", 1),
+            ("1", 1),
+            ("2", 2),
+            ("3", 3),
+            ("4", 3),
+            (" 2 ", 2),
+        )
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                scheduler, logger, _ = _load_scheduler(raw)
+                self.assertEqual(
+                    scheduler._dspark_max_inflight_prefills,
+                    expected,
+                )
+                self.assertEqual(logger.warnings, [])
 
-    def test_apply_injects_env_cap_into_admission_loop(self):
-        tmp = Path(tempfile.mkdtemp()) / "scheduler.py"
-        tmp.write_text(FIXTURE)
-        try:
-            _apply_to(tmp)
-        except SystemExit as e:
-            self.assertEqual(e.code, 0)
-        patched = tmp.read_text()
-        self.assertIn("# [issue27-hotfix]", patched)
-        self.assertIn("DSPARK_MAX_INFLIGHT_PREFILLS", patched)
-        self.assertIn("_pp_cap", patched)
-        self.assertIn("len(self._inflight_prefills)", patched)
-        try:
-            _apply_to(tmp)
-        except SystemExit as e:
-            self.assertEqual(e.code, 0)
-        self.assertEqual(patched, tmp.read_text())
+    def test_malformed_values_warn_and_use_config_fallback(self):
+        for raw in ("two", "2.0", "1x"):
+            with self.subTest(raw=raw):
+                scheduler, logger, _ = _load_scheduler(raw, config_cap=2)
+                self.assertEqual(scheduler._dspark_max_inflight_prefills, 2)
+                self.assertEqual(len(logger.warnings), 1)
+                self.assertIn(ENV_NAME, logger.warnings[0])
+
+    def test_config_fallback_is_also_clamped(self):
+        scheduler, _, _ = _load_scheduler(None, config_cap=4)
+        self.assertEqual(scheduler._dspark_max_inflight_prefills, 3)
+
+    def test_schedule_uses_cached_cap_without_rereading_environment(self):
+        scheduler, _, _ = _load_scheduler("2")
+        inflight = object()
+        scheduler._inflight_prefills.add(inflight)
+        with mock.patch.dict(os.environ, {ENV_NAME: "two"}):
+            self.assertEqual(scheduler.schedule(), 1)
+        self.assertIn(inflight, scheduler._inflight_prefills)
+
+    def test_admission_stops_at_cached_cap(self):
+        scheduler, _, _ = _load_scheduler("1")
+        scheduler._inflight_prefills.add(object())
+        self.assertEqual(scheduler.schedule(), 0)
+
+    def test_apply_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "scheduler.py"
+            path.write_text(FIXTURE)
+            _apply_to(path)
+            patched = path.read_text()
+            _apply_to(path)
+            self.assertEqual(path.read_text(), patched)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #105.

## Problem

The #27 hotfix parsed `DSPARK_MAX_INFLIGHT_PREFILLS` with bare `int(...)` inside every `Scheduler.schedule()` waiting-admission iteration. Malformed values survived startup, then raised `ValueError` when traffic reached the waiting queue. Restarting preserved the malformed environment value.

## Fix

- Parse once during `Scheduler` construction and cache `_dspark_max_inflight_prefills`.
- Preserve existing semantics: blank/nonpositive values use `SchedulerConfig.max_num_partial_prefills`; values above 3 clamp to 3.
- Malformed values warn once and use the scheduler-config fallback.
- Remove all environment reads and conversions from the scheduling hot loop.
- Replace source-string assertions with behavioral parser, fallback, clamp, admission, cache, and idempotence coverage.
- Document the operator-visible fallback.

## Verification

- `python3 tests/test_issue27_inflight_cap.py -q` — 6/6 pass.
- `bash scripts/ci-validate.sh` — pass, including 23/23 atomic-hotfix tests, 72/72 NCCL selector tests, and all CPU recipe gates.
- Exact pinned image `ghcr.io/anemll/dspark-vllm-gx10:0.1.1`: applied Issue #27 then Issue #43 hotfixes, compiled the resulting scheduler, and verified one cached-cap assignment with no environment read/conversion in `schedule()`.
- `git diff --check origin/main` — pass.
- Changed-file secret-pattern scan — no matches.

## Live validation status

Not run yet. The local TP=2 model is currently in use and was not restarted or otherwise touched. Keep this PR draft until a controlled malformed-value boot and restoration can be performed without interrupting that workload.

## Scope

No Compose default or scheduling policy change. Default `DSPARK_MAX_INFLIGHT_PREFILLS=2` remains unchanged. This does not address the separate non-fail-closed semicolon chain for default-on Python patchers.