### PR TITLE
feat(compose): add worker-safe healthcheck to vllm-dspark

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -11,6 +11,18 @@ services:
     restart: ${DSPARK_RESTART_POLICY:-unless-stopped}
     stop_grace_period: ${DSPARK_STOP_GRACE:-10s}
 
+    # Only rank 0 serves HTTP; the worker runs HEADLESS with no :8888 listener.
+    # Gate on $HEADLESS so the worker is not marked unhealthy forever. $$HEADLESS
+    # (double) is evaluated in the container at runtime; ${VLLM_PORT:-8888} is
+    # resolved by Compose. start_period covers cold model load (~6 min measured;
+    # raise it if your storage is slower).
+    healthcheck:
+      test: ["CMD-SHELL", "if [ -n \"$$HEADLESS\" ]; then exit 0; fi; curl -fsS http://127.0.0.1:${VLLM_PORT:-8888}/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 480s
+
     ulimits:
       memlock: -1
       stack: 67108864

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -254,4 +254,13 @@ if [ "$fail" -ne 0 ]; then
   echo "CI validate FAILED" >&2
   exit 1
 fi
+
+# Healthcheck present and worker-gated (rank 1 is headless; must not false-unhealthy)
+if grep -q "healthcheck:" docker-compose.dspark.yml \
+  && grep -qF 'if [ -n \"$$HEADLESS\" ]' docker-compose.dspark.yml; then
+  ok "compose healthcheck present and HEADLESS-gated"
+else
+  bad "compose healthcheck missing or not HEADLESS-gated"
+fi
+
 echo "CI validate passed (CPU recipe gates only)."


### PR DESCRIPTION
## What

Adds a `healthcheck` to the `vllm-dspark` service so Docker reports real serving status instead of only process Up/Down.

## Why

The compose has no healthcheck today — `docker ps` shows `Up` even if vLLM never finished loading or has stopped serving. The only readiness signal is an out-of-band `curl`.

## Worker-safe by design

The same compose runs on both ranks, but only rank 0 serves HTTP; the worker is `HEADLESS=1` with no `:8888` listener. An ungated `curl :8888/health` marks the worker **permanently unhealthy**. The `if [ -n "$HEADLESS" ]` gate skips the probe on headless ranks. `$$HEADLESS` (double) is evaluated in the container at runtime; `${VLLM_PORT:-8888}` is resolved by Compose.

## Validated on real hardware

2× DGX Spark (GB10), image `anemll/dspark-vllm-gx10:0.1.1`, TP=2. Same worker, only the healthcheck differed:

| healthcheck | real worker (rank 1) |
|---|---|
| ungated `curl /health` | **unhealthy** — `Failed to connect to 127.0.0.1 port 8888` |
| gated (this PR) | **healthy**; head reports real status, serves normally |

Head reaches `healthy` ~6 min after start (first `/health` 200); `start_period: 480s` covers it with margin. `docker compose config` parses on both `HEADLESS=` and `HEADLESS=1`, and substitutes `${VLLM_PORT}` (default `8888`, override `9999` confirmed). `ci-validate.sh` passes, including a new assertion that the healthcheck is present and HEADLESS-gated.

## Limitations (stated deliberately)

1. **Worker health is gated, not probed.** A headless rank has no HTTP endpoint, so its check passes whenever the container can run a shell. A green worker status is not an engine probe.
2. **Not self-healing.** `restart: unless-stopped` restarts on process exit, not on `unhealthy` (confirmed: an unhealthy container keeps running). Auto-restart-on-unhealthy would need an autoheal sidecar or external watcher.
3. **Does not detect an alive-but-wedged engine** (#65/#87). `/health` → `check_health()` is a dead/stopped boolean (`errored = engine_dead or not is_running`), not a responsiveness probe.

## Notes

- `start_period: 480s` is tuned for this hardware's ~6 min cold load; operators on slower storage should raise it.
- Touches `docker-compose.dspark.yml`, which open PR #62 also edits — whichever lands second should rebase (disjoint hunks).
