### PR TITLE
fix(boot): persist Triton cache + pre-warm spec-decode shape buckets (closes #117 local surface)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -317,6 +317,18 @@ TILELANG_CLEANUP_TEMP_FILES=1
 # (stock 300s). TileLang cache lives on the HF volume, not the container layer.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 TILELANG_CACHE_DIR=/cache/huggingface/tilelang-cache
+# Issue #117: persist Triton's JIT cache too — the in-image ~/.triton/cache
+# dies on container recreate, so every restart re-JITs known shapes mid-serve,
+# and a compiling rank can stall its TP peer past torch's 600s NCCL watchdog
+# (a deadline VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS does not extend).
+TRITON_CACHE_DIR=/cache/huggingface/triton-cache
+# Issue #117: post-ready boot sweep that burns the spec-decode/prefill Triton
+# shape buckets (concurrency C=1/2/4/6, medium + multi-chunk prefill,
+# thinking-off arm) before real traffic can JIT them mid-serve. Non-fatal:
+# warmup failure degrades to the mid-serve-JIT status quo, never a failed
+# boot. Closure signal: jit_monitor warnings during serve = a shape the sweep
+# missed. Set 0 to skip.
+# DSPARK_BOOT_SHAPE_WARMUP=1
 DG_JIT_USE_NVRTC=0
 DG_JIT_NVCC_COMPILER=/usr/local/cuda/bin/nvcc
 NCCL_NET=IB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-23
+
+### Added
+
+- **Boot-time defense against the mid-serve-JIT → TP-pair-loss chain ([Issue #117](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/117))**, two independent layers. (1) `TRITON_CACHE_DIR` now defaults to `/cache/huggingface/triton-cache` on the HF volume, mirroring the `TILELANG_CACHE_DIR` fix from issue #65: the in-image `~/.triton/cache` dies on container recreate, so every restart re-JIT-compiled already-known Triton shapes mid-serve — and a rank stalled in compilation leaves its TP peer waiting in a collective until torch's ProcessGroupNCCL watchdog (600 s, a deadline `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` does not extend) terminates it; the field incident in #117 recorded exactly this chain from `_prepare_dflash_inputs_kernel`. Cache entries are keyed by Triton version/backend hash, so the shared directory is safe across image updates. (2) `scripts/boot-shape-warmup.sh`, run by the launcher after the smoke request (gate `DSPARK_BOOT_SHAPE_WARMUP`, default `1`): a post-ready sweep — concurrency C=1/2/4/6 bursts, a medium and a multi-chunk (8192-boundary-crossing) prefill, and a thinking-off arm, all nonce-tagged so prefix caching cannot skip the prefill being warmed — that materializes the enumerable spec-decode/prefill shape buckets (`BLOCK_SIZE = min(256, next_pow2(max_tokens_per_req))`) before real traffic can JIT them. Warmup is non-fatal by contract: a failure degrades to the mid-serve-JIT status quo and WARNs, never fails the boot; `jit_monitor` warnings during subsequent serving are the closure signal for shapes the sweep still misses. Documented in `.env.dspark.example` and `docs/ENVS.md`; CPU-gated by `scripts/test-boot-shape-warmup.sh` (recording-curl-stub behavioral matrix: arm/tag inventory, single thinking-off arm, chunk-boundary length, per-run nonce rotation, fail and unreachable paths), wired into `scripts/ci-validate.sh`.
+
 ## 2026-08-22
 
 ### Changed

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -137,6 +137,13 @@ services:
       # Persist TileLang compiled kernels on the HF cache volume (issue #65).
       # Default in-image path was ~/.tilelang/cache (lost on recreate).
       TILELANG_CACHE_DIR: "${TILELANG_CACHE_DIR:-/cache/huggingface/tilelang-cache}"
+      # Persist Triton's JIT cache on the HF volume (issue #117). Default
+      # in-image path is ~/.triton/cache and dies on container recreate, so
+      # every restart re-JITs known shapes mid-serve; a compiling rank can
+      # stall its TP peer past torch's 600s NCCL watchdog. Entries are keyed
+      # by Triton version/backend hash, so sharing the dir across image
+      # updates is safe.
+      TRITON_CACHE_DIR: "${TRITON_CACHE_DIR:-/cache/huggingface/triton-cache}"
       DG_JIT_USE_NVRTC: "${DG_JIT_USE_NVRTC:-0}"
       DG_JIT_NVCC_COMPILER: "${DG_JIT_NVCC_COMPILER:-/usr/local/cuda/bin/nvcc}"
       PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -66,6 +66,8 @@ PY
 | `VLLM_CACHE_ROOT` | vLLM cache root (compose sets path) |
 | `CUTE_DSL_ARCH` | **Not** `VLLM_*` — CuTeDSL/b12x compile target (`sm_121a` on GB10) |
 | `TILELANG_CACHE_DIR` | **Not** `VLLM_*`. Compose default `/cache/huggingface/tilelang-cache` (HF volume). Issue #65: in-image `~/.tilelang/cache` dies on container recreate. |
+| `TRITON_CACHE_DIR` | **Not** `VLLM_*`. Compose default `/cache/huggingface/triton-cache` (HF volume). Issue #117: in-image `~/.triton/cache` dies on container recreate, so known shapes re-JIT mid-serve after every restart — and a compiling rank can stall its TP peer past torch's 600s NCCL watchdog. |
+| `DSPARK_BOOT_SHAPE_WARMUP` | Launcher-side (not passed to the container). `1` (default) runs `scripts/boot-shape-warmup.sh` after the smoke request: a C=1/2/4/6 + medium/long-prefill + thinking-off sweep that burns the spec-decode/prefill Triton shape buckets before traffic (issue #117). `0` skips. Warmup failure is a WARN, never a boot failure. |
 | `TORCH_CUDA_ARCH_LIST` / `FLASHINFER_CUDA_ARCH_LIST` | Build/JIT arch lists |
 | `NCCL_*` / `TP_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME` | Fabric |
 | `NCCL_IB_MERGE_NICS` | Passthrough, default **unset**. Contract for all four passthrough knobs below: a configured non-empty value passes through unchanged; an empty value is normalized to absent (the entrypoint unsets empty definitions before exec, so NCCL's built-in default and config-file values still apply and cannot be masked). NCCL's own default is `1`: it *permits* merging compatible dual-port NICs; it does not select HCAs or force arbitrary links (`NCCL_NET_MERGE_LEVEL`/`NCCL_NET_FORCE_MERGE` participate in that topology decision). `0` disables merging. |

--- a/scripts/boot-shape-warmup.sh
+++ b/scripts/boot-shape-warmup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# boot-shape-warmup.sh — burn spec-decode/prefill Triton shape buckets at boot.
+#
+# Why (issue #117): under live concurrent traffic, batch shapes that the single
+# smoke request never materializes JIT-compile mid-serve. jit_monitor warns
+# about the latency spike, but the real hazard on TP=2 is worse: a rank stalled
+# in compilation leaves its peer waiting in a collective, and torch's
+# ProcessGroupNCCL watchdog (600 s, NOT covered by
+# VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS) kills the pair. Observed kernel:
+# _prepare_dflash_inputs_kernel, whose shape key is
+#   BLOCK_SIZE = min(256, next_pow2(max_tokens_per_req))
+# so the reachable buckets are small and enumerable: spec-decode steps sit at
+# next_pow2(K+1), any prefill chunk >=256 tokens caps at 256, and small
+# prefill tails fill the low buckets. This sweep materializes them at boot,
+# before traffic: concurrency C=1/2/4/6 (multi-request decode batches), a
+# medium and a multi-chunk long prefill (8192-chunk + odd tail), and a
+# thinking-off arm. Prompts carry a per-request nonce so prefix caching cannot
+# skip the prefill compute being warmed.
+#
+# Non-fatal by design: the cost of a missed shape is a mid-serve JIT (what this
+# script exists to reduce), not an outage — the launcher must treat a warmup
+# failure as WARN, never as a boot failure. Pair with a persistent
+# TRITON_CACHE_DIR so each bucket is compiled once per image, not once per boot.
+#
+# Usage: boot-shape-warmup.sh [base_url] [model]
+#   base_url default http://127.0.0.1:8888 ; model default deepseek-v4-flash-0731
+# Env:
+#   DSPARK_WARMUP_REQ_TIMEOUT  per-request curl --max-time, seconds (default 240
+#                              — first-ever boot pays real compiles here)
+#   VLLM_API_KEY               added as Bearer auth when non-empty
+#   WARMUP_CURL                test seam: overrides the curl binary
+set -u
+
+BASE="${1:-http://127.0.0.1:8888}"
+MODEL="${2:-deepseek-v4-flash-0731}"
+CURL_BIN="${WARMUP_CURL:-curl}"
+REQ_TIMEOUT="${DSPARK_WARMUP_REQ_TIMEOUT:-240}"
+NONCE="$$-$(date +%s)"
+
+AUTH_ARGS=()
+[ -n "${VLLM_API_KEY:-}" ] && AUTH_ARGS=(-H "Authorization: Bearer ${VLLM_API_KEY}")
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mk_prompt() { # $1 = approx token count (repeated filler words), $2 = tag
+  local n=$1 tag=$2 body
+  body=$(printf 'warm %.0s' $(seq 1 "$n"))
+  printf '[warmup %s %s] The following is filler context, ignore it: %s Reply with OK.' \
+    "$NONCE" "$tag" "$body"
+}
+
+fire() { # $1 = tag, $2 = words, $3 = thinking(true|false), $4 = result file
+  local tag=$1 words=$2 thinking=$3 out=$4 prompt
+  prompt=$(mk_prompt "$words" "$tag")
+  if "$CURL_BIN" -fsS --max-time "$REQ_TIMEOUT" "${AUTH_ARGS[@]}" \
+      "$BASE/v1/chat/completions" -H "Content-Type: application/json" \
+      -d '{"model":"'"$MODEL"'","messages":[{"role":"user","content":"'"$prompt"'"}],"max_tokens":24,"temperature":0,"chat_template_kwargs":{"thinking":'"$thinking"',"reasoning_effort":"low"}}' \
+      >/dev/null 2>>"$tmpdir/errors"; then
+    echo ok > "$out"
+  else
+    echo fail > "$out"
+  fi
+}
+
+burst() { # $1 = arm name, $2 = concurrency, $3 = words-per-request
+  local arm=$1 c=$2 words=$3 i t0 t1
+  t0=$(date +%s)
+  for i in $(seq 1 "$c"); do
+    fire "${arm}-${i}" "$words" true "$tmpdir/${arm}-${i}" &
+  done
+  wait
+  t1=$(date +%s)
+  echo "  arm ${arm}: C=${c} x ~${words} tok, $((t1 - t0))s"
+}
+
+if ! "$CURL_BIN" -fsS --max-time 10 "${AUTH_ARGS[@]}" "$BASE/v1/models" >/dev/null 2>&1; then
+  echo "boot-shape-warmup: API not reachable at $BASE — skipping sweep" >&2
+  exit 1
+fi
+
+echo "boot-shape-warmup: sweeping spec-decode/prefill shape buckets (issue #117)"
+total_t0=$(date +%s)
+
+burst c1        1 300
+burst c2        2 420
+burst c4        4 380
+burst c6        6 350
+burst mid       1 2600
+burst longchunk 1 9500          # crosses the 8192-token chunk boundary + odd tail
+t0=$(date +%s)
+fire nothink-1 300 false "$tmpdir/nothink-1"
+t1=$(date +%s)
+echo "  arm nothink: C=1 x ~300 tok, thinking=false, $((t1 - t0))s"
+
+total=0 ok_count=0
+for f in "$tmpdir"/*-*; do
+  [ -f "$f" ] || continue
+  total=$((total + 1))
+  [ "$(cat "$f")" = "ok" ] && ok_count=$((ok_count + 1))
+done
+total_t1=$(date +%s)
+echo "boot-shape-warmup: ${ok_count}/${total} requests ok in $((total_t1 - total_t0))s"
+
+if [ "$ok_count" -lt "$total" ]; then
+  echo "boot-shape-warmup: $((total - ok_count)) request(s) failed — uncovered shapes may JIT mid-serve" >&2
+  sed -n '1,5p' "$tmpdir/errors" >&2 2>/dev/null || true
+  exit 1
+fi
+exit 0

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -23,6 +23,8 @@ for f in \
   scripts/test-draft-sample-method-gate.sh \
   scripts/test-nccl-fabric-passthrough.sh \
   scripts/test-nccl-ib-hca-gid-resolve.sh \
+  scripts/boot-shape-warmup.sh \
+  scripts/test-boot-shape-warmup.sh \
   patches/*.sh
 do
   [ -e "$f" ] || continue
@@ -96,6 +98,8 @@ bash scripts/test-draft-sample-method-gate.sh -q
 ok "test-draft-sample-method-gate"
 bash scripts/test-nccl-fabric-passthrough.sh -q
 ok "test-nccl-fabric-passthrough"
+bash scripts/test-boot-shape-warmup.sh -q
+ok "test-boot-shape-warmup"
 bash scripts/test-nccl-ib-hca-gid-resolve.sh -q
 ok "test-nccl-ib-hca-gid-resolve"
 

--- a/scripts/test-boot-shape-warmup.sh
+++ b/scripts/test-boot-shape-warmup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test-boot-shape-warmup.sh — CPU behavioral tests for scripts/boot-shape-warmup.sh.
+#
+# Uses the WARMUP_CURL seam to substitute a recording stub for curl; every
+# assertion is behavioral (exit codes, recorded request bodies). No GPU, no
+# network. Run: bash scripts/test-boot-shape-warmup.sh [-q]
+set -u
+
+QUIET="${1:-}"
+here="$(cd "$(dirname "$0")" && pwd)"
+target="$here/boot-shape-warmup.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0 fail=0
+ok()  { pass=$((pass + 1)); [ "$QUIET" = "-q" ] || printf '  ok  %s\n' "$*"; }
+bad() { fail=$((fail + 1)); printf '  FAIL %s\n' "$*" >&2; }
+
+# Recording curl stub. STUB_MODE: ok | chatfail | probefail.
+cat > "$work/curl-stub" <<'STUB'
+#!/usr/bin/env bash
+rec="${STUB_REC:?}"
+n=$(date +%s%N)-$$-$RANDOM
+is_probe=0; body=""
+prev=""
+for a in "$@"; do
+  case "$a" in */v1/models*) is_probe=1 ;; esac
+  [ "$prev" = "-d" ] && body="$a"
+  prev="$a"
+done
+if [ "$is_probe" = 1 ]; then
+  [ "${STUB_MODE:-ok}" = "probefail" ] && exit 22
+  exit 0
+fi
+printf '%s\n' "$body" > "$rec/chat-$n"
+[ "${STUB_MODE:-ok}" = "chatfail" ] && exit 22
+exit 0
+STUB
+chmod +x "$work/curl-stub"
+
+run_sweep() { # $1 = mode, $2 = record dir; returns script exit code
+  mkdir -p "$2"
+  STUB_MODE="$1" STUB_REC="$2" WARMUP_CURL="$work/curl-stub" \
+    bash "$target" http://stub:0 test-model > "$2/stdout" 2> "$2/stderr"
+}
+
+# ---- 1. all-success run: exit 0, 16 chat requests, every arm present -------
+rec="$work/r1"
+if run_sweep ok "$rec"; then ok "all-success sweep exits 0"; else bad "all-success sweep exited nonzero"; fi
+
+count=$(ls "$rec"/chat-* 2>/dev/null | wc -l)
+[ "$count" -eq 16 ] && ok "16 chat requests fired" || bad "expected 16 chat requests, got $count"
+
+for tag in c1-1 c2-1 c2-2 c4-1 c4-2 c4-3 c4-4 c6-1 c6-2 c6-3 c6-4 c6-5 c6-6 mid-1 longchunk-1; do
+  grep -lq "warmup .* ${tag}\]" "$rec"/chat-* || bad "arm ${tag} missing from recorded bodies"
+done
+grep -lq 'warmup .* nothink-1\]' "$rec"/chat-* && ok "all 16 arm tags present" \
+  || bad "nothink arm missing"
+
+# ---- 2. thinking-off arm is exactly one --------------------------------------
+tf=$(grep -l '"thinking":false' "$rec"/chat-* | wc -l)
+[ "$tf" -eq 1 ] && ok "exactly one thinking:false arm" || bad "thinking:false arms: $tf (want 1)"
+tt=$(grep -l '"thinking":true' "$rec"/chat-* | wc -l)
+[ "$tt" -eq 15 ] && ok "15 thinking:true arms" || bad "thinking:true arms: $tt (want 15)"
+
+# ---- 3. long arm actually crosses the 8192 chunk boundary --------------------
+longlen=$(wc -c < "$(grep -l 'longchunk-1\]' "$rec"/chat-*)")
+[ "$longlen" -gt 40000 ] && ok "longchunk body is ${longlen} bytes (> one 8192-token chunk)" \
+  || bad "longchunk body only ${longlen} bytes"
+
+# ---- 4. prefix-cache busting: per-run nonce differs, per-request tag differs -
+rec2="$work/r2"
+run_sweep ok "$rec2" >/dev/null 2>&1 || true
+n1=$(grep -oh 'warmup [^ ]*' "$rec"/chat-*  | sort -u | head -1)
+n2=$(grep -oh 'warmup [^ ]*' "$rec2"/chat-* | sort -u | head -1)
+[ -n "$n1" ] && [ "$n1" != "$n2" ] && ok "nonce differs across runs ($n1 vs $n2)" \
+  || bad "nonce identical across runs — prefix cache would skip the warmed prefill"
+uniq_tags=$(grep -oh 'warmup [^]]*\]' "$rec"/chat-* | sort -u | wc -l)
+[ "$uniq_tags" -eq 16 ] && ok "16 distinct request tags within a run" || bad "distinct tags: $uniq_tags (want 16)"
+
+# ---- 5. chat failures: exit 1, failure named on stderr -----------------------
+rec3="$work/r3"
+if run_sweep chatfail "$rec3"; then bad "chatfail sweep exited 0"; else ok "chatfail sweep exits nonzero"; fi
+grep -q "failed" "$rec3/stderr" && ok "failure named on stderr" || bad "no failure message on stderr"
+
+# ---- 6. unreachable API: exit 1 fast, no chat requests fired -----------------
+rec4="$work/r4"
+if run_sweep probefail "$rec4"; then bad "probefail sweep exited 0"; else ok "probefail sweep exits nonzero"; fi
+c4count=$(ls "$rec4"/chat-* 2>/dev/null | wc -l)
+[ "$c4count" -eq 0 ] && ok "no chat requests after failed probe" || bad "$c4count chat requests fired after failed probe"
+
+printf 'test-boot-shape-warmup: %d ok, %d failed\n' "$pass" "$fail"
+exit "$((fail > 0 ? 1 : 0))"

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -1108,6 +1108,17 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
         -d '{"model":"'"${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
       echo "Minimal chat request succeeded."
     fi
+    # Issue #117: burn the spec-decode/prefill Triton shape buckets before real
+    # traffic can JIT them mid-serve (a compiling rank can stall its peer past
+    # torch's 600 s NCCL watchdog). Non-fatal: warmup gaps degrade back to the
+    # mid-serve-JIT status quo, never to a failed boot.
+    if [ "${DSPARK_BOOT_SHAPE_WARMUP:-1}" = "1" ]; then
+      bash "$SCRIPT_DIR/scripts/boot-shape-warmup.sh" \
+        "${CHAT_URL%/v1/chat/completions}" "${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}" || \
+        echo "WARN: boot shape warmup incomplete — uncovered shapes may JIT mid-serve (issue #117)" >&2
+    else
+      echo "Boot shape warmup: SKIPPED (DSPARK_BOOT_SHAPE_WARMUP=0)"
+    fi
     exit 0
   fi
   wait_with_startup_logs


### PR DESCRIPTION
Implements the operator-side half of #117 — the two layers that don't need engine changes:

1. **`TRITON_CACHE_DIR` onto the HF volume** (mirrors the #65 `TILELANG_CACHE_DIR` fix). The in-image `~/.triton/cache` dies on container recreate, so every restart re-JITs already-known shapes mid-serve; #117's incident log shows what one such compile can cost on TP=2 (peer stalled in `_ALLGATHER_BASE` → torch's 600 s ProcessGroupNCCL watchdog kills the rank — a deadline `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` does not extend). Cache entries are keyed by Triton version/backend hash, so the shared dir is safe across image updates.

2. **`scripts/boot-shape-warmup.sh`** — launcher post-smoke sweep (gate `DSPARK_BOOT_SHAPE_WARMUP`, default 1, **non-fatal by contract**): concurrency C=1/2/4/6 bursts, a medium and an 8192-boundary-crossing prefill, and a thinking-off arm, all nonce-tagged so prefix caching cannot skip the prefill being warmed. The observed kernel's shape key is `BLOCK_SIZE = min(256, next_pow2(max_tokens_per_req))`, so the reachable buckets are enumerable and this sweep materializes them before traffic does. `jit_monitor` warnings during serve remain the closure signal for anything missed.

Not included (left for upstream per #117 ask 2): exposing the torch process-group timeout — on our own pair we deliberately keep the 600 s backstop, because both observed stalls exceeded 10 minutes and behave like rank desync rather than slow compiles; the layered external watchdog + docker self-heal handled recovery.

## Validation
- `bash scripts/ci-validate.sh` passes; new CPU gate `scripts/test-boot-shape-warmup.sh` (12 behavioral checks via a recording curl stub: arm/tag inventory, single thinking-off arm, chunk-boundary length, per-run nonce rotation, failure and unreachable paths).
- Live validation on both of our 2× DGX Spark TP=2 pairs is running today: first boot populates `/cache/huggingface/triton-cache` and the sweep compiles the buckets; second boot must show cache reuse (fast warmup, no new compile entries) and zero `jit_monitor` warnings under traffic. Will report numbers in this thread.

https://claude.ai/code/session_01Dcfsv9svWFUNJTUGxpYY9v