### PR TITLE
fix(sched): cap mixed prefills around active decode

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -190,6 +190,11 @@ MAX_NUM_BATCHED_TOKENS=8192
 # from ~46x to ~1.05x. Safe across MAX_NUM_SEQS and prompt lengths.
 LONG_PREFILL_TOKEN_THRESHOLD=1024
 
+# Issue #80: cap each prefill chunk only while an eligible decode lane is
+# active. Prefill-only work retains LONG_PREFILL_TOKEN_THRESHOLD=1024.
+# Default 256; set 0 to disable/roll back. Valid range: integer 0..8192.
+DSPARK_MIXED_PREFILL_TOKEN_CAP=256
+
 # Issue #43: max concurrent in-flight partial prefills. Raising to 2/3
 # overlaps prefills and is the lever that improves the whole-request min/max
 # decode rate #43 reports. NOTE: --max-num-partial-prefills is NOT available

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -81,6 +81,10 @@ services:
       # (scheduled prefill/decode tokens per request + zero-token decode
       # skips) when set to 1. Off by default (zero overhead).
       DSPARK_ISSUE43_SCHED_DIAG: "${DSPARK_ISSUE43_SCHED_DIAG:-0}"
+      # Issue #80: preserve the global 1024 prefill threshold when no decode is
+      # active, but cap new/resumed and running mixed-prefill chunks at 256.
+      # Set 0 to disable/roll back; parsed once when the scheduler imports.
+      DSPARK_MIXED_PREFILL_TOKEN_CAP: "${DSPARK_MIXED_PREFILL_TOKEN_CAP:-256}"
       # In-flight partial-prefill cap for the #27 hotfix (1-3, default 2).
       # Do NOT pass --max-num-partial-prefills (Anemll 0.1.1 rejects it).
       DSPARK_MAX_INFLIGHT_PREFILLS: "${DSPARK_MAX_INFLIGHT_PREFILLS:-2}"

--- a/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
+++ b/patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py
@@ -52,9 +52,30 @@ D. Step summary log (ask #1). When ``DSPARK_ISSUE43_SCHED_DIAG=1`` is set in
    decode_skips=[(rid,pos,computed)..]``. Off by default (zero overhead: the
    diag dict is cheap to build and only the log line is gated).
 
-Idempotent. Anchors are asserted; re-applying is a no-op once all marks are
-present. Safe to apply before or after the issue #27 hotfix (independent
-regions).
+E. Issue #80 mixed-step chunk cap. Parse ``DSPARK_MIXED_PREFILL_TOKEN_CAP``
+   once at module import (default 256; 0 disables; valid range 0..8192).
+   Whenever any eligible decode lane exists anywhere in ``self.running``, cap
+   each prefill chunk before generic Mamba block alignment and then apply the
+   issue #43 floor. Prefill-only steps retain the global
+   ``--long-prefill-token-threshold``.
+
+   The v3 revision also applies that same schedule-start decision to the first
+   chunk of a newly admitted or resumed WAITING request. The WAITING cap lives
+   in the ``load_kv_async == False`` branch, after the global threshold and
+   before budget checks and Mamba alignment; async remote-KV loads still
+   schedule zero new tokens and are untouched.
+
+F. Priority-preemption diagnostic rollback. When stock PRIORITY scheduling
+   removes a request already scheduled in the current step and restores its
+   token budget, remove that request from the prefill/decode diagnostic maps too
+   so their totals continue to match ``num_scheduled_tokens``.
+
+Versioned and idempotent. Current v2 sources receive only the WAITING block and
+v3 marker. A source carrying only the old issue #43 marker receives all issue80
+features, including the WAITING block. Fresh stock receives the complete current
+patch. Every upgrade anchor is asserted and all edits remain in memory until the
+single final write, so target drift fails closed. Safe to apply before or after
+the issue #27 hotfix (independent regions).
 
 Patches /usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py
 in-place inside the container (called from the compose entrypoint before
@@ -65,42 +86,91 @@ import sys
 
 P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")
 MARK = "# [issue43-hotfix]"
+V2_MARK = "# [issue80-scheduler-current-v2]"
+CURRENT_MARK = "# [issue80-scheduler-current-v3]"
+
+
+def patch_status(status_src):
+    has_issue43 = MARK in status_src
+    has_v2 = V2_MARK in status_src
+    has_current = CURRENT_MARK in status_src
+    if has_issue43 and has_v2 and has_current:
+        return "CURRENT"
+    if has_issue43 and has_v2 and not has_current:
+        return "LEGACY_V2"
+    if has_issue43 and not has_v2 and not has_current:
+        return "LEGACY"
+    if not has_issue43 and not has_v2 and not has_current:
+        return "NOT APPLIED"
+    return "INVALID/DRIFT"
+
+
 if len(sys.argv) > 1 and sys.argv[1] == "--status":
     status_src = P.read_text() if P.is_file() else ""
-    print("issue43 decode-fairness + diag     :",
-          "APPLIED" if MARK in status_src else "NOT APPLIED")
+    print("issue43 decode-fairness + diag     :", patch_status(status_src))
     raise SystemExit(0)
 src = P.read_text()
-if MARK in src:
-    print(f"[issue43-hotfix] already applied to {P}")
+status = patch_status(src)
+if status == "CURRENT":
+    print(f"[issue43-hotfix] already applied (current) to {P}")
     raise SystemExit(0)
-
-# --- 0. import os (module-level diag gate) -----------------------------------
-A0_OLD = "import itertools\nimport time\n"
-assert A0_OLD in src, "issue43: import anchor not found; refusing to patch"
-src = src.replace(
-    A0_OLD,
-    A0_OLD
-    + "# [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate\n"
-    + "import os\n",
-    1,
+assert status != "INVALID/DRIFT", (
+    "issue43: inconsistent version markers; refusing to patch"
 )
+legacy_v2 = status == "LEGACY_V2"
+legacy = status == "LEGACY"
+fresh = status == "NOT APPLIED"
 
-# --- 1. module-level diag gate constant --------------------------------------
+# --- 0. import os (module-level diag gate; fresh stock only) -----------------
+A0_OLD = "import itertools\nimport time\n"
+if fresh:
+    assert A0_OLD in src, "issue43: import anchor not found; refusing to patch"
+    src = src.replace(
+        A0_OLD,
+        A0_OLD
+        + "# [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate\n"
+        + "import os\n",
+        1,
+    )
+
+# --- 1. module-level diag and mixed-cap constants ----------------------------
 A1_OLD = "logger = init_logger(__name__)\n"
-assert A1_OLD in src, "issue43: logger anchor not found; refusing to patch"
+A1_LEGACY_OLD = (
+    "_ISSUE43_SCHED_DIAG = os.environ.get(\"DSPARK_ISSUE43_SCHED_DIAG\", \"0\") "
+    "not in (\"0\", \"\", \"false\", \"False\")\n"
+)
 A1_NEW = (
     A1_OLD
     + "# [issue43-hotfix] per-step scheduler diagnostics gate (issue #43).\n"
     + "# Set DSPARK_ISSUE43_SCHED_DIAG=1 in the container env to emit one\n"
     + "# compact scheduled-tokens / decode-skip summary line per step.\n"
     + "_ISSUE43_SCHED_DIAG = os.environ.get(\"DSPARK_ISSUE43_SCHED_DIAG\", \"0\") not in (\"0\", \"\", \"false\", \"False\")\n"
+    + "# [issue80-scheduler-current-v2] Complete issue80 scheduler revision.\n"
+    + "# [issue80-mixed-prefill-cap] Bound prefill chunks only while an eligible\n"
+    + "# decode is active. Parse once at module import; 0 is the rollback knob.\n"
+    + "_ISSUE80_MIXED_PREFILL_TOKEN_CAP_RAW = os.environ.get(\"DSPARK_MIXED_PREFILL_TOKEN_CAP\", \"256\")\n"
+    + "try:\n"
+    + "    _ISSUE80_MIXED_PREFILL_TOKEN_CAP = int(_ISSUE80_MIXED_PREFILL_TOKEN_CAP_RAW)\n"
+    + "except ValueError as exc:\n"
+    + "    raise ValueError(\"DSPARK_MIXED_PREFILL_TOKEN_CAP must be an integer in 0..8192\") from exc\n"
+    + "if not 0 <= _ISSUE80_MIXED_PREFILL_TOKEN_CAP <= 8192:\n"
+    + "    raise ValueError(\"DSPARK_MIXED_PREFILL_TOKEN_CAP must be in 0..8192\")\n"
 )
-src = src.replace(A1_OLD, A1_NEW, 1)
+if legacy:
+    assert A1_LEGACY_OLD in src, (
+        "issue43 legacy upgrade: diag constant anchor not found; refusing to patch"
+    )
+    issue80_constants = A1_NEW.split(A1_LEGACY_OLD, 1)[1]
+    src = src.replace(A1_LEGACY_OLD, A1_LEGACY_OLD + issue80_constants, 1)
+elif fresh:
+    assert A1_OLD in src, "issue43: logger anchor not found; refusing to patch"
+    src = src.replace(A1_OLD, A1_NEW, 1)
 
-# --- 2. init diag dict at the top of schedule(), after prefill_scheduled -----
+# --- 2. init diag dict and global decode eligibility scan --------------------
 A2_OLD = "        prefill_scheduled = False\n"
-assert A2_OLD in src, "issue43: prefill_scheduled anchor not found; refusing to patch"
+A2_LEGACY_OLD = (
+    "        issue43_step_diag = {\"prefill\": {}, \"decode\": {}, \"skips\": []}\n"
+)
 A2_NEW = (
     A2_OLD
     + "        # [issue43-hotfix] per-step scheduler diagnostics (issue #43).\n"
@@ -108,26 +178,59 @@ A2_NEW = (
     + "        # zero-token decode skips (by request_id and running-list pos).\n"
     + "        # Always built (cheap); only the step log line (below) is gated.\n"
     + "        issue43_step_diag = {\"prefill\": {}, \"decode\": {}, \"skips\": []}\n"
+    + "        # [issue80-mixed-prefill-cap] Determine whether any decode lane is\n"
+    + "        # eligible once at schedule start. Scanning all of self.running\n"
+    + "        # makes the mixed cap independent of running-list order. Mirror\n"
+    + "        # issue #43 floor eligibility and explicitly exclude prefills.\n"
+    + "        _issue80_has_eligible_decode = False\n"
+    + "        if _ISSUE80_MIXED_PREFILL_TOKEN_CAP > 0:\n"
+    + "            for _r in self.running:\n"
+    + "                if (_r.num_output_placeholders > 0 and\n"
+    + "                        _r.num_computed_tokens + 2\n"
+    + "                        - _r.num_output_placeholders\n"
+    + "                        >= _r.num_prompt_tokens + _r.max_tokens):\n"
+    + "                    continue\n"
+    + "                if self.current_step < _r.next_decode_eligible_step:\n"
+    + "                    continue\n"
+    + "                if getattr(_r, \"is_prefill_chunk\", False):\n"
+    + "                    continue\n"
+    + "                if _r.num_computed_tokens >= _r.num_prompt_tokens:\n"
+    + "                    _issue80_has_eligible_decode = True\n"
+    + "                    break\n"
 )
-src = src.replace(A2_OLD, A2_NEW, 1)
+if legacy:
+    assert A2_LEGACY_OLD in src, (
+        "issue43 legacy upgrade: step-diag anchor not found; refusing to patch"
+    )
+    issue80_eligibility = A2_NEW.split(A2_LEGACY_OLD, 1)[1]
+    src = src.replace(A2_LEGACY_OLD, A2_LEGACY_OLD + issue80_eligibility, 1)
+elif fresh:
+    assert A2_OLD in src, (
+        "issue43: prefill_scheduled anchor not found; refusing to patch"
+    )
+    src = src.replace(A2_OLD, A2_NEW, 1)
 
-# --- 3. decode-floor reservation, inserted after the mamba split block and
-#        before the num_new_tokens == 0 skip check ----------------------------
-A3_OLD = (
+# --- 3. mixed cap -> Mamba alignment -> issue43 floor -> zero check ----------
+A3_MAMBA = (
     "            if self.need_mamba_block_aligned_split:\n"
     "                num_new_tokens = self._mamba_block_aligned_split(\n"
     "                    request, num_new_tokens\n"
     "                )\n"
     "\n"
-    "            if num_new_tokens == 0:\n"
 )
-assert A3_OLD in src, "issue43: mamba-split/zero-check anchor not found; refusing to patch"
-A3_NEW = (
-    "            if self.need_mamba_block_aligned_split:\n"
-    "                num_new_tokens = self._mamba_block_aligned_split(\n"
-    "                    request, num_new_tokens\n"
-    "                )\n"
+A3_CAP = (
+    "            # [issue80-mixed-prefill-cap] Keep prefill-only scheduling at\n"
+    "            # the global long-prefill threshold, but cap each mixed prefill\n"
+    "            # before Mamba block alignment and issue #43's decode floor.\n"
+    "            # 0 disables the cap.\n"
+    "            if (_ISSUE80_MIXED_PREFILL_TOKEN_CAP > 0 and\n"
+    "                    _issue80_has_eligible_decode and\n"
+    "                    getattr(request, \"is_prefill_chunk\", False)):\n"
+    "                num_new_tokens = min(\n"
+    "                    num_new_tokens, _ISSUE80_MIXED_PREFILL_TOKEN_CAP)\n"
     "\n"
+)
+A3_FLOOR = (
     "            # [issue43-hotfix] bounded decode service during mixed prefill\n"
     "            # steps (issue #43 ask #3). Generalizes the #27\n"
     "            # max_num_partial_prefills cap: regardless of the configured\n"
@@ -158,9 +261,21 @@ A3_NEW = (
     "                        num_new_tokens,\n"
     "                        max(0, token_budget - _dec_floor))\n"
     "\n"
-    "            if num_new_tokens == 0:\n"
 )
-src = src.replace(A3_OLD, A3_NEW, 1)
+A3_ZERO = "            if num_new_tokens == 0:\n"
+A3_OLD = A3_MAMBA + A3_ZERO
+A3_LEGACY_OLD = A3_MAMBA + A3_FLOOR + A3_ZERO
+A3_NEW = A3_CAP + A3_MAMBA + A3_FLOOR + A3_ZERO
+if legacy:
+    assert A3_LEGACY_OLD in src, (
+        "issue43 legacy upgrade: mamba/floor anchor not found; refusing to patch"
+    )
+    src = src.replace(A3_LEGACY_OLD, A3_NEW, 1)
+elif fresh:
+    assert A3_OLD in src, (
+        "issue43: mamba-split/zero-check anchor not found; refusing to patch"
+    )
+    src = src.replace(A3_OLD, A3_NEW, 1)
 
 # --- 4. record zero-token decode skips inside the skip branch ----------------
 A4_OLD = (
@@ -170,7 +285,6 @@ A4_OLD = (
     "                req_index += 1\n"
     "                continue\n"
 )
-assert A4_OLD in src, "issue43: woosuk-skip anchor not found; refusing to patch"
 A4_NEW = (
     "                # NOTE(woosuk): Here, by doing `continue` instead of `break`,\n"
     "                # we do not strictly follow the FCFS scheduling policy and\n"
@@ -186,7 +300,9 @@ A4_NEW = (
     "                req_index += 1\n"
     "                continue\n"
 )
-src = src.replace(A4_OLD, A4_NEW, 1)
+if fresh:
+    assert A4_OLD in src, "issue43: woosuk-skip anchor not found; refusing to patch"
+    src = src.replace(A4_OLD, A4_NEW, 1)
 
 # --- 5. record per-request scheduled tokens in the running branch -----------
 A5_OLD = (
@@ -198,7 +314,6 @@ A5_OLD = (
     "            token_budget -= num_new_tokens\n"
     "            req_index += 1\n"
 )
-assert A5_OLD in src, "issue43: running-schedule anchor not found; refusing to patch"
 A5_NEW = (
     "            scheduled_running_reqs.append(request)\n"
     "            prefill_scheduled |= request.is_prefill_chunk\n"
@@ -214,11 +329,14 @@ A5_NEW = (
     "                \"decode\" if _is_dec else \"prefill\"][request_id] = num_new_tokens\n"
     "            req_index += 1\n"
 )
-src = src.replace(A5_OLD, A5_NEW, 1)
+if fresh:
+    assert A5_OLD in src, (
+        "issue43: running-schedule anchor not found; refusing to patch"
+    )
+    src = src.replace(A5_OLD, A5_NEW, 1)
 
 # --- 6. step summary log + stash diag on self, at end of running loop -------
 A6_OLD = "        # Record the LoRAs in scheduled_running_reqs\n"
-assert A6_OLD in src, "issue43: end-of-running-loop anchor not found; refusing to patch"
 A6_NEW = (
     "        # [issue43-hotfix] step summary (issue #43 asks #1/#2). Stash the\n"
     "        # per-step diag for the live reproducer; emit a compact log line\n"
@@ -236,7 +354,76 @@ A6_NEW = (
     "\n"
     "        # Record the LoRAs in scheduled_running_reqs\n"
 )
-src = src.replace(A6_OLD, A6_NEW, 1)
+if fresh:
+    assert A6_OLD in src, (
+        "issue43: end-of-running-loop anchor not found; refusing to patch"
+    )
+    src = src.replace(A6_OLD, A6_NEW, 1)
+
+# --- 7. remove preempted scheduled requests from diagnostic totals -----------
+# V2 already carries this block; old issue43 and fresh stock still need it.
+if not legacy_v2:
+    A7_OLD = "scheduled_spec_decode_tokens.pop(preempted_req_id, None)\n"
+    assert src.count(A7_OLD) == 1, (
+        "issue43: priority-preemption rollback anchor not found or ambiguous; "
+        "refusing to patch"
+    )
+    a7_index = src.index(A7_OLD)
+    a7_line_start = src.rfind("\n", 0, a7_index) + 1
+    a7_indent = src[a7_line_start:a7_index]
+    assert a7_indent and not a7_indent.strip(), (
+        "issue43: priority-preemption indentation anchor invalid; refusing to patch"
+    )
+    A7_NEW = (
+        A7_OLD
+        + a7_indent
+        + "# [issue43-hotfix] Roll back diagnostics with scheduler bookkeeping.\n"
+        + a7_indent
+        + "issue43_step_diag[\"prefill\"].pop(preempted_req_id, None)\n"
+        + a7_indent
+        + "issue43_step_diag[\"decode\"].pop(preempted_req_id, None)\n"
+    )
+    src = src.replace(A7_OLD, A7_NEW, 1)
+
+# --- 8. cap the first chunk admitted from WAITING -----------------------------
+# This anchor is deliberately wholly inside load_kv_async's false branch. It
+# applies to new and resumed requests, but cannot touch async-load num_new_tokens
+# == 0. It also preserves threshold -> cap -> budget/encoder -> Mamba ordering.
+A8_OLD = (
+    "                    threshold = self.scheduler_config.long_prefill_token_threshold\n"
+    "                    if 0 < threshold < num_new_tokens:\n"
+    "                        num_new_tokens = threshold\n"
+    "\n"
+    "                    # chunked prefill has to be enabled explicitly to allow\n"
+)
+A8_CAP = (
+    "                    threshold = self.scheduler_config.long_prefill_token_threshold\n"
+    "                    if 0 < threshold < num_new_tokens:\n"
+    "                        num_new_tokens = threshold\n"
+    "\n"
+    "                    # [issue80-scheduler-current-v3] Complete issue80\n"
+    "                    # scheduler revision: cap a new/resumed WAITING first\n"
+    "                    # chunk when schedule-start found an eligible decode.\n"
+    "                    # This false branch excludes async remote-KV load0.\n"
+    "                    if (_ISSUE80_MIXED_PREFILL_TOKEN_CAP > 0 and\n"
+    "                            _issue80_has_eligible_decode):\n"
+    "                        num_new_tokens = min(\n"
+    "                            num_new_tokens,\n"
+    "                            _ISSUE80_MIXED_PREFILL_TOKEN_CAP)\n"
+    "\n"
+    "                    # chunked prefill has to be enabled explicitly to allow\n"
+)
+assert src.count(A8_OLD) == 1, (
+    "issue43: WAITING false-branch threshold/budget anchor not found or "
+    "ambiguous; refusing to patch"
+)
+src = src.replace(A8_OLD, A8_CAP, 1)
 
 P.write_text(src)
-print(f"[issue43-hotfix] patched {P}")
+if legacy_v2:
+    action = "upgraded v2 patch on"
+elif legacy:
+    action = "upgraded legacy patch on"
+else:
+    action = "patched"
+print(f"[issue43-hotfix] {action} {P}")

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -88,6 +88,11 @@ python3 scripts/test-empty-encoder-output-hotfix.py -q
 ok "test-empty-encoder-output-hotfix"
 python3 tests/test_issue27_inflight_cap.py -q
 ok "test_issue27_inflight_cap"
+python3 -m unittest -q \
+  tests.test_issue80_mixed_prefill_cap \
+  tests.test_issue80_mixed_prefill_cap_parser \
+  tests.test_issue80_scheduler_upgrade_gaps
+ok "test_issue80_mixed_prefill_cap"
 python3 scripts/verify-dsv4-027-equality-gate.py
 ok "verify-dsv4-027-equality-gate"
 bash scripts/verify-overlay-sources.sh

--- a/tests/sim/test_issue43_scheduler_sim.py
+++ b/tests/sim/test_issue43_scheduler_sim.py
@@ -37,6 +37,7 @@ class Req:
         self.num_output_placeholders = 0
         self.is_prefill_chunk = False
         self.next_decode_eligible_step = 0
+        self.load_kv_async = False
         self._sps = sampled_tokens_per_step
 
     @property
@@ -47,10 +48,27 @@ class Req:
         return f"{self.request_id}(c={self.num_computed_tokens},p={self.num_prompt_tokens})"
 
 
+def has_eligible_decode(self_running, current_step):
+    """Mirror the production schedule-start decode eligibility scan."""
+    for request in self_running:
+        if (request.num_output_placeholders > 0 and
+                request.num_computed_tokens + 2 - request.num_output_placeholders
+                >= request.num_prompt_tokens + request.max_tokens):
+            continue
+        if current_step < request.next_decode_eligible_step:
+            continue
+        if request.is_prefill_chunk:
+            continue
+        if request.num_computed_tokens >= request.num_prompt_tokens:
+            return True
+    return False
+
+
 def step(self_running, token_budget, current_step, defer_prefills=False,
          long_threshold=1024, max_num_partial_prefills=1,
          num_sampled_tokens_per_step=1, in_flight_prefills=None,
-         diag=None, floor=True):
+         diag=None, floor=True, mixed_prefill_cap=None,
+         mamba_block_size=None, eligible_decode_at_start=None):
     """One Scheduler.schedule RUNNING-list pass.
 
     Returns (scheduled:list[(req, ntok)], leftover_budget). Mutates each
@@ -58,6 +76,10 @@ def step(self_running, token_budget, current_step, defer_prefills=False,
     in_flight_prefills (issue #27 admission gate is modeled by the caller
     admitting at most max_num_partial_prefills NEW prefills per step).
     `diag` (dict) is filled like self.issue43_last_step_diag.
+    `mixed_prefill_cap` models issue #80's decode-active-only prefill cap. None
+    or 0 disables it, matching the production rollback knob.
+    `mamba_block_size` enables the generic hybrid-scheduler alignment step;
+    the exact DeepSeek target leaves it as None because it has no Mamba layer.
     """
     if diag is not None:
         diag["prefill"] = {}
@@ -67,6 +89,14 @@ def step(self_running, token_budget, current_step, defer_prefills=False,
     req_index = 0
     scheduled = []
     budget = token_budget
+    # [issue80-mixed-prefill-cap] Determine mixed-mode once, before walking the
+    # running list, so behavior does not depend on request order. Eligibility
+    # mirrors issue #43's decode floor, while explicitly excluding prefills.
+    eligible_decode = (
+        has_eligible_decode(self_running, current_step)
+        if eligible_decode_at_start is None
+        else eligible_decode_at_start
+    )
     while req_index < len(self_running) and budget > 0:
         request = self_running[req_index]
 
@@ -100,6 +130,26 @@ def step(self_running, token_budget, current_step, defer_prefills=False,
             if 0 < long_threshold < num_new_tokens:
                 num_new_tokens = long_threshold
         num_new_tokens = min(num_new_tokens, budget)
+
+        # [issue80-mixed-prefill-cap] Keep the global threshold unchanged for
+        # prefill-only steps, but bound mixed prefill chunks before the issue
+        # #43 floor so decode token counts and floor accounting are preserved.
+        if (mixed_prefill_cap and eligible_decode and
+                request.is_prefill_chunk):
+            num_new_tokens = min(num_new_tokens, mixed_prefill_cap)
+
+        # Match the production ordering: the dynamic cap is an input to the
+        # generic Mamba alignment helper, never a post-alignment override.
+        if (mamba_block_size and request.is_prefill_chunk and
+                num_new_tokens >= mamba_block_size):
+            last_cache_position = (
+                request.num_tokens_with_spec
+                - request.num_tokens_with_spec % mamba_block_size
+            )
+            if request.num_computed_tokens + num_new_tokens < last_cache_position:
+                num_new_tokens = (
+                    num_new_tokens // mamba_block_size * mamba_block_size
+                )
 
         # --- [issue43-hotfix] bounded decode service reservation ---
         # Gated by `floor`; disabled by the ablation (--no-floor) to prove
@@ -156,6 +206,83 @@ def step(self_running, token_budget, current_step, defer_prefills=False,
         req_index += 1
 
     return scheduled, budget
+
+
+def production_order_step(self_running, waiting, token_budget, current_step,
+                          defer_prefills=False, long_threshold=1024,
+                          max_num_partial_prefills=1,
+                          num_sampled_tokens_per_step=1,
+                          in_flight_prefills=None, floor=True,
+                          mixed_prefill_cap=None, mamba_block_size=None):
+    """Model one production-order RUNNING pass followed by WAITING admission.
+
+    The mixed-mode decision is captured once at schedule start and reused by
+    both phases. The returned diagnostic maps intentionally model issue43's
+    RUNNING-pass diagnostics; ``scheduled`` models production's combined
+    ``num_scheduled_tokens`` output for budget reconciliation.
+    """
+    eligible_decode = has_eligible_decode(self_running, current_step)
+    diag = {}
+    scheduled, budget = step(
+        self_running,
+        token_budget,
+        current_step,
+        defer_prefills=defer_prefills,
+        long_threshold=long_threshold,
+        max_num_partial_prefills=max_num_partial_prefills,
+        num_sampled_tokens_per_step=num_sampled_tokens_per_step,
+        in_flight_prefills=in_flight_prefills,
+        diag=diag,
+        floor=floor,
+        mixed_prefill_cap=mixed_prefill_cap,
+        mamba_block_size=mamba_block_size,
+        eligible_decode_at_start=eligible_decode,
+    )
+
+    for request in waiting:
+        if budget <= 0:
+            break
+        # The production async-load branch deliberately schedules zero new
+        # work and bypasses the false-branch first-chunk cap.
+        if request.load_kv_async:
+            continue
+
+        num_new_tokens = request.num_tokens_with_spec - request.num_computed_tokens
+        if 0 < long_threshold < num_new_tokens:
+            num_new_tokens = long_threshold
+        if mixed_prefill_cap and eligible_decode:
+            num_new_tokens = min(num_new_tokens, mixed_prefill_cap)
+        num_new_tokens = min(num_new_tokens, budget)
+
+        if mamba_block_size and num_new_tokens >= mamba_block_size:
+            last_cache_position = (
+                request.num_tokens_with_spec
+                - request.num_tokens_with_spec % mamba_block_size
+            )
+            if request.num_computed_tokens + num_new_tokens < last_cache_position:
+                num_new_tokens = (
+                    num_new_tokens // mamba_block_size * mamba_block_size
+                )
+        if num_new_tokens == 0:
+            break
+
+        scheduled.append((request, num_new_tokens))
+        budget -= num_new_tokens
+
+    return scheduled, budget, diag
+
+
+def rollback_scheduled_preemption(self_running, scheduled,
+                                  num_scheduled_tokens, diag, request_id):
+    """Model stock PRIORITY rollback plus issue43 diagnostic rollback."""
+    victim = next(r for r in self_running if r.request_id == request_id)
+    self_running.remove(victim)
+    scheduled[:] = [item for item in scheduled if item[0] is not victim]
+    restored = num_scheduled_tokens.pop(request_id)
+    if diag is not None:
+        diag["prefill"].pop(request_id, None)
+        diag["decode"].pop(request_id, None)
+    return restored
 
 
 def simulate_cell(n_lanes, prompt_tokens, out_tokens=256,

--- a/tests/test_issue43_patchapply.py
+++ b/tests/test_issue43_patchapply.py
@@ -9,6 +9,10 @@ HERE = pathlib.Path(__file__).resolve().parent  # .../tests
 ROOT = HERE.parent                            # project root
 HOT43 = ROOT / "patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
 HOT27 = ROOT / "patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py"
+IMAGE = (
+    "ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:"
+    "a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8"
+)
 # Real container target path the hotfix patches inside the image.
 REAL = "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py"
 
@@ -19,7 +23,7 @@ def extract_real():
     os.close(fd)
     r = subprocess.run(
         ["docker", "run", "--rm", "--entrypoint", "cat",
-         "ghcr.io/anemll/dspark-vllm-gx10:0.1.1", REAL],
+         IMAGE, REAL],
         check=True, stdout=open(path, "w"))
     return pathlib.Path(path)
 
@@ -61,7 +65,27 @@ def main():
     assert "# [issue27-hotfix]" in base.read_text()
 
     apply_hotfix_to_copy(base, HOT43)
-    assert "# [issue43-hotfix]" in base.read_text()
+    patched = base.read_text()
+    assert "# [issue43-hotfix]" in patched
+    assert "# [issue80-scheduler-current-v2]" in patched
+    assert "# [issue80-scheduler-current-v3]" in patched
+    cap_pos = patched.index("num_new_tokens, _ISSUE80_MIXED_PREFILL_TOKEN_CAP")
+    mamba_pos = patched.index("if self.need_mamba_block_aligned_split", cap_pos)
+    floor_pos = patched.index("_dec_floor = 0", mamba_pos)
+    assert cap_pos < mamba_pos < floor_pos
+    assert 'issue43_step_diag["prefill"].pop(preempted_req_id, None)' in patched
+    assert 'issue43_step_diag["decode"].pop(preempted_req_id, None)' in patched
+    waiting_threshold = patched.index(
+        "threshold = self.scheduler_config.long_prefill_token_threshold"
+    )
+    waiting_cap = patched.index("# [issue80-scheduler-current-v3]", waiting_threshold)
+    waiting_budget = patched.index(
+        "# chunked prefill has to be enabled explicitly", waiting_cap
+    )
+    waiting_mamba = patched.index(
+        "if self.need_mamba_block_aligned_split", waiting_budget
+    )
+    assert waiting_threshold < waiting_cap < waiting_budget < waiting_mamba
     print("[4/6] applied issue #43 hotfix on top of #27")
 
     # 5. compiles
@@ -69,6 +93,7 @@ def main():
     print("[5/6] py_compile OK (patched scheduler is syntactically valid)")
 
     # 6. idempotent: re-apply #43 -> no-op (exits early with SystemExit)
+    once = base.read_bytes()
     try:
         apply_hotfix_to_copy(base, HOT43)
         print("[6/6] FAIL: re-apply did not raise SystemExit")
@@ -76,8 +101,7 @@ def main():
     except SystemExit:
         pass
     # ensure file unchanged after re-apply attempt
-    after = base.read_text()
-    once = base.read_text()
+    after = base.read_bytes()
     assert once == after
     print("[6/6] idempotent re-apply is a no-op (SystemExit, file unchanged)")
     print("\nPASS: issue #43 hotfix applies cleanly on top of #27, compiles, "

--- a/tests/test_issue80_mixed_prefill_cap.py
+++ b/tests/test_issue80_mixed_prefill_cap.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Regressions for issue #80's decode-active-only mixed prefill cap.
+
+The production scheduler must retain the 1024-token global long-prefill
+threshold for prefill-only throughput, but dynamically cap each prefill chunk
+to 256 whenever any eligible decode-active request is present in ``running``.
+The mixed cap must be applied before issue #43's decode-service floor, and the
+same schedule-start decision must cap a new/resumed WAITING request's first
+non-async chunk after RUNNING requests have been scheduled.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+from tests.sim.test_issue43_scheduler_sim import Req, production_order_step, step
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOTFIX = ROOT / "patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
+COMPOSE = ROOT / "docker-compose.dspark.yml"
+ENV_EXAMPLE = ROOT / ".env.dspark.example"
+
+LONG_THRESHOLD = 1024
+MIXED_PREFILL_CAP = 256
+SPS = 6
+TOKEN_BUDGET = 8192
+CURRENT_STEP = 7
+
+
+def _prefill(rid: str = "prefill") -> Req:
+    request = Req(rid, prompt_tokens=4096, max_tokens=128)
+    request.is_prefill_chunk = True
+    return request
+
+
+def _decode(rid: str = "decode") -> Req:
+    request = Req(
+        rid,
+        prompt_tokens=32,
+        max_tokens=128,
+        sampled_tokens_per_step=SPS,
+    )
+    request.num_computed_tokens = request.num_prompt_tokens
+    return request
+
+
+def _run(running: list[Req], *, token_budget: int = TOKEN_BUDGET):
+    diag: dict = {}
+    scheduled, leftover = step(
+        running,
+        token_budget=token_budget,
+        current_step=CURRENT_STEP,
+        long_threshold=LONG_THRESHOLD,
+        num_sampled_tokens_per_step=SPS,
+        diag=diag,
+        floor=True,
+        mixed_prefill_cap=MIXED_PREFILL_CAP,
+    )
+    return {request.request_id: tokens for request, tokens in scheduled}, leftover, diag
+
+
+class MixedPrefillCapBehaviorTests(unittest.TestCase):
+    def test_prefill_only_retains_global_1024_threshold(self):
+        scheduled, leftover, diag = _run([_prefill()])
+
+        self.assertEqual(scheduled, {"prefill": LONG_THRESHOLD})
+        self.assertEqual(leftover, TOKEN_BUDGET - LONG_THRESHOLD)
+        self.assertEqual(
+            diag,
+            {
+                "prefill": {"prefill": LONG_THRESHOLD},
+                "decode": {},
+                "skips": [],
+            },
+        )
+
+    def test_mixed_prefill_then_decode_caps_prefill_and_preserves_sps(self):
+        scheduled, leftover, diag = _run([_prefill(), _decode()])
+
+        self.assertEqual(
+            scheduled,
+            {"prefill": MIXED_PREFILL_CAP, "decode": SPS},
+        )
+        self.assertEqual(leftover, TOKEN_BUDGET - MIXED_PREFILL_CAP - SPS)
+        self.assertEqual(
+            diag,
+            {
+                "prefill": {"prefill": MIXED_PREFILL_CAP},
+                "decode": {"decode": SPS},
+                "skips": [],
+            },
+        )
+
+    def test_mixed_decode_then_prefill_caps_independent_of_running_order(self):
+        scheduled, leftover, diag = _run([_decode(), _prefill()])
+
+        self.assertEqual(
+            scheduled,
+            {"decode": SPS, "prefill": MIXED_PREFILL_CAP},
+        )
+        self.assertEqual(leftover, TOKEN_BUDGET - MIXED_PREFILL_CAP - SPS)
+        self.assertEqual(
+            diag,
+            {
+                "prefill": {"prefill": MIXED_PREFILL_CAP},
+                "decode": {"decode": SPS},
+                "skips": [],
+            },
+        )
+
+    def _assert_noneligible_decode_does_not_cap(self, decode: Req):
+        scheduled, leftover, diag = _run([_prefill(), decode])
+
+        self.assertEqual(scheduled, {"prefill": LONG_THRESHOLD})
+        self.assertEqual(leftover, TOKEN_BUDGET - LONG_THRESHOLD)
+        self.assertEqual(
+            diag,
+            {
+                "prefill": {"prefill": LONG_THRESHOLD},
+                "decode": {},
+                "skips": [],
+            },
+        )
+
+    def test_ineligible_decode_does_not_trigger_mixed_cap(self):
+        decode = _decode()
+        decode.next_decode_eligible_step = CURRENT_STEP + 1
+
+        self._assert_noneligible_decode_does_not_cap(decode)
+
+    def test_finished_decode_does_not_trigger_mixed_cap(self):
+        decode = _decode()
+        decode.num_computed_tokens = decode.num_prompt_tokens + decode.max_tokens
+        decode.num_output_placeholders = 1
+
+        self._assert_noneligible_decode_does_not_cap(decode)
+
+    def test_cap_precedes_issue43_floor_without_skip_and_diag_reconciles(self):
+        exact_budget = MIXED_PREFILL_CAP + SPS
+        scheduled, leftover, diag = _run(
+            [_prefill(), _decode()],
+            token_budget=exact_budget,
+        )
+
+        self.assertEqual(
+            scheduled,
+            {"prefill": MIXED_PREFILL_CAP, "decode": SPS},
+        )
+        self.assertEqual(diag["skips"], [])
+        diagnostic_total = sum(diag["prefill"].values()) + sum(
+            diag["decode"].values()
+        )
+        self.assertEqual(diagnostic_total, sum(scheduled.values()))
+        self.assertEqual(leftover, exact_budget - sum(scheduled.values()))
+        self.assertEqual(leftover, 0)
+
+
+class WaitingFirstChunkCapBehaviorTests(unittest.TestCase):
+    def _production_step(self, running: list[Req], waiting: list[Req]):
+        return production_order_step(
+            running,
+            waiting,
+            token_budget=TOKEN_BUDGET,
+            current_step=CURRENT_STEP,
+            long_threshold=LONG_THRESHOLD,
+            num_sampled_tokens_per_step=SPS,
+            mixed_prefill_cap=MIXED_PREFILL_CAP,
+        )
+
+    def test_running_decode_is_scheduled_before_cold_waiting_prefill_cap(self):
+        decode = _decode()
+        scheduled, leftover, diag = self._production_step([decode], [_prefill()])
+
+        self.assertEqual(
+            [(request.request_id, tokens) for request, tokens in scheduled],
+            [("decode", SPS), ("prefill", MIXED_PREFILL_CAP)],
+        )
+        self.assertEqual(leftover, TOKEN_BUDGET - SPS - MIXED_PREFILL_CAP)
+        self.assertEqual(diag["decode"], {"decode": SPS})
+        self.assertEqual(diag["prefill"], {})
+        self.assertEqual(diag["skips"], [])
+        self.assertEqual(
+            sum(tokens for _, tokens in scheduled) + leftover,
+            TOKEN_BUDGET,
+        )
+        self.assertEqual(
+            sum(diag["prefill"].values()) + sum(diag["decode"].values()),
+            scheduled[0][1],
+        )
+
+    def test_waiting_prefill_only_retains_global_threshold(self):
+        scheduled, leftover, diag = self._production_step([], [_prefill()])
+
+        self.assertEqual(
+            [(request.request_id, tokens) for request, tokens in scheduled],
+            [("prefill", LONG_THRESHOLD)],
+        )
+        self.assertEqual(leftover, TOKEN_BUDGET - LONG_THRESHOLD)
+        self.assertEqual(diag, {"prefill": {}, "decode": {}, "skips": []})
+
+    def test_ineligible_and_finished_running_decodes_do_not_cap_waiting(self):
+        ineligible = _decode("ineligible")
+        ineligible.next_decode_eligible_step = CURRENT_STEP + 1
+        finished = _decode("finished")
+        finished.num_computed_tokens = finished.num_prompt_tokens + finished.max_tokens
+        finished.num_output_placeholders = 1
+
+        for decode in (ineligible, finished):
+            with self.subTest(decode=decode.request_id):
+                scheduled, leftover, diag = self._production_step(
+                    [decode], [_prefill()]
+                )
+                self.assertEqual(
+                    [(request.request_id, tokens) for request, tokens in scheduled],
+                    [("prefill", LONG_THRESHOLD)],
+                )
+                self.assertEqual(leftover, TOKEN_BUDGET - LONG_THRESHOLD)
+                self.assertEqual(
+                    diag, {"prefill": {}, "decode": {}, "skips": []}
+                )
+
+    def test_resumed_waiting_request_is_capped_but_async_load_zero_is_not_scheduled(self):
+        resumed = _prefill("resumed")
+        resumed.num_computed_tokens = 512
+        async_load = _prefill("async-load")
+        async_load.load_kv_async = True
+
+        scheduled, leftover, _ = self._production_step(
+            [_decode()], [resumed, async_load]
+        )
+
+        self.assertEqual(
+            [(request.request_id, tokens) for request, tokens in scheduled],
+            [("decode", SPS), ("resumed", MIXED_PREFILL_CAP)],
+        )
+        self.assertEqual(leftover, TOKEN_BUDGET - SPS - MIXED_PREFILL_CAP)
+
+
+class MixedPrefillCapStaticContractTests(unittest.TestCase):
+    def test_issue43_hotfix_declares_dynamic_issue80_cap_default_256(self):
+        source = HOTFIX.read_text()
+
+        self.assertTrue(
+            "DSPARK_MIXED_PREFILL_TOKEN_CAP" in source,
+            "issue43 hotfix must read DSPARK_MIXED_PREFILL_TOKEN_CAP",
+        )
+        self.assertTrue(
+            "# [issue80-mixed-prefill-cap]" in source,
+            "issue43 hotfix must carry the dynamic mixed-cap patch marker",
+        )
+        normalized_source = source.replace("\\", "")
+        self.assertRegex(
+            normalized_source,
+            re.compile(
+                r"os\.environ\.get\(\s*[\"']DSPARK_MIXED_PREFILL_TOKEN_CAP[\"']"
+                r"\s*,\s*[\"']256[\"']"
+            ),
+        )
+
+    def test_compose_exposes_mixed_prefill_cap_with_default_256(self):
+        source = COMPOSE.read_text()
+
+        expected = (
+            'DSPARK_MIXED_PREFILL_TOKEN_CAP: '
+            '"${DSPARK_MIXED_PREFILL_TOKEN_CAP:-256}"'
+        )
+        self.assertTrue(
+            expected in source,
+            "compose must expose DSPARK_MIXED_PREFILL_TOKEN_CAP with default 256",
+        )
+
+    def test_env_example_documents_cap_without_lowering_global_threshold(self):
+        source = ENV_EXAMPLE.read_text()
+
+        self.assertTrue(
+            "LONG_PREFILL_TOKEN_THRESHOLD=1024" in source,
+            "global prefill-only threshold must remain 1024",
+        )
+        self.assertTrue(
+            "DSPARK_MIXED_PREFILL_TOKEN_CAP=256" in source,
+            "env example must document the decode-active mixed cap as 256",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue80_mixed_prefill_cap_parser.py
+++ b/tests/test_issue80_mixed_prefill_cap_parser.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Parser regressions for issue #80's injected mixed-prefill cap constant."""
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import unittest
+from unittest import mock
+
+from tests.sim.test_issue43_scheduler_sim import Req, step
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOTFIX = ROOT / "patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
+ENV_NAME = "DSPARK_MIXED_PREFILL_TOKEN_CAP"
+CONSTANT = "_ISSUE80_MIXED_PREFILL_TOKEN_CAP"
+
+
+def _injected_constants_source() -> str:
+    """Evaluate only the string expression assigned to A1_NEW in the patcher."""
+    tree = ast.parse(HOTFIX.read_text())
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "A1_NEW"
+                for target in node.targets)
+    )
+
+    def evaluate(node: ast.expr) -> str:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name) and node.id == "A1_OLD":
+            return "logger = init_logger(__name__)\n"
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return evaluate(node.left) + evaluate(node.right)
+        raise AssertionError(f"unexpected A1_NEW expression: {ast.dump(node)}")
+
+    generated = evaluate(assignment.value)
+    # The logger anchor is pre-existing target code and has unrelated imports.
+    return generated.split("\n", 1)[1]
+
+
+def _load_cap(value: str | None = None) -> int:
+    env = {} if value is None else {ENV_NAME: value}
+    with mock.patch.dict(os.environ, env, clear=True):
+        namespace: dict[str, object] = {"os": os}
+        exec(compile(_injected_constants_source(), "<issue80-cap-constants>", "exec"),
+             namespace)
+        cap_value = namespace[CONSTANT]
+        assert isinstance(cap_value, int)
+        return cap_value
+
+
+class MixedPrefillCapParserTests(unittest.TestCase):
+    def test_default_is_256_and_zero_disables(self):
+        self.assertEqual(_load_cap(), 256)
+        self.assertEqual(_load_cap("0"), 0)
+
+    def test_valid_upper_boundary_is_accepted(self):
+        self.assertEqual(_load_cap("8192"), 8192)
+
+    def test_invalid_values_fail_closed(self):
+        for value in ("-1", "8193", "not-an-int", ""):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                _load_cap(value)
+
+    def test_zero_rollback_disables_mixed_cap(self):
+        prefill = Req("prefill", prompt_tokens=4096, max_tokens=128)
+        prefill.is_prefill_chunk = True
+        decode = Req("decode", prompt_tokens=32, max_tokens=128,
+                     sampled_tokens_per_step=6)
+        decode.num_computed_tokens = decode.num_prompt_tokens
+
+        scheduled, _ = step(
+            [prefill, decode],
+            token_budget=8192,
+            current_step=7,
+            long_threshold=1024,
+            num_sampled_tokens_per_step=6,
+            mixed_prefill_cap=_load_cap("0"),
+        )
+
+        self.assertEqual(
+            {request.request_id: tokens for request, tokens in scheduled},
+            {"prefill": 1024, "decode": 6},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue80_scheduler_upgrade_gaps.py
+++ b/tests/test_issue80_scheduler_upgrade_gaps.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Regression tests for the issue #80 scheduler review gaps."""
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+import py_compile
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from tests.sim import test_issue43_scheduler_sim as sim
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOTFIX = ROOT / "patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py"
+COMPOSE = ROOT / "docker-compose.dspark.yml"
+TARGET_LITERAL = (
+    'Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py")'
+)
+V2_MARK = "# [issue80-scheduler-current-v2]"
+CURRENT_MARK = "# [issue80-scheduler-current-v3]"
+
+# A compact but realistic scheduler fragment after the pre-issue80 issue #43
+# patch. The legacy issue43 blocks and stock priority-preemption rollback are
+# preserved verbatim so the upgrade path is tested against asserted anchors.
+LEGACY_PATCHED_SCHEDULER = textwrap.dedent(
+    '''\
+    import itertools
+    import time
+    # [issue43-hotfix] os import for DSPARK_ISSUE43_SCHED_DIAG gate
+    import os
+
+    def init_logger(name):
+        return None
+
+    logger = init_logger(__name__)
+    # [issue43-hotfix] per-step scheduler diagnostics gate (issue #43).
+    # Set DSPARK_ISSUE43_SCHED_DIAG=1 in the container env to emit one
+    # compact scheduled-tokens / decode-skip summary line per step.
+    _ISSUE43_SCHED_DIAG = os.environ.get("DSPARK_ISSUE43_SCHED_DIAG", "0") not in ("0", "", "false", "False")
+
+    class Scheduler:
+        def _mamba_block_aligned_split(self, request, num_new_tokens):
+            return num_new_tokens
+
+        def schedule(self):
+            scheduled_running_reqs = []
+            req_to_new_blocks = {}
+            num_scheduled_tokens = {}
+            scheduled_spec_decode_tokens = {}
+            scheduled_encoder_inputs = {}
+            token_budget = 8192
+            encoder_compute_budget = 0
+            scheduled_timestamp = time.monotonic()
+            preempted_reqs = []
+            req_index = 0
+            defer_prefills = False
+            prefill_scheduled = False
+            # [issue43-hotfix] per-step scheduler diagnostics (issue #43).
+            # Tracks per-request scheduled prefill/decode token counts and
+            # zero-token decode skips (by request_id and running-list pos).
+            # Always built (cheap); only the step log line (below) is gated.
+            issue43_step_diag = {"prefill": {}, "decode": {}, "skips": []}
+            request = self.running[req_index]
+            num_new_tokens = token_budget
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(
+                    request, num_new_tokens
+                )
+
+            # [issue43-hotfix] bounded decode service during mixed prefill
+            # steps (issue #43 ask #3). Generalizes the #27
+            # max_num_partial_prefills cap: regardless of the configured
+            # --long-prefill-token-threshold, never let a prefill chunk
+            # consume so much remaining token budget that a decode-active
+            # request later in self.running is forced to num_new_tokens==0
+            # and skipped. Reserve >=1 decode step of tokens for every
+            # not-yet-visited decode-active lane; if the reservation can't
+            # be met alongside the prefill chunk, drop the chunk to 0 so the
+            # zero-check below skips it (continue) and the decodes run.
+            if getattr(request, "is_prefill_chunk", False):
+                _dec_floor = 0
+                for _ri in range(req_index + 1, len(self.running)):
+                    _r = self.running[_ri]
+                    if (_r.num_output_placeholders > 0 and
+                            _r.num_computed_tokens + 2
+                            - _r.num_output_placeholders
+                            >= _r.num_prompt_tokens + _r.max_tokens):
+                        continue
+                    if self.current_step < _r.next_decode_eligible_step:
+                        continue
+                    if defer_prefills and getattr(_r, "is_prefill_chunk", False):
+                        continue
+                    if _r.num_computed_tokens >= _r.num_prompt_tokens:
+                        _dec_floor += self.num_sampled_tokens_per_step
+                if _dec_floor > 0:
+                    num_new_tokens = min(
+                        num_new_tokens,
+                        max(0, token_budget - _dec_floor))
+
+            if num_new_tokens == 0:
+                # The request cannot be scheduled.
+                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                # we do not strictly follow the FCFS scheduling policy and
+                # allow the lower-priority requests to be scheduled.
+                # [issue43-hotfix] record zero-token decode skips (issue #43
+                # ask #2): a request past its prompt with no pending async
+                # max-tokens sentinel is decode-active and got skipped here.
+                if (request.num_computed_tokens >= request.num_prompt_tokens
+                        and request.num_output_placeholders == 0):
+                    issue43_step_diag["skips"].append(
+                        (request.request_id, req_index,
+                         request.num_computed_tokens))
+                req_index += 1
+
+            if False:
+                preempted_req = request
+                self.running.remove(preempted_req)
+                if preempted_req in scheduled_running_reqs:
+                    preempted_req_id = preempted_req.request_id
+                    scheduled_running_reqs.remove(preempted_req)
+                    token_budget += num_scheduled_tokens.pop(preempted_req_id)
+                    req_to_new_blocks.pop(preempted_req_id)
+                    scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                    preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                        preempted_req_id, None
+                    )
+                    if preempted_encoder_inputs:
+                        encoder_compute_budget += 1
+                    req_index -= 1
+
+            scheduled_running_reqs.append(request)
+            prefill_scheduled |= request.is_prefill_chunk
+            request_id = request.request_id
+            req_to_new_blocks[request_id] = object()
+            num_scheduled_tokens[request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            # [issue43-hotfix] per-request scheduled-tokens record (issue
+            # #43 ask #1). Decode-active => "decode", else prefill chunk.
+            _is_dec = (request.num_computed_tokens >= request.num_prompt_tokens
+                       and not request.is_prefill_chunk)
+            issue43_step_diag[
+                "decode" if _is_dec else "prefill"][request_id] = num_new_tokens
+            req_index += 1
+
+            # [issue43-hotfix] step summary (issue #43 asks #1/#2). Stash the
+            # per-step diag for the live reproducer; emit a compact log line
+            # only when DSPARK_ISSUE43_SCHED_DIAG=1 to keep default overhead 0.
+            self.issue43_last_step_diag = issue43_step_diag
+            if _ISSUE43_SCHED_DIAG and (issue43_step_diag["prefill"]
+                                        or issue43_step_diag["decode"]
+                                        or issue43_step_diag["skips"]):
+                pass
+
+            # Record the LoRAs in scheduled_running_reqs
+            # Next, schedule the WAITING requests.
+            if not preempted_reqs:
+                load_kv_async = False
+                num_computed_tokens = request.num_computed_tokens
+                num_new_local_computed_tokens = 0
+                num_external_computed_tokens = 0
+                if load_kv_async:
+                    num_new_tokens = 0
+                else:
+                    # Number of tokens to be scheduled.
+                    # We use `request.num_tokens` instead of
+                    # `request.num_prompt_tokens` to consider the resumed
+                    # requests, which have output tokens.
+                    num_new_tokens = request.num_tokens - num_computed_tokens
+                    threshold = self.scheduler_config.long_prefill_token_threshold
+                    if 0 < threshold < num_new_tokens:
+                        num_new_tokens = threshold
+
+                    # chunked prefill has to be enabled explicitly to allow
+                    # pooling requests to be chunked
+                    if num_new_tokens > token_budget:
+                        pass
+                    num_new_tokens = min(num_new_tokens, token_budget)
+
+                if self.need_mamba_block_aligned_split:
+                    num_new_tokens = self._mamba_block_aligned_split(
+                        request, num_new_tokens
+                    )
+            return issue43_step_diag
+    '''
+)
+
+# The real anchors live inside the RUNNING-list loop. Keep the fixture readable
+# above, then nest that fragment to the same indentation as the image target.
+_LEGACY_LOOP_START = "        request = self.running[req_index]\n"
+_LEGACY_LOOP_END = "\n        if False:\n"
+_loop_start = LEGACY_PATCHED_SCHEDULER.index(_LEGACY_LOOP_START)
+_loop_end = LEGACY_PATCHED_SCHEDULER.index(_LEGACY_LOOP_END, _loop_start)
+_loop_body = LEGACY_PATCHED_SCHEDULER[_loop_start:_loop_end]
+LEGACY_PATCHED_SCHEDULER = (
+    LEGACY_PATCHED_SCHEDULER[:_loop_start]
+    + "        if True:\n"
+    + textwrap.indent(_loop_body, "    ")
+    + LEGACY_PATCHED_SCHEDULER[_loop_end:]
+)
+
+# Likewise retain production's WAITING queue loop depth so the v3 anchor is the
+# exact 20-space false-branch threshold block used by the preserved scheduler.
+_WAIT_BODY_START = "            load_kv_async = False\n"
+_WAIT_BODY_END = "        return issue43_step_diag\n"
+_wait_start = LEGACY_PATCHED_SCHEDULER.index(_WAIT_BODY_START)
+_wait_end = LEGACY_PATCHED_SCHEDULER.index(_WAIT_BODY_END, _wait_start)
+_wait_body = LEGACY_PATCHED_SCHEDULER[_wait_start:_wait_end]
+LEGACY_PATCHED_SCHEDULER = (
+    LEGACY_PATCHED_SCHEDULER[:_wait_start]
+    + "            while True:\n"
+    + textwrap.indent(_wait_body, "    ")
+    + LEGACY_PATCHED_SCHEDULER[_wait_end:]
+)
+
+
+def run_hotfix(target: pathlib.Path, *args: str) -> str:
+    source = HOTFIX.read_text().replace(TARGET_LITERAL, f"Path({str(target)!r})")
+    old_argv = sys.argv
+    output = io.StringIO()
+    try:
+        sys.argv = [str(HOTFIX), *args]
+        with contextlib.redirect_stdout(output):
+            exec(compile(source, str(HOTFIX), "exec"), {})
+    except SystemExit as exc:
+        if exc.code not in (None, 0):
+            raise
+    finally:
+        sys.argv = old_argv
+    return output.getvalue()
+
+
+class LegacyUpgradeTests(unittest.TestCase):
+    def test_legacy_patch_upgrades_compiles_reports_current_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / "scheduler.py"
+            target.write_text(LEGACY_PATCHED_SCHEDULER)
+
+            self.assertIn("LEGACY", run_hotfix(target, "--status"))
+            run_hotfix(target)
+            upgraded = target.read_text()
+
+            self.assertIn(CURRENT_MARK, upgraded)
+            self.assertIn(V2_MARK, upgraded)
+            self.assertIn("DSPARK_MIXED_PREFILL_TOKEN_CAP", upgraded)
+            self.assertIn("_issue80_has_eligible_decode", upgraded)
+            self.assertEqual(
+                upgraded.count("per-request scheduled-tokens record (issue"), 1,
+                "legacy issue43 diagnostics must not be re-applied",
+            )
+            self.assertIn(
+                'issue43_step_diag["prefill"].pop(preempted_req_id, None)',
+                upgraded,
+            )
+            self.assertIn(
+                'issue43_step_diag["decode"].pop(preempted_req_id, None)',
+                upgraded,
+            )
+            cap_pos = upgraded.index("num_new_tokens, _ISSUE80_MIXED_PREFILL_TOKEN_CAP")
+            mamba_pos = upgraded.index("if self.need_mamba_block_aligned_split", cap_pos)
+            floor_pos = upgraded.index("_dec_floor = 0", mamba_pos)
+            self.assertLess(cap_pos, mamba_pos)
+            self.assertLess(mamba_pos, floor_pos)
+            waiting_cap_pos = upgraded.index(CURRENT_MARK)
+            waiting_async_zero_pos = upgraded.rfind(
+                "                    num_new_tokens = 0", 0, waiting_cap_pos
+            )
+            waiting_threshold_pos = upgraded.rfind(
+                "threshold = self.scheduler_config.long_prefill_token_threshold",
+                0,
+                waiting_cap_pos,
+            )
+            waiting_budget_pos = upgraded.index(
+                "# chunked prefill has to be enabled explicitly", waiting_cap_pos
+            )
+            waiting_mamba_pos = upgraded.index(
+                "if self.need_mamba_block_aligned_split", waiting_budget_pos
+            )
+            self.assertGreaterEqual(waiting_async_zero_pos, 0)
+            self.assertGreaterEqual(waiting_threshold_pos, 0)
+            self.assertLess(waiting_async_zero_pos, waiting_threshold_pos)
+            self.assertLess(waiting_threshold_pos, waiting_cap_pos)
+            self.assertLess(waiting_cap_pos, waiting_budget_pos)
+            self.assertLess(waiting_budget_pos, waiting_mamba_pos)
+            py_compile.compile(str(target), doraise=True)
+            self.assertIn("CURRENT", run_hotfix(target, "--status"))
+
+            before = target.read_bytes()
+            output = run_hotfix(target)
+            self.assertIn("already applied", output)
+            self.assertEqual(target.read_bytes(), before)
+
+    def test_status_distinguishes_stock_legacy_v2_and_current_v3(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / "scheduler.py"
+            target.write_text("# stock\n")
+            self.assertIn("NOT APPLIED", run_hotfix(target, "--status"))
+
+            target.write_text(LEGACY_PATCHED_SCHEDULER)
+            self.assertRegex(run_hotfix(target, "--status"), r": LEGACY\s*$")
+            run_hotfix(target)
+            current = target.read_text()
+            self.assertRegex(run_hotfix(target, "--status"), r": CURRENT\s*$")
+
+            waiting_start = current.index(
+                "                    # [issue80-scheduler-current-v3]"
+            )
+            waiting_end = current.index(
+                "                    # chunked prefill has to be enabled", waiting_start
+            )
+            target.write_text(current[:waiting_start] + current[waiting_end:])
+            self.assertIn(V2_MARK, target.read_text())
+            self.assertNotIn(CURRENT_MARK, target.read_text())
+            self.assertRegex(run_hotfix(target, "--status"), r": LEGACY_V2\s*$")
+
+    def test_realistic_v2_to_v3_upgrade_adds_only_waiting_block(self):
+        """Build current locally, regress it to v2, then exercise the upgrader."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / "scheduler.py"
+            target.write_text(LEGACY_PATCHED_SCHEDULER)
+            run_hotfix(target)
+            expected_current = target.read_text()
+
+            waiting_start = expected_current.index(
+                "                    # [issue80-scheduler-current-v3]"
+            )
+            waiting_end = expected_current.index(
+                "                    # chunked prefill has to be enabled", waiting_start
+            )
+            v2 = expected_current[:waiting_start] + expected_current[waiting_end:]
+            self.assertIn(V2_MARK, v2)
+            self.assertNotIn(CURRENT_MARK, v2)
+            target.write_text(v2)
+
+            self.assertRegex(run_hotfix(target, "--status"), r": LEGACY_V2\s*$")
+            run_hotfix(target)
+            self.assertEqual(target.read_text(), expected_current)
+            py_compile.compile(str(target), doraise=True)
+            self.assertRegex(run_hotfix(target, "--status"), r": CURRENT\s*$")
+
+            before = target.read_bytes()
+            self.assertIn("already applied", run_hotfix(target))
+            self.assertEqual(target.read_bytes(), before)
+
+    def test_v2_upgrade_fails_closed_when_waiting_anchor_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / "scheduler.py"
+            target.write_text(LEGACY_PATCHED_SCHEDULER)
+            run_hotfix(target)
+            current = target.read_text()
+            waiting_start = current.index(
+                "                    # [issue80-scheduler-current-v3]"
+            )
+            waiting_end = current.index(
+                "                    # chunked prefill has to be enabled", waiting_start
+            )
+            v2 = current[:waiting_start] + current[waiting_end:]
+            v2 = v2.replace(
+                "                    threshold = self.scheduler_config.long_prefill_token_threshold\n",
+                "                    waiting_threshold = self.scheduler_config.long_prefill_token_threshold\n",
+                1,
+            )
+            target.write_text(v2)
+            before = target.read_bytes()
+
+            with self.assertRaisesRegex(AssertionError, "WAITING"):
+                run_hotfix(target)
+            self.assertEqual(target.read_bytes(), before)
+
+    def test_legacy_upgrade_fails_closed_when_an_asserted_anchor_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / "scheduler.py"
+            broken = LEGACY_PATCHED_SCHEDULER.replace(
+                "scheduled_spec_decode_tokens.pop(preempted_req_id, None)\n",
+                "",
+            )
+            target.write_text(broken)
+            before = target.read_bytes()
+
+            with self.assertRaisesRegex(AssertionError, "preemption"):
+                run_hotfix(target)
+            self.assertEqual(target.read_bytes(), before)
+
+
+class MambaAndPreemptionBehaviorTests(unittest.TestCase):
+    @staticmethod
+    def _prefill(rid: str = "prefill") -> sim.Req:
+        request = sim.Req(rid, prompt_tokens=4096, max_tokens=128)
+        request.is_prefill_chunk = True
+        return request
+
+    @staticmethod
+    def _decode(rid: str = "decode") -> sim.Req:
+        request = sim.Req(rid, prompt_tokens=32, max_tokens=128,
+                          sampled_tokens_per_step=1)
+        request.num_computed_tokens = request.num_prompt_tokens
+        return request
+
+    def test_mixed_cap_is_aligned_before_floor_for_generic_mamba_scheduler(self):
+        running = [self._prefill(), self._decode()]
+        scheduled, _ = sim.step(
+            running,
+            token_budget=4096,
+            current_step=1,
+            long_threshold=1024,
+            mixed_prefill_cap=255,
+            mamba_block_size=128,
+        )
+        by_id = {request.request_id: tokens for request, tokens in scheduled}
+        self.assertEqual(by_id, {"prefill": 128, "decode": 1})
+        self.assertEqual(by_id["prefill"] % 128, 0)
+
+    def test_preempted_scheduled_request_is_removed_from_both_diag_maps(self):
+        prefill = self._prefill("victim")
+        decode = self._decode("survivor")
+        running = [prefill, decode]
+        diag: dict = {}
+        scheduled, leftover = sim.step(
+            running,
+            token_budget=1024,
+            current_step=1,
+            long_threshold=256,
+            mixed_prefill_cap=255,
+            diag=diag,
+        )
+        num_scheduled_tokens = {
+            request.request_id: tokens for request, tokens in scheduled
+        }
+
+        restored = sim.rollback_scheduled_preemption(
+            running, scheduled, num_scheduled_tokens, diag, "victim"
+        )
+        leftover += restored
+
+        self.assertNotIn("victim", [request.request_id for request in running])
+        self.assertNotIn("victim", [request.request_id for request, _ in scheduled])
+        self.assertEqual(set(diag["prefill"]) | set(diag["decode"]),
+                         set(num_scheduled_tokens))
+        self.assertEqual(
+            sum(diag["prefill"].values()) + sum(diag["decode"].values()),
+            sum(num_scheduled_tokens.values()),
+        )
+        self.assertEqual(leftover + sum(num_scheduled_tokens.values()), 1024)
+
+
+class ComposeFailClosedTests(unittest.TestCase):
+    def test_each_critical_python_scheduler_patch_has_its_own_failure_guard(self):
+        compose = COMPOSE.read_text()
+        for name in (
+            "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
+            "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(f"python3 /opt/{name} || exit 1;", compose)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Mitigates #80's mixed prefill/decode wall-clock stall on the current pinned Anemll vLLM image.

- keep the global long-prefill threshold at 1,024 when no decode lane is eligible
- cap each RUNNING or newly admitted/resumed WAITING prefill chunk at 256 while an eligible decode lane exists
- preserve the existing #43 decode-service floor and diagnostics
- expose `DSPARK_MIXED_PREFILL_TOKEN_CAP` (`256` default, `0` rollback)
- add fresh/legacy/v2→v3 patch upgrade handling and fail-closed anchors
- reconcile issue43 diagnostics when PRIORITY preemption rolls back a scheduled request

This is an interim post-TTFT QoS mitigation. It does not solve the initial serialized-prefill/TTFT stagger tracked by #45.

## Root-cause evidence

Per-step scheduler diagnostics showed that the affected decode lane was not skipped:

```text
prefill_toks={peer: 1024}
decode_toks={active: 6}
decode_skips=[]
```

Host-side timing on both TP ranks localized the slowdown to the mixed `execute_model` span:

| Shape | Rank 0 execute p50/p95 | Rank 1 execute p50/p95 |
|---|---:|---:|
| decode-only `(6,1,6)` | 3.64 / 5.48 ms | 3.09 / 3.80 ms |
| mixed `(1030,2,1024)` | 577.26 / 620.97 ms | 577.28 / 620.76 ms |

The mean absolute TP-rank difference on 480 mixed steps was 0.40 ms, so this was not a rank/fabric straggler. Sampling was secondary at about 36.5 ms.

## Threshold A/B

Deterministic two-lane workload: Lane A = 256 cold prompt + 8,192 output; Lane B = cold 98,304 prompt + 32 output; TP=2, async scheduling, MTP5, prefill cap=2, zero preemptions/waiting/cache hits.

| Global threshold | Mixed tok/s | Mixed ITL p95 | B TTFT | Pair makespan |
|---:|---:|---:|---:|---:|
| 1024 | 9.74 | 665 ms | 60.18 s | 146.46 s |
| 512 | 15.51 | 515 ms | 75.06 s | 156.66 s |
| 256 | 24.58 | 257 ms | 94.22 s | 161.12 s |
| 128 | 29.34 | ~200 ms runner p95 | 157.59 s | 198.67 s |

256 was the measured knee: 128 gained only about 19% mixed decode but regressed TTFT about 67% and makespan about 23% versus 256.

## Dynamic-cap live validation

Configuration:

```text
LONG_PREFILL_TOKEN_THRESHOLD=1024
DSPARK_MIXED_PREFILL_TOKEN_CAP=256
DSPARK_MAX_INFLIGHT_PREFILLS=2
```

Prefill-only control retained four 1,024-token chunks for a cold 4,096-token prompt.

The first mixed batch, including a newly admitted WAITING request, was exactly:

```text
scheduled_toks=262 requests=2 max_req_toks=256
```

on both ranks. No initial 1,030-token mixed batch occurred.

| Cold peer prompt | Mixed tok/s | Recovery tok/s | Max gap | Verdict |
|---:|---:|---:|---:|---|
| 32K | 22.49 | 87.35 | 2.94 s* | NO_REPRO |
| 64K | 24.41 | 87.41 | 0.304 s | NO_REPRO |
| 98K | 23.74 | 86.88 | 0.361 s | NO_REPRO |
| 131K | 23.53 | 86.72 | 0.389 s | NO_REPRO |

`*` one-time first-shape JIT, symmetric across both ranks.

All cells passed exact access-log, API/Prometheus counter, SSE/usage, sampler freshness, final finite-metric, and drain gates. Final state was Running=0, Waiting=0, KV=0, preemptions=0. MTP acceptance was 27,444 / 27,485 = 99.85%. No CUDA, NCCL, Xid, OOM, or engine errors occurred.

The no-cap 98K baseline reproduced `PASS_DEGRADED_CLASS` and confirmed 3/3 with fresh prefixes. Dynamic v3 returned `NO_REPRO` through 131K.

## Scheduler details

- eligible decode detection scans the full RUNNING list, independent of request order
- finished async sentinels, future-cadence requests, and prefill chunks do not activate the cap
- the cap is applied before Mamba alignment and the existing #43 floor
- the same schedule-start decision caps the first non-async WAITING chunk after RUNNING scheduling
- async remote-KV load-zero remains untouched
- `0` disables the cap; invalid values fail closed at scheduler import
- v3 supports fresh install, old #43 legacy upgrade, v2→v3 upgrade, and current idempotence

## Validation

- 25 focused cap/parser/WAITING/upgrade/preemption tests
- exact pinned-image scheduler extraction and #27→#43/v3 patch application, compile, and idempotence
- issue43 simulator at partial-prefill caps 1 and 2 with zero decode skips
- complete `bash scripts/ci-validate.sh`
- `py_compile`, shell syntax, Compose rendering, and `git diff --check`

## Scope and limitations

- The diagnostic GPUWorker timing patch used to localize the stall is intentionally not included here.
- This does not claim to satisfy #45's whole-request min/max or TTFT-skew acceptance criteria.
- The exact dual-400K workload should remain an upstream acceptance cell; this PR validates cold peers through 131K plus ordinary-traffic captures.
- Rollback requires setting `DSPARK_MIXED_PREFILL_TOKEN_CAP=0` and recreating both containers because the value is parsed at module import.

Addresses #80. Related: #27, #43, #45, #47.
