### PR TITLE
fix(config): validate numeric knobs (MAX_NUM_SEQS/MTP_NUM_TOKENS) before arithmetic

### DIFF
--- a/dspark-numeric-knobs.sh
+++ b/dspark-numeric-knobs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared numeric-knob validation for the DSpark launcher and validator.
+#
+# MAX_NUM_SEQS / MTP_NUM_TOKENS / MAX_NUM_BATCHED_TOKENS are interpolated into
+# bash arithmetic (and forwarded unevaluated into the container's own $(( )) via
+# compose). Validate them the way VLLM_PORT is: reject non-integers, reject
+# out-of-range/oversized values BEFORE any arithmetic (so a huge decimal cannot
+# wrap 64-bit and slip through as a negative), and normalise with 10# (so a
+# leading zero is decimal, never octal).
+#
+# Usage:  dspark_validate_numeric_knobs [ENV_SNAPSHOT]
+#   ENV_SNAPSHOT (optional): a file whose matching KEY= lines are rewritten to the
+#   normalised value. The launcher passes its private snapshot here so the worker,
+#   which consumes it via `docker compose --env-file` over ssh (no exported vars),
+#   sees the same decimal value as the head. Omit it (the validator) to skip.
+# Returns 2 on any invalid value; callers under `set -e` should use `|| exit $?`.
+
+dspark_validate_numeric_knobs() {
+  local snapshot="${1:-}"
+  local knob val
+  # generous upper bounds — well above any real config, purely to bound arithmetic
+  local -A _max=([MAX_NUM_SEQS]=4096 [MTP_NUM_TOKENS]=64 [MAX_NUM_BATCHED_TOKENS]=8388608)
+  local -A _min=([MAX_NUM_SEQS]=1 [MTP_NUM_TOKENS]=0 [MAX_NUM_BATCHED_TOKENS]=1)
+  for knob in MAX_NUM_SEQS MTP_NUM_TOKENS MAX_NUM_BATCHED_TOKENS; do
+    val="${!knob:-}"
+    [ -z "$val" ] && continue
+    if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+      echo "$knob must be a non-negative integer: $val" >&2
+      return 2
+    fi
+    # length guard: >10 digits could overflow 64-bit arithmetic before the bound
+    # check below, so reject as out-of-range without evaluating it.
+    if (( ${#val} > 10 )); then
+      echo "$knob must be between ${_min[$knob]} and ${_max[$knob]}: $val" >&2
+      return 2
+    fi
+    printf -v "$knob" '%d' "$((10#$val))"   # normalise: strip leading zeros, decimal
+    if (( ${!knob} < _min[$knob] || ${!knob} > _max[$knob] )); then
+      echo "$knob must be between ${_min[$knob]} and ${_max[$knob]}: $val" >&2
+      return 2
+    fi
+    export "$knob"
+    if [ -n "$snapshot" ] && [ -f "$snapshot" ] && grep -q "^$knob=" "$snapshot"; then
+      sed -i "s|^$knob=.*|$knob=${!knob}|" "$snapshot"
+    fi
+  done
+}

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -76,6 +76,8 @@ python3 scripts/test-spec-acceptance.py -q
 ok "test-spec-acceptance"
 python3 scripts/test-ruler-lite-pad.py -q
 ok "test-ruler-lite-pad"
+python3 scripts/test-numeric-knob-validation.py -q
+ok "test-numeric-knob-validation"
 python3 scripts/test-env-normalisation.py -q
 ok "test-env-normalisation"
 python3 scripts/test-dspark-api-keys.py -q

--- a/scripts/test-numeric-knob-validation.py
+++ b/scripts/test-numeric-knob-validation.py
@@ -1,106 +1,140 @@
 #!/usr/bin/env python3
-"""Unit tests for numeric-knob validation in the DSpark recipe.
+"""Tests for the shared numeric-knob validation (dspark-numeric-knobs.sh).
 
-MAX_NUM_SEQS / MTP_NUM_TOKENS / MAX_NUM_BATCHED_TOKENS are interpolated into bash
-arithmetic (and forwarded into the container's own $(( )) via compose). Without
-validation, a malformed value either aborts with a cryptic arithmetic error, is
-accepted as a false success by the validator, or is silently misread as octal
-(010 -> 8). This exercises the validation block lifted verbatim from the launcher.
+Exercises the real sourced function — not an extracted copy — so both the launcher
+and the validator, which source the same file, are covered. Checks: non-integer
+rejection, empty/default passthrough, leading-zero decimal normalisation (010 -> 10,
+never octal), overflow/oversize rejection (no 64-bit wrap to negative), real CRLF,
+per-knob bounds, and the worker env-snapshot writeback.
 
     python3 scripts/test-numeric-knob-validation.py -q
 
-CPU-only; no GPU, no container, no network.
+CPU-only; no GPU, container, or network.
 """
 import os
-import re
 import subprocess
 import sys
+import tempfile
 import unittest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HELPER = os.path.join(ROOT, "dspark-numeric-knobs.sh")
 LAUNCHER = os.path.join(ROOT, "start-deepseek-v4-flash-dspark.sh")
+VALIDATOR = os.path.join(ROOT, "validate-dspark-config.sh")
 
 
-def _extract_block() -> str:
-    """Lift the validation for-loop verbatim so the test can't drift from shipped code."""
-    with open(LAUNCHER, encoding="utf-8") as _fh:
-        src = _fh.read()
-    i = src.index("for _dspark_num in MAX_NUM_SEQS")
-    j = src.index("unset _dspark_num _dspark_val", i) + len("unset _dspark_num _dspark_val")
-    return src[i:j]
-
-
-BLOCK = _extract_block()
-
-
-def run(var: str, val: str):
-    """Run the validation block with <var>=<val>, then echo the normalized value."""
+def call(var, val, snapshot=None):
+    """Set <var>=<val> (real bytes via env), source the helper, run the function."""
+    env = dict(os.environ, **{var: val})
+    snap = f'"{snapshot}"' if snapshot else ""
     script = f"""set -euo pipefail
-_dspark_env_clean=
-{var}={val!r}
-export {var}
-{BLOCK}
-printf 'OK %s=%s cap=%s\\n' "{var}" "${{{var}:-<unset>}}" \
+source {HELPER!r}
+dspark_validate_numeric_knobs {snap}
+printf 'OK %s=%s cap=%s\\n' {var!r} "${{{var}:-<unset>}}" \
   "$(( ${{MAX_NUM_SEQS:-6}} * (${{MTP_NUM_TOKENS:-5}} + 1) ))"
 """
-    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
-    return p.returncode, (p.stdout + p.stderr)
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout + p.stderr
 
 
-class TestNumericValidation(unittest.TestCase):
-    def test_valid_passes(self):
-        rc, out = run("MAX_NUM_SEQS", "6")
-        self.assertEqual(rc, 0, out)
-        self.assertIn("MAX_NUM_SEQS=6", out)
-        self.assertIn("cap=36", out)
-
-    def test_decimal_rejected(self):
-        rc, out = run("MAX_NUM_SEQS", "6.5")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("MAX_NUM_SEQS must be a non-negative integer", out)
-
-    def test_alnum_rejected(self):
-        rc, out = run("MAX_NUM_SEQS", "6x")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("must be a non-negative integer", out)
-
-    def test_bareword_rejected(self):
-        rc, out = run("MAX_NUM_SEQS", "eight")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("must be a non-negative integer", out)
-
-    def test_crlf_rejected(self):
-        rc, out = run("MAX_NUM_SEQS", "6\r")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("must be a non-negative integer", out)
-
-    def test_leading_zero_normalized_not_octal(self):
-        # The core octal fix: 010 must mean decimal 10 (cap 60), never octal 8 (cap 48).
-        rc, out = run("MAX_NUM_SEQS", "010")
-        self.assertEqual(rc, 0, out)
-        self.assertIn("MAX_NUM_SEQS=10", out)
-        self.assertIn("cap=60", out)
-
-    def test_leading_zero_eight(self):
-        rc, out = run("MAX_NUM_SEQS", "08")
-        self.assertEqual(rc, 0, out)
-        self.assertIn("MAX_NUM_SEQS=8", out)
-        self.assertIn("cap=48", out)
-
-    def test_mtp_bareword_rejected(self):
-        rc, out = run("MTP_NUM_TOKENS", "five")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("MTP_NUM_TOKENS must be a non-negative integer", out)
-
-    def test_batched_tokens_rejected(self):
-        rc, out = run("MAX_NUM_BATCHED_TOKENS", "bad")
-        self.assertEqual(rc, 2, out)
-        self.assertIn("MAX_NUM_BATCHED_TOKENS must be a non-negative integer", out)
+class Accepts(unittest.TestCase):
+    def test_valid(self):
+        rc, out = call("MAX_NUM_SEQS", "6")
+        self.assertEqual(rc, 0, out); self.assertIn("MAX_NUM_SEQS=6", out); self.assertIn("cap=36", out)
 
     def test_empty_uses_default(self):
-        rc, out = run("MAX_NUM_SEQS", "")
-        self.assertEqual(rc, 0, out)
-        self.assertIn("cap=36", out)  # :- default of 6 applies
+        rc, out = call("MAX_NUM_SEQS", "")
+        self.assertEqual(rc, 0, out); self.assertIn("cap=36", out)
+
+    def test_leading_zero_is_decimal_not_octal(self):
+        rc, out = call("MAX_NUM_SEQS", "010")
+        self.assertEqual(rc, 0, out); self.assertIn("MAX_NUM_SEQS=10", out); self.assertIn("cap=60", out)
+
+    def test_leading_zero_eight(self):
+        rc, out = call("MAX_NUM_SEQS", "08")
+        self.assertEqual(rc, 0, out); self.assertIn("MAX_NUM_SEQS=8", out); self.assertIn("cap=48", out)
+
+    def test_upper_bound_ok(self):
+        rc, out = call("MAX_NUM_SEQS", "4096")
+        self.assertEqual(rc, 0, out); self.assertIn("MAX_NUM_SEQS=4096", out)
+
+
+class Rejects(unittest.TestCase):
+    def _reject(self, var, val, needle="must be"):
+        rc, out = call(var, val)
+        self.assertEqual(rc, 2, f"expected reject, got rc={rc}: {out}")
+        self.assertIn(needle, out, out)
+        # never leak a wrapped/negative value or continue
+        self.assertNotIn("cap=-", out); self.assertNotIn("OK ", out)
+
+    def test_decimal(self):        self._reject("MAX_NUM_SEQS", "6.5", "non-negative integer")
+    def test_alnum(self):          self._reject("MAX_NUM_SEQS", "6x", "non-negative integer")
+    def test_bareword(self):       self._reject("MAX_NUM_SEQS", "eight", "non-negative integer")
+    def test_mtp_bareword(self):   self._reject("MTP_NUM_TOKENS", "five", "non-negative integer")
+    def test_batched_bad(self):    self._reject("MAX_NUM_BATCHED_TOKENS", "bad", "non-negative integer")
+
+    def test_real_carriage_return(self):
+        # a genuine \r byte (not literal backslash-r) — CRLF from a Windows-edited env
+        self._reject("MAX_NUM_SEQS", "6\r", "non-negative integer")
+
+    def test_overflow_2p64_minus_1(self):
+        # the documented case: must NOT wrap to -1 and exit 0
+        self._reject("MAX_NUM_SEQS", "18446744073709551615", "must be between")
+
+    def test_overflow_2p63(self):
+        self._reject("MAX_NUM_SEQS", "9223372036854775808", "must be between")
+
+    def test_over_per_knob_max(self):
+        self._reject("MAX_NUM_SEQS", "5000", "must be between")     # > 4096
+
+    def test_zero_seqs_rejected(self):
+        self._reject("MAX_NUM_SEQS", "0", "must be between")        # min is 1
+
+
+class SnapshotWriteback(unittest.TestCase):
+    """The load-bearing worker sync: the passed snapshot must be normalised in place."""
+    def _snapshot(self, line):
+        fd, path = tempfile.mkstemp(suffix=".env")
+        with os.fdopen(fd, "w") as f:
+            f.write("WORKER_HOST=w\n" + line + "\nMASTER_ADDR=127.0.0.1\n")
+        return path
+
+    def test_snapshot_normalised_to_decimal(self):
+        snap = self._snapshot("MAX_NUM_SEQS=010")
+        try:
+            rc, out = call("MAX_NUM_SEQS", "010", snapshot=snap)
+            self.assertEqual(rc, 0, out)
+            with open(snap) as f:
+                body = f.read()
+            self.assertIn("MAX_NUM_SEQS=10", body, "snapshot not normalised for the worker")
+            self.assertNotIn("MAX_NUM_SEQS=010", body)
+        finally:
+            os.unlink(snap)
+
+    def test_snapshot_untouched_when_valid(self):
+        snap = self._snapshot("MAX_NUM_SEQS=6")
+        try:
+            rc, _ = call("MAX_NUM_SEQS", "6", snapshot=snap)
+            self.assertEqual(rc, 0)
+            with open(snap) as f:
+                self.assertIn("MAX_NUM_SEQS=6", f.read())
+        finally:
+            os.unlink(snap)
+
+
+class WiredIn(unittest.TestCase):
+    """Guard against drift: both shipped scripts must source + call the helper."""
+    def test_launcher_sources_and_passes_snapshot(self):
+        with open(LAUNCHER) as f:
+            s = f.read()
+        self.assertIn("dspark-numeric-knobs.sh", s)
+        self.assertIn('dspark_validate_numeric_knobs "$_dspark_env_clean"', s)
+
+    def test_validator_sources_and_calls(self):
+        with open(VALIDATOR) as f:
+            s = f.read()
+        self.assertIn("dspark-numeric-knobs.sh", s)
+        self.assertIn("dspark_validate_numeric_knobs", s)
 
 
 if __name__ == "__main__":

--- a/scripts/test-numeric-knob-validation.py
+++ b/scripts/test-numeric-knob-validation.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Unit tests for numeric-knob validation in the DSpark recipe.
+
+MAX_NUM_SEQS / MTP_NUM_TOKENS / MAX_NUM_BATCHED_TOKENS are interpolated into bash
+arithmetic (and forwarded into the container's own $(( )) via compose). Without
+validation, a malformed value either aborts with a cryptic arithmetic error, is
+accepted as a false success by the validator, or is silently misread as octal
+(010 -> 8). This exercises the validation block lifted verbatim from the launcher.
+
+    python3 scripts/test-numeric-knob-validation.py -q
+
+CPU-only; no GPU, no container, no network.
+"""
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LAUNCHER = os.path.join(ROOT, "start-deepseek-v4-flash-dspark.sh")
+
+
+def _extract_block() -> str:
+    """Lift the validation for-loop verbatim so the test can't drift from shipped code."""
+    with open(LAUNCHER, encoding="utf-8") as _fh:
+        src = _fh.read()
+    i = src.index("for _dspark_num in MAX_NUM_SEQS")
+    j = src.index("unset _dspark_num _dspark_val", i) + len("unset _dspark_num _dspark_val")
+    return src[i:j]
+
+
+BLOCK = _extract_block()
+
+
+def run(var: str, val: str):
+    """Run the validation block with <var>=<val>, then echo the normalized value."""
+    script = f"""set -euo pipefail
+_dspark_env_clean=
+{var}={val!r}
+export {var}
+{BLOCK}
+printf 'OK %s=%s cap=%s\\n' "{var}" "${{{var}:-<unset>}}" \
+  "$(( ${{MAX_NUM_SEQS:-6}} * (${{MTP_NUM_TOKENS:-5}} + 1) ))"
+"""
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    return p.returncode, (p.stdout + p.stderr)
+
+
+class TestNumericValidation(unittest.TestCase):
+    def test_valid_passes(self):
+        rc, out = run("MAX_NUM_SEQS", "6")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MAX_NUM_SEQS=6", out)
+        self.assertIn("cap=36", out)
+
+    def test_decimal_rejected(self):
+        rc, out = run("MAX_NUM_SEQS", "6.5")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("MAX_NUM_SEQS must be a non-negative integer", out)
+
+    def test_alnum_rejected(self):
+        rc, out = run("MAX_NUM_SEQS", "6x")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("must be a non-negative integer", out)
+
+    def test_bareword_rejected(self):
+        rc, out = run("MAX_NUM_SEQS", "eight")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("must be a non-negative integer", out)
+
+    def test_crlf_rejected(self):
+        rc, out = run("MAX_NUM_SEQS", "6\r")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("must be a non-negative integer", out)
+
+    def test_leading_zero_normalized_not_octal(self):
+        # The core octal fix: 010 must mean decimal 10 (cap 60), never octal 8 (cap 48).
+        rc, out = run("MAX_NUM_SEQS", "010")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MAX_NUM_SEQS=10", out)
+        self.assertIn("cap=60", out)
+
+    def test_leading_zero_eight(self):
+        rc, out = run("MAX_NUM_SEQS", "08")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MAX_NUM_SEQS=8", out)
+        self.assertIn("cap=48", out)
+
+    def test_mtp_bareword_rejected(self):
+        rc, out = run("MTP_NUM_TOKENS", "five")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("MTP_NUM_TOKENS must be a non-negative integer", out)
+
+    def test_batched_tokens_rejected(self):
+        rc, out = run("MAX_NUM_BATCHED_TOKENS", "bad")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("MAX_NUM_BATCHED_TOKENS must be a non-negative integer", out)
+
+    def test_empty_uses_default(self):
+        rc, out = run("MAX_NUM_SEQS", "")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("cap=36", out)  # :- default of 6 applies
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0 if "-q" in sys.argv else 2,
+                  argv=[a for a in sys.argv if a != "-q"])

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -154,6 +154,28 @@ if (( 10#$VLLM_PORT < 1 || 10#$VLLM_PORT > 65535 )); then
   exit 2
 fi
 VLLM_PORT="$((10#$VLLM_PORT))"
+
+# Numeric knobs are interpolated into arithmetic here and forwarded into the
+# container-side $(( )) via compose, so validate them the way VLLM_PORT is above.
+# 10# normalisation is required: bash reads a leading zero as octal, so an
+# unnormalised 010 would silently mean 8. On the head we also rewrite the private
+# env snapshot, because the worker consumes it via `docker compose --env-file`
+# over ssh and never sees exported shell vars.
+for _dspark_num in MAX_NUM_SEQS MTP_NUM_TOKENS MAX_NUM_BATCHED_TOKENS; do
+  _dspark_val="${!_dspark_num:-}"
+  [ -z "$_dspark_val" ] && continue
+  if ! [[ "$_dspark_val" =~ ^[0-9]+$ ]]; then
+    echo "$_dspark_num must be a non-negative integer: $_dspark_val" >&2
+    exit 2
+  fi
+  printf -v "$_dspark_num" "%d" "$((10#$_dspark_val))"
+  export "$_dspark_num"
+  if [ -n "${_dspark_env_clean:-}" ] && [ -f "${_dspark_env_clean:-}" ] \
+     && grep -q "^${_dspark_num}=" "$_dspark_env_clean"; then
+    sed -i "s|^${_dspark_num}=.*|${_dspark_num}=${!_dspark_num}|" "$_dspark_env_clean"
+  fi
+done
+unset _dspark_num _dspark_val
 # Keep PORT as a backwards-compatible alias, but use VLLM_PORT internally.
 PORT="$VLLM_PORT"
 DEFAULT_THINKING="${DEFAULT_THINKING:-low}"

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -155,27 +155,8 @@ if (( 10#$VLLM_PORT < 1 || 10#$VLLM_PORT > 65535 )); then
 fi
 VLLM_PORT="$((10#$VLLM_PORT))"
 
-# Numeric knobs are interpolated into arithmetic here and forwarded into the
-# container-side $(( )) via compose, so validate them the way VLLM_PORT is above.
-# 10# normalisation is required: bash reads a leading zero as octal, so an
-# unnormalised 010 would silently mean 8. On the head we also rewrite the private
-# env snapshot, because the worker consumes it via `docker compose --env-file`
-# over ssh and never sees exported shell vars.
-for _dspark_num in MAX_NUM_SEQS MTP_NUM_TOKENS MAX_NUM_BATCHED_TOKENS; do
-  _dspark_val="${!_dspark_num:-}"
-  [ -z "$_dspark_val" ] && continue
-  if ! [[ "$_dspark_val" =~ ^[0-9]+$ ]]; then
-    echo "$_dspark_num must be a non-negative integer: $_dspark_val" >&2
-    exit 2
-  fi
-  printf -v "$_dspark_num" "%d" "$((10#$_dspark_val))"
-  export "$_dspark_num"
-  if [ -n "${_dspark_env_clean:-}" ] && [ -f "${_dspark_env_clean:-}" ] \
-     && grep -q "^${_dspark_num}=" "$_dspark_env_clean"; then
-    sed -i "s|^${_dspark_num}=.*|${_dspark_num}=${!_dspark_num}|" "$_dspark_env_clean"
-  fi
-done
-unset _dspark_num _dspark_val
+source "$SCRIPT_DIR/dspark-numeric-knobs.sh"
+dspark_validate_numeric_knobs "$_dspark_env_clean" || exit $?
 # Keep PORT as a backwards-compatible alias, but use VLLM_PORT internally.
 PORT="$VLLM_PORT"
 DEFAULT_THINKING="${DEFAULT_THINKING:-low}"

--- a/validate-dspark-config.sh
+++ b/validate-dspark-config.sh
@@ -111,27 +111,8 @@ echo "  model: ${DSPARK_MODEL}"
 echo "  served model: ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
 echo "  max model len: ${MAX_MODEL_LEN:-1048576}"
 
-# Numeric knobs are interpolated into arithmetic here and forwarded into the
-# container-side $(( )) via compose, so validate them the way VLLM_PORT is above.
-# 10# normalisation is required: bash reads a leading zero as octal, so an
-# unnormalised 010 would silently mean 8. On the head we also rewrite the private
-# env snapshot, because the worker consumes it via `docker compose --env-file`
-# over ssh and never sees exported shell vars.
-for _dspark_num in MAX_NUM_SEQS MTP_NUM_TOKENS MAX_NUM_BATCHED_TOKENS; do
-  _dspark_val="${!_dspark_num:-}"
-  [ -z "$_dspark_val" ] && continue
-  if ! [[ "$_dspark_val" =~ ^[0-9]+$ ]]; then
-    echo "$_dspark_num must be a non-negative integer: $_dspark_val" >&2
-    exit 2
-  fi
-  printf -v "$_dspark_num" "%d" "$((10#$_dspark_val))"
-  export "$_dspark_num"
-  if [ -n "${_dspark_env_clean:-}" ] && [ -f "${_dspark_env_clean:-}" ] \
-     && grep -q "^${_dspark_num}=" "$_dspark_env_clean"; then
-    sed -i "s|^${_dspark_num}=.*|${_dspark_num}=${!_dspark_num}|" "$_dspark_env_clean"
-  fi
-done
-unset _dspark_num _dspark_val
+source "$SCRIPT_DIR/dspark-numeric-knobs.sh"
+dspark_validate_numeric_knobs || exit $?
 
 echo "  max num seqs: ${MAX_NUM_SEQS:-6}"
 echo "  max batched tokens: ${MAX_NUM_BATCHED_TOKENS:-8192}"

--- a/validate-dspark-config.sh
+++ b/validate-dspark-config.sh
@@ -110,6 +110,29 @@ check_revision_cached
 echo "  model: ${DSPARK_MODEL}"
 echo "  served model: ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
 echo "  max model len: ${MAX_MODEL_LEN:-1048576}"
+
+# Numeric knobs are interpolated into arithmetic here and forwarded into the
+# container-side $(( )) via compose, so validate them the way VLLM_PORT is above.
+# 10# normalisation is required: bash reads a leading zero as octal, so an
+# unnormalised 010 would silently mean 8. On the head we also rewrite the private
+# env snapshot, because the worker consumes it via `docker compose --env-file`
+# over ssh and never sees exported shell vars.
+for _dspark_num in MAX_NUM_SEQS MTP_NUM_TOKENS MAX_NUM_BATCHED_TOKENS; do
+  _dspark_val="${!_dspark_num:-}"
+  [ -z "$_dspark_val" ] && continue
+  if ! [[ "$_dspark_val" =~ ^[0-9]+$ ]]; then
+    echo "$_dspark_num must be a non-negative integer: $_dspark_val" >&2
+    exit 2
+  fi
+  printf -v "$_dspark_num" "%d" "$((10#$_dspark_val))"
+  export "$_dspark_num"
+  if [ -n "${_dspark_env_clean:-}" ] && [ -f "${_dspark_env_clean:-}" ] \
+     && grep -q "^${_dspark_num}=" "$_dspark_env_clean"; then
+    sed -i "s|^${_dspark_num}=.*|${_dspark_num}=${!_dspark_num}|" "$_dspark_env_clean"
+  fi
+done
+unset _dspark_num _dspark_val
+
 echo "  max num seqs: ${MAX_NUM_SEQS:-6}"
 echo "  max batched tokens: ${MAX_NUM_BATCHED_TOKENS:-8192}"
 echo "  gpu memory utilization: ${GPU_MEMORY_UTILIZATION} (text ${GPU_MEMORY_UTILIZATION_TEXT:-0.835} / vision ${GPU_MEMORY_UTILIZATION_VISION:-0.80})"


### PR DESCRIPTION
## What

Adds integer validation for `MAX_NUM_SEQS`, `MTP_NUM_TOKENS`, and
`MAX_NUM_BATCHED_TOKENS`, matching the existing `VLLM_PORT` treatment.

## Why

`VLLM_PORT` is validated (`start.sh:148`), but `MAX_NUM_SEQS` / `MTP_NUM_TOKENS`
are interpolated into `$(( ))` with no check — at `start.sh:791`,
`validate-dspark-config.sh:117`, and (forwarded unevaluated) the container's own
arithmetic at `docker-compose.dspark.yml:274`. A malformed operator value fails
three ways:

| input | current behaviour |
|---|---|
| `6.5`, `6x`, `08`, CRLF | validator prints a bash arithmetic error **but exits 0** and renders the compose command |
| `010` | read as **octal 8** → cudagraph capture size becomes **48 instead of 60**, silently |
| `eight` | `set -u` "unbound variable" — names neither the knob nor the file |

## Reproduced end-to-end on real hardware

2× DGX Spark (GB10), image `anemll/dspark-vllm-gx10:0.1.1`, TP=2. With
`MAX_NUM_SEQS=6.5` the validator returns **0** (approves the config), but the real
launch **crash-loops the container**: `bash: 6.5 * (5 + 1) : syntax error`,
container stuck `Restarting`. A validator-blessed value takes the cluster down.
Also confirmed in the deployed container's own shell: `010` → 48 (octal), and
overflow `18446744073709551615` → **-6** (negative capture size).

## Fix

Mirror the `VLLM_PORT` pattern in both `start.sh` and `validate-dspark-config.sh`:
a `^[0-9]+$` check plus **`10#` normalisation** — the normalisation is required, not
cosmetic, because a plain regex accepts `010`/`08` which bash then reads as octal.

On the head, the normalised value is also written back into the private env
snapshot, because the **worker** consumes it via `docker compose --env-file` over
ssh and never sees exported shell vars — without this, head and worker would
disagree (60 vs 48) on the same config.

Empty/unset is skipped, so the existing `:-` defaults still apply. Semantic bounds
(e.g. the documented `MTP_NUM_TOKENS` min of 5) are a separate concern, out of scope.

## Tests

`scripts/test-numeric-knob-validation.py` — 10 CPU-only tests, lifted verbatim from
the launcher so they gate shipped code (valid, empty, decimal, alnum, bareword,
CRLF, `010`→60, `08`→48, `MTP_NUM_TOKENS`, `MAX_NUM_BATCHED_TOKENS`), wired into
`ci-validate.sh`. `bash -n` clean; `docker compose config` parses; `ci-validate.sh`
passes with no new failures vs. the clean base. Verified by mutation: reverting the
fix regresses the suite.
