### PR TITLE
fix(encoder): reopen generation after trailing latest_reminder

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -231,14 +231,15 @@ VLLM_PREFIX_CACHE_RETENTION_INTERVAL=4096
 # VLLM_SUPPRESS_STOPS_IN_REASONING=0
 
 # Issue #52 / PR #53 (assistant-final continuation hotfix): when a request's
-# messages array ends with an assistant message, the stock renderer closes the
-# turn with EOS and appends no generation header, so the model generates from
-# a dead state — empty no-op turns / hallucinated DSML markup loops in agent
-# harnesses. Default 0 = stock renderer (patch is present on the worker but
-# never invoked). Set exactly 1 to apply the patch at container boot; the boot
-# then fails (exit 1) if the patch cannot be applied or verified, and an
-# already-patched encoder is re-verified instead of rewritten. See
-# docs/PATCHES.md ("Issue #52") for evidence status and fail-closed details.
+# messages array ends with an assistant message — or with a trailing
+# `latest_reminder` annotation directly after that closed assistant turn — the
+# stock renderer leaves the prompt without a generation header, so the model
+# generates from a dead state — empty no-op turns / hallucinated DSML markup
+# loops in agent harnesses. Default 0 = stock renderer (patch is present on
+# the worker but never invoked). Set exactly 1 to apply the patch at container
+# boot; the boot then fails (exit 1) if the patch cannot be applied or
+# verified, and an already-patched encoder is re-verified instead of rewritten.
+# See docs/PATCHES.md ("Issue #52") for evidence status and fail-closed details.
 DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX=0
 
 # Issue #66 / #31 GPU thinking_token_budget hotfix: default 0 = stock V2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-23
+
+### Fixed
+
+- **Trailing `latest_reminder` after a retried assistant turn no longer defeats the assistant-final generation-header hotfix ([Issue #120](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/120); extends Issue #52)**: a harness retry that re-sends its partial assistant turn and appends a trailing `latest_reminder` annotation left the prompt ending on the bare reminder with no generation header — stock closes the turn with EOS first — so the model kept generating from a dead state (immediate EOS or hallucinated DSML markup) and the #52 patcher's final-index guard never fired. The opt-in `DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX=1` patcher now also matches exactly one shape, a **final** `latest_reminder` whose immediate predecessor is an assistant message, and appends one fresh `<｜Assistant｜><think>` header after the reminder content; reminder tails directly after user/developer already end inside the checkpoint's pending generation slot and stay byte-identical, as do mid-transcript reminders, task rendering precedence, and every assistant-final shape. The post-write self-check now verifies both fixed shapes and fails closed (original bytes restored) if a patched encoder drops either header or double-headers a user→reminder tail. CPU regression tests fail on the pre-extension hotfix; verified against the real `encoding_dsv4.py` snapshot on CPU only — live two-rank boot proof is still outstanding (`docs/PATCHES.md`, "Issue #52").
+
 ## 2026-08-22
 
 ### Changed

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -230,6 +230,27 @@ turn, then appends a fresh generation header. Reopening the turn with `wo_eos`
 was measured worse (1-token empty generation on a complete turn) and is not
 used. Runs after the entrypoint copies the encoder into place.
 
+### Extension — trailing `latest_reminder` annotation (Issue #120)
+A harness retry can append a trailing `latest_reminder` message after the
+re-sent partial assistant turn. The reminder defeats the fix above: stock
+closes the assistant turn with EOS, renders the bare reminder after it, and
+the prompt still ends with no generation header — a dead state the model
+escapes with immediate EOS or hallucinated markup. Verified on the real
+checkpoint encoder (`encoding_dsv4.py`, snapshot `9e165c30`): a
+reminder tail directly after `user`/`developer` already ends inside the
+pending generation slot — the checkpoint emits
+`ASSISTANT_SP_TOKEN` + thinking token *before* such a reminder — so those
+tails are correct as-is.
+
+The transition condition is therefore widened by exactly one more clause: a
+**final** `latest_reminder` whose immediate predecessor is an **assistant**
+message gains one fresh generation header appended after the reminder content
+(thinking mode `<｜Assistant｜><think>`, chat mode `<｜Assistant｜></think>`).
+Reminder tails after user/developer, reminders mid-transcript, task-precedence
+rendering, and every assistant-final shape are byte-identical to the
+pre-extension hotfix behavior; the post-write self-check additionally fails
+closed if a patched encoder double-headers a user→reminder tail.
+
 ### Flag (default OFF = stock)
 | value | behavior |
 |---|---|
@@ -238,8 +259,10 @@ used. Runs after the entrypoint copies the encoder into place.
 
 Fail-closed when ON: missing encoder file, missing anchor, or a failed
 post-write self-check (patched module must import and render a
-trailing-assistant transcript with a generation header) → nonzero exit, boot
-aborts; a failed self-check **restores the original file bytes** first. An
+trailing-assistant transcript with a generation header and an
+assistant-plus-trailing-`latest_reminder` transcript with one fresh header,
+without appending a second header to a user→reminder tail) → nonzero exit,
+boot aborts; a failed self-check **restores the original file bytes** first. An
 already-patched encoder is re-validated (idempotent), never double-patched.
 
 ### Evidence status
@@ -261,6 +284,13 @@ same 98 stock token IDs were preserved with exactly
 `alpha beta`. Re-running the patcher on both ranks reported
 `already applied and verified`. A deliberate anchor-drift boot exited `1` on
 both ranks, entered restart/failure state, and never served the API.
+
+Extension evidence is CPU-only so far: the patched patcher was applied to a
+copy of the real checkpoint encoder (snapshot `9e165c30`) and a 16-case
+render matrix confirmed the fixed shape gains exactly one fresh header while
+every other shape stays byte-identical to the pre-extension hotfix. **No live
+serving validation of the reminder-tail rescue exists yet** — run the same
+gated-ON/OFF boot proof on both ranks before relying on it in production.
 
 ### Test
 ```bash

--- a/patches/hotfix-dsv4-assistant-final-continuation.py
+++ b/patches/hotfix-dsv4-assistant-final-continuation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Hotfix: emit a generation header when a request ends with an assistant turn.
+"""Hotfix: emit a generation header when a request effectively ends with a closed assistant turn, including when a trailing latest_reminder annotation follows it.
 
 Symptom
 -------
@@ -33,6 +33,13 @@ whenever a harness retries after a mid-stream error and re-sends the partial
 assistant turn, which is why the same prompt works for a long time and then
 does not.
 
+The same retry shape can carry a trailing `latest_reminder` annotation after
+the re-sent partial assistant turn (the harness appends fresh context as a
+reminder message). The reminder defeats the fix twice over: stock closes the
+assistant turn with EOS, renders the bare reminder after it, and the prompt
+still ends with no generation header — the model reads the reminder from the
+same dead state.
+
 Why a header and not `wo_eos`
 -----------------------------
 `encoding_dsv4.py` also has `assistant_msg_wo_eos_template`, and reopening the
@@ -51,8 +58,13 @@ the checkpoint encoder's existing generation transition.
 Scope
 -----
 Only the final message of a request is affected, and only when it is an
-assistant turn. Every other rendering path, including consecutive assistant
-messages mid-transcript, is untouched.
+assistant turn, or a `latest_reminder` whose immediate predecessor is an
+assistant turn. Every other rendering path is untouched, including:
+consecutive assistant messages mid-transcript; reminders mid-transcript; and
+reminder tails directly after a `user`/`developer` message — those already
+end inside the pending generation slot (the checkpoint emits
+`ASSISTANT_SP_TOKEN` + thinking token *before* such a reminder) and must stay
+byte-identical.
 
 Gating and fail-closed operation
 --------------------------------
@@ -64,9 +76,11 @@ invocation means the operator asked for the fix, everything fails nonzero:
 - encoder file missing (the prerequisite `encoding_dsv4.py` copy did not
   happen) — a gated-ON boot must not silently serve the buggy stock renderer;
 - anchor text missing (upstream encoder drifted) — nothing is written;
-- post-write self-check failure (patched module does not import, or a
-  trailing-assistant transcript still renders without a generation header) —
-  the original file bytes are restored first, then exit 1.
+- post-write self-check failure (patched module does not import, a fixed
+  shape still renders without a generation header — assistant-final, or
+  assistant-final plus trailing `latest_reminder` — or a
+  user->latest_reminder tail gains a second header) — the original file
+  bytes are restored first, then exit 1.
 
 Idempotent: an already-patched encoder is not rewritten, but it must still pass
 the self-check. Patches the encoding module the server actually loads, so it
@@ -94,11 +108,20 @@ OLD = (
 NEW = (
     "    elif messages[index].get(\"role\") in [\"user\", \"developer\"] or (\n"
     f"        # {MARK} A request may legitimately end with an assistant turn\n"
-    "        # (harness retry, continuation). Without a generation header the\n"
-    "        # prompt ends on a bare EOS and the model generates from a dead\n"
-    "        # state: immediate EOS, or raw DSML markup emitted as text.\n"
+    "        # (harness retry, continuation), optionally annotated by a\n"
+    "        # trailing latest_reminder harness message. Without a generation\n"
+    "        # header the prompt ends on a bare EOS (or a bare reminder after\n"
+    "        # the closed turn) and the model generates from a dead state:\n"
+    "        # immediate EOS, or raw DSML markup emitted as text. A reminder\n"
+    "        # tail directly after user/developer already ends inside the\n"
+    "        # pending generation slot and must stay byte-identical.\n"
     "        messages[index].get(\"role\") == \"assistant\"\n"
     "        and index == len(messages) - 1\n"
+    "    ) or (\n"
+    "        messages[index].get(\"role\") == \"latest_reminder\"\n"
+    "        and index == len(messages) - 1\n"
+    "        and index > 0\n"
+    "        and messages[index - 1].get(\"role\") == \"assistant\"\n"
     "    ):\n"
     "        # Normal generation: append Assistant + thinking token\n"
 )
@@ -108,7 +131,10 @@ def _self_check(target: Path) -> tuple[bool, str]:
     """Import the patched encoder and confirm the fix actually renders.
 
     A trailing-assistant transcript must end with the generation header
-    (assistant speaker token + thinking token) instead of a bare EOS.
+    (assistant speaker token + thinking token) instead of a bare EOS, the
+    same shape annotated by a trailing latest_reminder must regain that
+    fresh header after the reminder, and a user->latest_reminder tail must
+    keep its stock single in-slot header (no second header appended).
     """
     spec = importlib.util.spec_from_file_location("enc_check", target)
     if spec is None or spec.loader is None:
@@ -116,11 +142,22 @@ def _self_check(target: Path) -> tuple[bool, str]:
     enc = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(enc)
-        rendered = enc.encode_messages(
+        base = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "A finished answer."},
+        ]
+        rendered = enc.encode_messages(base, "thinking", reasoning_effort="high")
+        reminded = enc.encode_messages(
+            base + [{"role": "latest_reminder", "content": "Fresh context."}],
+            "thinking",
+            reasoning_effort="high",
+        )
+        intact = enc.encode_messages(
             [
                 {"role": "system", "content": "s"},
                 {"role": "user", "content": "u"},
-                {"role": "assistant", "content": "A finished answer."},
+                {"role": "latest_reminder", "content": "Fresh context."},
             ],
             "thinking",
             reasoning_effort="high",
@@ -133,15 +170,27 @@ def _self_check(target: Path) -> tuple[bool, str]:
         return False, f"self-check raised {type(err).__name__}: {err}"
     if not speaker or not thinking:
         return False, "generation-header tokens are unavailable"
-    if isinstance(rendered, str):
-        valid = rendered.endswith(speaker + thinking)
-    elif isinstance(rendered, (list, tuple)):
-        valid = list(rendered[-2:]) == [speaker, thinking]
-    else:
-        return False, f"unexpected encoder output type: {type(rendered).__name__}"
-    if valid:
-        return True, "generation header terminates trailing-assistant render"
-    return False, f"generation header does not terminate render: {rendered[-80:]!r}"
+
+    def _ends_with_header(out):
+        if isinstance(out, str):
+            return out.endswith(speaker + thinking)
+        if isinstance(out, (list, tuple)):
+            return list(out[-2:]) == [speaker, thinking]
+        raise TypeError(f"unexpected encoder output type: {type(out).__name__}")
+
+    try:
+        valid = _ends_with_header(rendered) and _ends_with_header(reminded)
+        # The user->latest_reminder tail ends inside the pending generation
+        # slot (exactly one header, before the reminder); an over-broad
+        # transition would append a second header there.
+        untouched = intact.count(speaker) == 1 and not _ends_with_header(intact)
+    except TypeError as err:
+        return False, str(err)
+    if not valid:
+        return False, f"generation header does not terminate render: {rendered[-80:]!r}"
+    if not untouched:
+        return False, "transition widened too far: user->latest_reminder tail changed"
+    return True, "generation headers terminate assistant-final renders"
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/test-assistant-final-continuation.py
+++ b/scripts/test-assistant-final-continuation.py
@@ -3,8 +3,9 @@
 
 These are CPU-only gates: they verify the patcher transforms a faithful
 minimal stock encoder shape (trailing-assistant generation gains exactly one
-header; the same shape without a generation prompt and every unrelated shape
-render byte-identically),
+header, the same shape annotated by a trailing latest_reminder gains exactly
+one fresh header after the reminder, reminder tails directly after
+user/developer and every unrelated shape render byte-identically),
 that apply is idempotent, that a gated-ON invocation fails closed on missing
 target / missing anchor / failed self-check and restores the original bytes,
 and that the compose/.env/start wiring invokes the patch only when
@@ -35,6 +36,7 @@ STOCK_ENCODER = '''\
 eos_token = "<|end of sentence|>"
 user_sp_token = "<|User|>"
 assistant_sp_token = "<|Assistant|>"
+latest_reminder_sp_token = "<|latest_reminder|>"
 thinking_start_token = "<think>"
 
 
@@ -52,6 +54,8 @@ def render_message(index, messages, thinking_mode, drop_thinking=True, reasoning
         out.append(content)
     elif role == "assistant":
         out = [content, eos_token]
+    elif role == "latest_reminder":
+        out = [latest_reminder_sp_token + content]
     else:
         raise NotImplementedError(role)
 
@@ -85,6 +89,30 @@ TRAILING_ASSISTANT = [
     {"role": "assistant", "content": "A finished answer."},
 ]
 
+# The extension defect: a harness retry re-sends the closed assistant turn
+# and appends a trailing latest_reminder annotation after it. Stock (and the
+# pre-extension hotfix) end this shape without any generation header.
+ASSISTANT_FINAL_WITH_TRAILING_REMINDER = [
+    {"role": "system", "content": "s"},
+    {"role": "user", "content": "u"},
+    {"role": "assistant", "content": "A finished answer."},
+    {"role": "latest_reminder", "content": "Fresh context."},
+]
+
+# Reminder tails directly after user/developer already end inside the
+# pending generation slot in stock; they must stay byte-identical.
+USER_THEN_TRAILING_REMINDER = [
+    {"role": "system", "content": "s"},
+    {"role": "user", "content": "u"},
+    {"role": "latest_reminder", "content": "Fresh context."},
+]
+
+DEVELOPER_THEN_TRAILING_REMINDER = [
+    {"role": "system", "content": "s"},
+    {"role": "developer", "content": "d"},
+    {"role": "latest_reminder", "content": "Fresh context."},
+]
+
 # Shapes whose final message is NOT assistant: the hotfix must not touch
 # their rendering at all.
 UNRELATED_SHAPES = [
@@ -114,6 +142,25 @@ UNRELATED_SHAPES = [
         {"role": "system", "content": "s"},
         {"role": "user", "content": "u"},
         {"role": "tool", "content": "t"},
+    ],
+    # reminders mid-transcript (the trailing slot belongs to another turn)
+    [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+        {"role": "latest_reminder", "content": "r"},
+        {"role": "user", "content": "u2"},
+    ],
+    [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a"},
+        {"role": "latest_reminder", "content": "r"},
+        {"role": "user", "content": "u2"},
+    ],
+    # task precedence keeps winning next to reminder tails
+    [
+        {"role": "user", "content": "u", "task": "title"},
+        {"role": "latest_reminder", "content": "r"},
     ],
     [
         {"role": "system", "content": "s"},
@@ -176,6 +223,53 @@ class AssistantFinalHotfixTest(unittest.TestCase):
                 stock_out + ["<|Assistant|>", "<think>"],
             )
             self.assertEqual(len(out), len(stock_out) + 2)
+
+    def test_assistant_final_with_trailing_latest_reminder_gains_exactly_one_generation_header(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, STOCK_ENCODER)
+            self.assertEqual(self._run(path), 0)
+            patched = _load_module_from(path)
+            stock = _exec_dict(STOCK_ENCODER)
+            messages = ASSISTANT_FINAL_WITH_TRAILING_REMINDER
+            out = patched.encode_messages(messages, "thinking")
+            stock_out = stock["encode_messages"](messages, "thinking")
+            # Stock ends on the bare reminder after the EOS-closed assistant
+            # turn (no generation header). Patched rendering preserves those
+            # stock bytes and appends exactly one fresh generation header.
+            self.assertEqual(stock_out[-2:], ["<|end of sentence|>",
+                                              "<|latest_reminder|>Fresh context."])
+            self.assertEqual(
+                out,
+                stock_out + ["<|Assistant|>", "<think>"],
+            )
+            self.assertEqual(len(out), len(stock_out) + 2)
+
+    def test_user_then_trailing_latest_reminder_stays_byte_identical(self):
+        # Stock already ends a user->latest_reminder tail inside the pending
+        # generation slot (header emitted before the reminder); the widened
+        # transition must not append a second header there.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, STOCK_ENCODER)
+            self.assertEqual(self._run(path), 0)
+            patched = _load_module_from(path)
+            stock = _exec_dict(STOCK_ENCODER)
+            self.assertEqual(patched.encode_messages(
+                USER_THEN_TRAILING_REMINDER, "thinking"),
+                stock["encode_messages"](USER_THEN_TRAILING_REMINDER, "thinking"),
+            )
+
+    def test_developer_then_trailing_latest_reminder_stays_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, STOCK_ENCODER)
+            self.assertEqual(self._run(path), 0)
+            patched = _load_module_from(path)
+            stock = _exec_dict(STOCK_ENCODER)
+            self.assertEqual(patched.encode_messages(
+                DEVELOPER_THEN_TRAILING_REMINDER, "thinking"),
+                stock["encode_messages"](DEVELOPER_THEN_TRAILING_REMINDER, "thinking"),
+            )
 
 
     def test_unrelated_shapes_byte_identical(self):


### PR DESCRIPTION
Closes #120. Extends the opt-in Issue #52 assistant-final hotfix narrowly.

## Problem

A harness retry can end with `assistant` followed by `latest_reminder`. Stock closes the assistant turn, renders the reminder, and leaves no terminal generation header. The existing final-assistant guard never fires because the reminder is now the final message.

## Change

- append exactly one fresh generation header only when the final message is `latest_reminder` and its immediate predecessor is assistant
- preserve byte-identical rendering for user/developer reminder tails, mid-transcript reminders, task precedence, `wo_eos`, and all existing assistant-final shapes
- extend the patcher's post-write self-check and fail-closed restore path
- add behavior regressions and operator documentation; default remains opt-in/OFF

## Verification

- `bash scripts/ci-validate.sh` — PASS at `b748c03`
- `scripts/test-assistant-final-continuation.py` — 16/16 PASS; pre-extension behavior fails the new regression
- CPU probe against the real checkpoint encoder confirmed the defective and unaffected render shapes
- per-commit secret/source-identifier scan — 0 findings

Live two-rank opt-in render verification will be posted before merge.