### PR TITLE
fix: remove phantom encoder output tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Default-on Python source hotfixes now fail closed before `vllm serve` ([Issue #107](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/107))**: the encoding copy/reasoning-map rewrite and Issue #21, #55, #27, #43, #26, and suppress-stops patchers were separated by bare semicolons, so a missing file, anchor drift, assertion, or self-check failure could be masked by a later successful command and startup continued with stale runtime code. Every enabled step now propagates failure explicitly with `|| exit 1`, and Issue #21 anchor drift plus a missing suppress-stops target now return nonzero; the existing missing-encoding warning and all enable/skip switches retain their prior behavior. CPU failure injection covers every step, ordering, optional Issue #31, and the suppress-stops skip path.
 
+### Fixed
+
+- **Encoder-only EC producer steps no longer emit phantom token ID 0 or loop after encoding ([Issue #109](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/109))**: `make_empty_encoder_model_runner_output` now returns one distinct empty token row per scheduled request, so the scheduler cannot append token 0, advance grammar/stop state, count fake output, or distort speculative-decoding accounting when the encoder producer sampled nothing. The paired scheduler branch stops an encoder-only request once all prompt tokens are consumed, avoiding an empty-output loop. Both source overlays implement the paired semantics from [vLLM upstream commit `7ca49fb`](https://github.com/vllm-project/vllm/commit/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6); one fail-closed, idempotent startup patch applies both corrections to pinned image `ghcr.io/anemll/dspark-vllm-gx10:0.1.1` and is synchronized to the worker.
+
 ## 2026-08-21
 
 ### Added

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -33,6 +33,8 @@ services:
       # Issue #55 tool-call truncation safety: finish_reason=length + drop
       # non-JSON-parseable args when max_tokens cuts a tool call mid-flight.
       - ${DSPARK_ISSUE55_HOTFIX:-./patches/hotfix-dsv4-issue55-tool-truncation.py}:/opt/hotfix-dsv4-issue55-tool-truncation.py:ro
+      # Issue #109: encoder-only EC producer steps must not emit phantom token 0.
+      - ${DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX:-./patches/hotfix-vllm-empty-encoder-output.py}:/opt/hotfix-vllm-empty-encoder-output.py:ro
       # Issue #27 partial-prefill concurrency hotfix (enforce max_num_partial_prefills).
       - ${DSPARK_ISSUE27_HOTFIX:-./patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py}:/opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py:ro
       # Issue #43 bounded decode service during mixed prefill steps + scheduler diag.
@@ -220,7 +222,7 @@ services:
         if [ "$${DSPARK_SKIP_SPIN_WAIT_HOTFIX:-0}" != "1" ]; then if [ ! -f /opt/dspark-patches/hotfix-gb10-spin-wait.sh ]; then echo "FATAL: /opt/dspark-patches/hotfix-gb10-spin-wait.sh missing" >&2; exit 1; fi; bash /opt/dspark-patches/hotfix-gb10-spin-wait.sh || exit 1; fi;
         if [ "$${DSPARK_SKIP_HOTFIX:-0}" != "1" ]; then for _hf in hotfix-dsv4-mtp-buffer-50312.sh hotfix-dsv4-adaptive-topk-50004.sh hotfix-dsv4-skip-topk-49486.sh hotfix-dsv4-dense-prefill-indexer-48407.sh hotfix-dsv4-skip-empty-c128-48957.sh hotfix-dsv4-flashmla-workspace-50298.sh hotfix-dsv4-grammar-advance.sh; do if [ ! -f /opt/dspark-patches/$${_hf} ]; then echo "FATAL: /opt/dspark-patches/$${_hf} missing" >&2; exit 1; fi; bash /opt/dspark-patches/$${_hf} || exit 1; done; fi;
         if [ "$${_dspark_keys_set}" = "1" ] || [ -n "$${VLLM_API_KEY:-}" ]; then bash /opt/dspark-patches/hotfix-vllm-redact-api-key-log.sh || exit 1; bash /opt/dspark-patches/hotfix-vllm-redact-api-key-log.sh --status || exit 1; fi;
-        python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py || exit 1; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py || exit 1; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py || exit 1; fi; VLLM_QUANTIZATION_ARGS="";
+        python3 /opt/hotfix-vllm-empty-encoder-output.py || exit 1; python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py || exit 1; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py || exit 1; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py || exit 1; fi; VLLM_QUANTIZATION_ARGS="";
         if [ "$${DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX:-0}" = "1" ]; then python3 /opt/hotfix-dsv4-assistant-final-continuation.py || exit 1; fi;
         if [ "$${ENABLE_VLLM_GB10_PATCH:-0}" = "1" ]; then
           python3 -m pip install -e /opt/vllm-gb10-hybrid-nvfp4 --no-deps;

--- a/patches/hotfix-vllm-empty-encoder-output.py
+++ b/patches/hotfix-vllm-empty-encoder-output.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Backport complete encoder-only EC producer output semantics.
+
+The pinned Anemll runtime image fabricates token 0 when an encoder producer
+sampled nothing, and its scheduler lacks the paired encoder-only completion
+branch. Upstream vLLM commit 7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6
+returns one empty row per request and finishes an encoder-only request once its
+prompt is consumed. This startup patch applies both changes to the pinned image.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable
+
+DEFAULT_OUTPUTS_TARGET = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/outputs.py"
+)
+DEFAULT_SCHEDULER_TARGET = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py"
+)
+OUTPUT_OLD_LINE = (
+    "    sampled_token_ids: list[list[int]] = [[0] for _ in req_ids]\n"
+)
+OUTPUT_NEW_LINE = (
+    "    sampled_token_ids: list[list[int]] = [[] for _ in req_ids]\n"
+)
+SCHEDULER_OLD_FLAGS = (
+    "        self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder\n"
+    "\n"
+)
+SCHEDULER_NEW_FLAGS = (
+    "        self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder\n"
+    "        mm_config = vllm_config.model_config.multimodal_config\n"
+    "        self.is_mm_encoder_only = bool(mm_config and mm_config.mm_encoder_only)\n"
+    "\n"
+)
+SCHEDULER_OLD_STOP = (
+    "            elif request.pooling_params and pooler_output is not None:\n"
+    "                # Pooling stops as soon as there is output.\n"
+    "                request.status = RequestStatus.FINISHED_STOPPED\n"
+    "                stopped = True\n"
+    "\n"
+)
+SCHEDULER_NEW_STOP = (
+    "            elif request.pooling_params and pooler_output is not None:\n"
+    "                # Pooling stops as soon as there is output.\n"
+    "                request.status = RequestStatus.FINISHED_STOPPED\n"
+    "                stopped = True\n"
+    "            elif (\n"
+    "                self.is_mm_encoder_only\n"
+    "                and request.num_computed_tokens >= request.num_prompt_tokens\n"
+    "            ):\n"
+    "                # An encoder instance publishes embeddings instead of sampling.\n"
+    "                # Once its prompt is consumed, every encoder item has run.\n"
+    "                request.status = RequestStatus.FINISHED_STOPPED\n"
+    "                stopped = True\n"
+    "\n"
+)
+PatchText = Callable[[str], tuple[str, str]]
+
+
+def patch_outputs_text(source: str) -> tuple[str, str]:
+    """Return updated outputs.py source and applied/skipped/drift status."""
+    old_count = source.count(OUTPUT_OLD_LINE)
+    new_count = source.count(OUTPUT_NEW_LINE)
+    if old_count == 1 and new_count == 0:
+        updated = source.replace(OUTPUT_OLD_LINE, OUTPUT_NEW_LINE, 1)
+        compile(updated, "outputs.py", "exec")
+        return updated, "applied"
+    if old_count == 0 and new_count == 1:
+        return source, "skipped"
+    return source, f"drift:old={old_count},new={new_count}"
+
+
+def patch_scheduler_text(source: str) -> tuple[str, str]:
+    """Return updated scheduler.py source and applied/skipped/drift status."""
+    old_counts = (
+        source.count(SCHEDULER_OLD_FLAGS),
+        source.count(SCHEDULER_OLD_STOP),
+    )
+    new_counts = (
+        source.count(SCHEDULER_NEW_FLAGS),
+        source.count(SCHEDULER_NEW_STOP),
+    )
+    if old_counts == (1, 1) and new_counts == (0, 0):
+        updated = source.replace(SCHEDULER_OLD_FLAGS, SCHEDULER_NEW_FLAGS, 1)
+        updated = updated.replace(SCHEDULER_OLD_STOP, SCHEDULER_NEW_STOP, 1)
+        compile(updated, "scheduler.py", "exec")
+        return updated, "applied"
+    if old_counts == (0, 0) and new_counts == (1, 1):
+        return source, "skipped"
+    return source, f"drift:old={old_counts},new={new_counts}"
+
+
+def _prepare(path: Path, patch_text: PatchText) -> tuple[str, str]:
+    return patch_text(path.read_text(encoding="utf-8"))
+
+
+def patch_files(outputs_path: Path, scheduler_path: Path) -> tuple[str, str]:
+    """Preflight both files, then write only when neither source has drifted."""
+    outputs_source = outputs_path.read_text(encoding="utf-8")
+    scheduler_source = scheduler_path.read_text(encoding="utf-8")
+    outputs_updated, outputs_status = patch_outputs_text(outputs_source)
+    scheduler_updated, scheduler_status = patch_scheduler_text(scheduler_source)
+    valid = {"applied", "skipped"}
+    if outputs_status not in valid or scheduler_status not in valid:
+        return outputs_status, scheduler_status
+    if outputs_status == "applied":
+        outputs_path.write_text(outputs_updated, encoding="utf-8")
+    if scheduler_status == "applied":
+        scheduler_path.write_text(scheduler_updated, encoding="utf-8")
+    return outputs_status, scheduler_status
+
+
+def _targets(argv: list[str], offset: int) -> tuple[Path, Path] | None:
+    remaining = argv[offset:]
+    if not remaining:
+        return DEFAULT_OUTPUTS_TARGET, DEFAULT_SCHEDULER_TARGET
+    if len(remaining) == 2:
+        return Path(remaining[0]), Path(remaining[1])
+    return None
+
+
+def main(argv: list[str]) -> int:
+    status_only = len(argv) > 1 and argv[1] == "--status"
+    targets = _targets(argv, 2 if status_only else 1)
+    if targets is None:
+        print(f"usage: {argv[0]} [--status] [OUTPUTS.py SCHEDULER.py]", file=sys.stderr)
+        return 2
+    outputs_path, scheduler_path = targets
+    missing = [str(path) for path in targets if not path.is_file()]
+    if missing:
+        print(
+            f"[empty-encoder-output] missing target(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if status_only:
+        _, outputs_status = _prepare(outputs_path, patch_outputs_text)
+        _, scheduler_status = _prepare(scheduler_path, patch_scheduler_text)
+        applied = outputs_status == scheduler_status == "skipped"
+        label = (
+            "APPLIED"
+            if applied
+            else f"NOT APPLIED (outputs={outputs_status}, scheduler={scheduler_status})"
+        )
+        print("empty encoder output semantics    :", label)
+        return 0 if applied else 1
+
+    outputs_status, scheduler_status = patch_files(outputs_path, scheduler_path)
+    if outputs_status in {"applied", "skipped"} and scheduler_status in {
+        "applied",
+        "skipped",
+    }:
+        print(
+            "[empty-encoder-output] "
+            f"outputs={outputs_status}, scheduler={scheduler_status}"
+        )
+        return 0
+    print(
+        "[empty-encoder-output] source drift; refusing to patch "
+        f"(outputs={outputs_status}, scheduler={scheduler_status})",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/recipe/overlay/vllm/v1/core/sched/scheduler.py
+++ b/recipe/overlay/vllm/v1/core/sched/scheduler.py
@@ -89,6 +89,8 @@ class Scheduler(SchedulerInterface):
             )
         self.structured_output_manager = structured_output_manager
         self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
+        mm_config = vllm_config.model_config.multimodal_config
+        self.is_mm_encoder_only = bool(mm_config and mm_config.mm_encoder_only)
 
         # include_finished_set controls whether a separate set of finished
         # request ids should be included in the EngineCoreOutputs returned
@@ -1411,6 +1413,14 @@ class Scheduler(SchedulerInterface):
                 )
             elif request.pooling_params and pooler_output is not None:
                 # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+            elif (
+                self.is_mm_encoder_only
+                and request.num_computed_tokens >= request.num_prompt_tokens
+            ):
+                # An encoder instance publishes embeddings instead of sampling.
+                # Once its prompt is consumed, every encoder item has run.
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 

--- a/recipe/overlay/vllm/v1/outputs.py
+++ b/recipe/overlay/vllm/v1/outputs.py
@@ -323,7 +323,7 @@ def make_empty_encoder_model_runner_output(
     req_id_to_index: dict[str, int] = {rid: idx for idx, rid in enumerate(req_ids)}
 
     # No tokens generated yet ⇒ one empty list per request
-    sampled_token_ids: list[list[int]] = [[0] for _ in req_ids]
+    sampled_token_ids: list[list[int]] = [[] for _ in req_ids]
 
     # Pooler outputs are not available yet ⇒ use None placeholders
     pooler_output: list[torch.Tensor | None] = [None for _ in req_ids]

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -48,6 +48,7 @@ py_files+=(
   scripts/test-redact-api-key-log.py
   scripts/test-hotfix-atomic-transaction.py
   scripts/test-python-hotfix-failclosed.py
+  scripts/test-empty-encoder-output-hotfix.py
   scripts/ruler-lite.py
   scripts/verify-dsv4-027-equality-gate.py
 )
@@ -83,6 +84,8 @@ python3 scripts/test-hotfix-atomic-transaction.py -q
 ok "test-hotfix-atomic-transaction"
 python3 scripts/test-python-hotfix-failclosed.py -q
 ok "test-python-hotfix-failclosed"
+python3 scripts/test-empty-encoder-output-hotfix.py -q
+ok "test-empty-encoder-output-hotfix"
 python3 tests/test_issue27_inflight_cap.py -q
 ok "test_issue27_inflight_cap"
 python3 scripts/verify-dsv4-027-equality-gate.py
@@ -181,6 +184,13 @@ if grep -q 'hotfix-dsv4-issue55-tool-truncation.py' docker-compose.dspark.yml \
 else
   bad "compose must apply issue #55 with || exit 1"
 fi
+if grep -Fq 'hotfix-vllm-empty-encoder-output.py}:/opt/hotfix-vllm-empty-encoder-output.py:ro' docker-compose.dspark.yml \
+  && grep -Fq 'python3 /opt/hotfix-vllm-empty-encoder-output.py || exit 1' docker-compose.dspark.yml \
+  && grep -Fq 'scp "$DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-vllm-empty-encoder-output.py"' start-deepseek-v4-flash-dspark.sh; then
+  ok "empty encoder output hotfix is mounted, fail-closed, and worker-synced"
+else
+  bad "empty encoder output hotfix wiring is incomplete"
+fi
 # Assistant-final continuation (#52/PR53): default OFF (stock renderer);
 # ON must be an exactly-1 gate with a fail-closed invocation.
 if grep -Fq 'DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX: "${DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX:-0}"' docker-compose.dspark.yml \
@@ -215,6 +225,7 @@ for p in \
   patches/hotfix-dsv4-issue55-tool-truncation.py \
   patches/hotfix-dsv4-issue26-hybrid-swa-min.py \
   patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py \
+  patches/hotfix-vllm-empty-encoder-output.py \
   patches/hotfix-nvfp4-ds-mla-issue22.sh \
   patches/hotfix-gb10-spin-wait.sh \
   patches/hotfix-dsv4-suppress-stops-in-reasoning.py \

--- a/scripts/test-empty-encoder-output-hotfix.py
+++ b/scripts/test-empty-encoder-output-hotfix.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""CPU regression tests for complete encoder-only output semantics."""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+HOTFIX = ROOT / "patches" / "hotfix-vllm-empty-encoder-output.py"
+OVERLAY_OUTPUTS = ROOT / "recipe" / "overlay" / "vllm" / "v1" / "outputs.py"
+OVERLAY_SCHEDULER = (
+    ROOT / "recipe" / "overlay" / "vllm" / "v1" / "core" / "sched" / "scheduler.py"
+)
+
+OUTPUTS_FIXTURE = '''def make_empty_encoder_model_runner_output(req_ids):
+    # No tokens generated yet ⇒ one empty list per request
+    sampled_token_ids: list[list[int]] = [[0] for _ in req_ids]
+    return sampled_token_ids
+'''
+
+SCHEDULER_FIXTURE = '''class RequestStatus:
+    FINISHED_STOPPED = "finished"
+
+class Scheduler:
+    def __init__(self, vllm_config):
+        self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
+
+    def _update_request_with_output(self, request, new_token_ids):
+        raise AssertionError("encoder-only requests must not sample")
+
+    def finish(self, request, new_token_ids, pooler_output=None):
+        stopped = False
+        for _ in [None]:
+            if new_token_ids:
+                new_token_ids, stopped = self._update_request_with_output(
+                    request, new_token_ids
+                )
+            elif request.pooling_params and pooler_output is not None:
+                # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
+        return stopped
+'''
+
+
+def _load_hotfix():
+    spec = importlib.util.spec_from_file_location("empty_encoder_output_hotfix", HOTFIX)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rows(source: str, req_ids: list[str]) -> list[list[int]]:
+    namespace: dict[str, object] = {}
+    exec(source, namespace)
+    make_output = namespace["make_empty_encoder_model_runner_output"]
+    return make_output(req_ids)
+
+
+def _scheduler(source: str, *, encoder_only: bool):
+    namespace: dict[str, object] = {}
+    exec(source, namespace)
+    model_config = SimpleNamespace(
+        is_encoder_decoder=False,
+        multimodal_config=SimpleNamespace(mm_encoder_only=encoder_only),
+    )
+    return namespace["Scheduler"](SimpleNamespace(model_config=model_config))
+
+
+class EmptyEncoderOutputHotfixTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.hotfix = _load_hotfix()
+
+    def test_patch_removes_phantom_tokens_and_keeps_distinct_rows(self):
+        self.assertEqual(_rows(OUTPUTS_FIXTURE, ["a", "b"]), [[0], [0]])
+        updated, status = self.hotfix.patch_outputs_text(OUTPUTS_FIXTURE)
+        self.assertEqual(status, "applied")
+        rows = _rows(updated, ["a", "b"])
+        self.assertEqual(rows, [[], []])
+        self.assertIsNot(rows[0], rows[1])
+
+    def test_encoder_only_request_finishes_when_prompt_is_consumed(self):
+        updated, status = self.hotfix.patch_scheduler_text(SCHEDULER_FIXTURE)
+        self.assertEqual(status, "applied")
+        scheduler = _scheduler(updated, encoder_only=True)
+        request = SimpleNamespace(
+            pooling_params=None,
+            num_computed_tokens=16,
+            num_prompt_tokens=16,
+            status="running",
+        )
+        self.assertTrue(scheduler.finish(request, []))
+        self.assertEqual(request.status, "finished")
+
+    def test_encoder_only_request_does_not_finish_early(self):
+        updated, _ = self.hotfix.patch_scheduler_text(SCHEDULER_FIXTURE)
+        scheduler = _scheduler(updated, encoder_only=True)
+        request = SimpleNamespace(
+            pooling_params=None,
+            num_computed_tokens=15,
+            num_prompt_tokens=16,
+            status="running",
+        )
+        self.assertFalse(scheduler.finish(request, []))
+        self.assertEqual(request.status, "running")
+
+    def test_non_encoder_model_does_not_take_completion_branch(self):
+        updated, _ = self.hotfix.patch_scheduler_text(SCHEDULER_FIXTURE)
+        scheduler = _scheduler(updated, encoder_only=False)
+        request = SimpleNamespace(
+            pooling_params=None,
+            num_computed_tokens=16,
+            num_prompt_tokens=16,
+            status="running",
+        )
+        self.assertFalse(scheduler.finish(request, []))
+        self.assertEqual(request.status, "running")
+
+    def test_patch_is_idempotent(self):
+        outputs, outputs_status = self.hotfix.patch_outputs_text(OUTPUTS_FIXTURE)
+        scheduler, scheduler_status = self.hotfix.patch_scheduler_text(SCHEDULER_FIXTURE)
+        self.assertEqual((outputs_status, scheduler_status), ("applied", "applied"))
+        outputs_again, outputs_second = self.hotfix.patch_outputs_text(outputs)
+        scheduler_again, scheduler_second = self.hotfix.patch_scheduler_text(scheduler)
+        self.assertEqual((outputs_second, scheduler_second), ("skipped", "skipped"))
+        self.assertEqual((outputs_again, scheduler_again), (outputs, scheduler))
+
+    def test_source_drift_fails_before_mutating_either_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outputs = Path(tmp) / "outputs.py"
+            scheduler = Path(tmp) / "scheduler.py"
+            outputs.write_text(OUTPUTS_FIXTURE, encoding="utf-8")
+            scheduler.write_text("# incompatible scheduler\n", encoding="utf-8")
+            self.assertEqual(
+                self.hotfix.main(["hotfix", str(outputs), str(scheduler)]),
+                1,
+            )
+            self.assertEqual(outputs.read_text(encoding="utf-8"), OUTPUTS_FIXTURE)
+            self.assertEqual(
+                scheduler.read_text(encoding="utf-8"),
+                "# incompatible scheduler\n",
+            )
+
+    def test_missing_target_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outputs = Path(tmp) / "outputs.py"
+            scheduler = Path(tmp) / "missing.py"
+            outputs.write_text(OUTPUTS_FIXTURE, encoding="utf-8")
+            self.assertEqual(
+                self.hotfix.main(["hotfix", str(outputs), str(scheduler)]),
+                1,
+            )
+
+    def test_file_application_and_second_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outputs = Path(tmp) / "outputs.py"
+            scheduler = Path(tmp) / "scheduler.py"
+            outputs.write_text(OUTPUTS_FIXTURE, encoding="utf-8")
+            scheduler.write_text(SCHEDULER_FIXTURE, encoding="utf-8")
+            argv = ["hotfix", str(outputs), str(scheduler)]
+            self.assertEqual(self.hotfix.main(argv), 0)
+            first = (outputs.read_text(), scheduler.read_text())
+            self.assertEqual(_rows(first[0], ["a"]), [[]])
+            self.assertTrue("self.is_mm_encoder_only" in first[1])
+            self.assertEqual(self.hotfix.main(argv), 0)
+            self.assertEqual((outputs.read_text(), scheduler.read_text()), first)
+
+    def test_repository_overlays_already_have_upstream_shape(self):
+        outputs_source = OVERLAY_OUTPUTS.read_text(encoding="utf-8")
+        scheduler_source = OVERLAY_SCHEDULER.read_text(encoding="utf-8")
+        outputs_unchanged, outputs_status = self.hotfix.patch_outputs_text(outputs_source)
+        scheduler_unchanged, scheduler_status = self.hotfix.patch_scheduler_text(
+            scheduler_source
+        )
+        self.assertEqual((outputs_status, scheduler_status), ("skipped", "skipped"))
+        self.assertEqual(outputs_unchanged, outputs_source)
+        self.assertEqual(scheduler_unchanged, scheduler_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-python-hotfix-failclosed.py
+++ b/scripts/test-python-hotfix-failclosed.py
@@ -190,6 +190,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
         self.assertEqual(
             invocations,
             [
+                "hotfix-vllm-empty-encoder-output.py",
                 "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
                 "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
                 "hotfix-dsv4-issue26-hybrid-swa-min.py",
@@ -200,6 +201,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
 
     def test_each_runtime_patcher_failure_blocks_later_steps_and_service_exec(self):
         order = [
+            "hotfix-vllm-empty-encoder-output.py",
             "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
             "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
             "hotfix-dsv4-issue26-hybrid-swa-min.py",
@@ -224,6 +226,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
         self.assertEqual(
             invocations,
             [
+                "hotfix-vllm-empty-encoder-output.py",
                 "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
                 "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
                 "hotfix-dsv4-issue26-hybrid-swa-min.py",

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -977,6 +977,12 @@ if [ -f "$DSPARK_ISSUE55_HOTFIX" ]; then
   ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
   scp "$DSPARK_ISSUE55_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue55-tool-truncation.py"
 fi
+DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX="${DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX:-$SCRIPT_DIR/patches/hotfix-vllm-empty-encoder-output.py}"
+if [ -f "$DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX" ]; then
+  echo "Syncing Issue #109 empty-encoder-output hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"
+  ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
+  scp "$DSPARK_EMPTY_ENCODER_OUTPUT_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-vllm-empty-encoder-output.py"
+fi
 DSPARK_ISSUE27_HOTFIX="${DSPARK_ISSUE27_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py}"
 if [ -f "$DSPARK_ISSUE27_HOTFIX" ]; then
   echo "Syncing Issue #27 partial-prefill hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"


### PR DESCRIPTION
Closes #109.

Depends on merged prerequisite #108, which made default-on Python source patchers fail closed before `vllm serve`.

## Built
- return one distinct empty sampled-token row per scheduled request on encoder-only EC producer steps instead of fabricating token ID 0
- add the paired encoder-only completion branch: stop once every prompt token is consumed, avoiding an empty-output loop
- apply both corrections in the source overlays
- add one exact-anchor, idempotent, drift-refusing two-file patcher for pinned image `ghcr.io/anemll/dspark-vllm-gx10:0.1.1`
- mount and invoke the patcher first with `|| exit 1`; synchronize it to the worker
- add CPU behavior, not-early, non-encoder, idempotence, all-or-none drift, overlay parity, and real-Compose failure-injection coverage
- document provenance from vLLM commit `7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6`

## Verification
- `python3 scripts/test-empty-encoder-output-hotfix.py -q` — 9/9
- `python3 scripts/test-python-hotfix-failclosed.py -q` — 8/8; the new patcher failure blocks all later patchers and service exec
- exact pinned-image ephemeral composition — first run applies both files, second run is idempotent, empty rows + completion branch present, phantom rows absent
- `docker compose -f docker-compose.dspark.yml config --quiet`
- `bash scripts/ci-validate.sh` on exact commit `ebe4ca2`
- `git diff --check origin/main`
- changed-file secret scan: no matches
- FREN parallel semantic review found the phantom-token consumer effects and supported the empty-row correction; one provisional FREN test note was discarded because it incorrectly proposed pinning the buggy `[0]` contract
- independent Fable round-2 review: PASS, no BLOCKER/HIGH/MEDIUM; its substantive round-1 completion-gap finding was implemented and re-reviewed
- final parent diff review: PASS

## Deviated
- Expanded the initial one-line correction with upstream's paired encoder-only completion branch. Empty rows alone would leave completed encoder requests producing empty steps indefinitely.

## Skipped
- Live EC-transfer/encoder-only serve validation: the shipped DeepSeek profile does not enable EC transfer, and the active TP=2 model was intentionally not restarted or touched.

## Honest gaps
- Draft remains blocked on a controlled encoder-only/EC-transfer runtime validation environment. Hosted feature-branch CI pending.