### PR TITLE
fix(stage-c): load DSpark shared expert gate/up tensors

### DIFF
--- a/build-dspark-vllm-runtime.sh
+++ b/build-dspark-vllm-runtime.sh
@@ -26,7 +26,7 @@ build_one() {
       -t "$DSPARK_BASE_IMAGE" \
       "$SCRIPT_DIR/recipe/overlay"
     docker run --rm --entrypoint /opt/env/bin/python "$DSPARK_BASE_IMAGE" -c \
-      "import vllm.v1.spec_decode.dspark as d; import vllm.v1.spec_decode.dspark_proposer as p; print('dspark overlay ok', d.__name__, p.__name__)"
+      "import vllm.v1.spec_decode.dspark as d; import vllm.v1.spec_decode.dspark_proposer as p; assert d.map_dspark_stacked_param_name('model.layers.0.ffn.shared_experts.w1.weight') == ('model.layers.0.ffn.shared_experts.gate_up_proj.weight', 0); print('dspark overlay ok', d.__name__, p.__name__)"
     docker build \
       --build-arg BASE_IMAGE="$DSPARK_BASE_IMAGE" \
       -f "$SCRIPT_DIR/recipe/nvfp4/Dockerfile.stage-a" \

--- a/recipe/overlay/vllm/v1/spec_decode/dspark.py
+++ b/recipe/overlay/vllm/v1/spec_decode/dspark.py
@@ -15,6 +15,8 @@ StepCurve = Callable[[int], float]
 _STACKED_PARAM_NAME_MAPPING = (
     ("attn.fused_wqa_wkv", ".attn.wq_a", 0),
     ("attn.fused_wqa_wkv", ".attn.wkv", 1),
+    ("shared_experts.gate_up_proj", ".shared_experts.w1", 0),
+    ("shared_experts.gate_up_proj", ".shared_experts.w3", 1),
 )
 
 

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -53,6 +53,7 @@ py_files+=(
   scripts/test-empty-encoder-output-hotfix.py
   scripts/ruler-lite.py
   scripts/verify-dsv4-027-equality-gate.py
+  tests/test_dspark_stacked_mapping.py
 )
 python3 -m py_compile "${py_files[@]}"
 ok "py_compile ${#py_files[@]} files"
@@ -90,6 +91,8 @@ python3 scripts/test-empty-encoder-output-hotfix.py -q
 ok "test-empty-encoder-output-hotfix"
 python3 tests/test_issue27_inflight_cap.py -q
 ok "test_issue27_inflight_cap"
+python3 tests/test_dspark_stacked_mapping.py -q
+ok "test_dspark_stacked_mapping"
 python3 scripts/verify-dsv4-027-equality-gate.py
 ok "verify-dsv4-027-equality-gate"
 bash scripts/verify-overlay-sources.sh

--- a/tests/test_dspark_stacked_mapping.py
+++ b/tests/test_dspark_stacked_mapping.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""CPU tests for DSpark checkpoint-to-stacked-parameter mapping."""
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "recipe" / "overlay" / "vllm" / "v1" / "spec_decode" / "dspark.py"
+sys.modules["torch"] = types.ModuleType("torch")
+SPEC = importlib.util.spec_from_file_location("dspark_mapping", SOURCE)
+dspark = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = dspark
+SPEC.loader.exec_module(dspark)
+
+
+class DSparkStackedMappingTest(unittest.TestCase):
+    def test_maps_shared_expert_gate_and_up_shards(self):
+        cases = (
+            ("model.layers.43.ffn.shared_experts.w1.weight", "model.layers.43.ffn.shared_experts.gate_up_proj.weight", 0),
+            ("model.layers.45.ffn.shared_experts.w3.weight_scale_inv", "model.layers.45.ffn.shared_experts.gate_up_proj.weight_scale_inv", 1),
+        )
+        for source, target, shard in cases:
+            with self.subTest(source=source):
+                self.assertEqual(dspark.map_dspark_stacked_param_name(source), (target, shard))
+
+    def test_does_not_capture_routed_experts_or_markov_head(self):
+        names = (
+            "model.layers.43.ffn.experts.0.w1.weight",
+            "model.layers.45.markov_head.markov_w1.weight",
+        )
+        for name in names:
+            with self.subTest(name=name):
+                self.assertIsNone(dspark.map_dspark_stacked_param_name(name))
+
+    def test_keeps_attention_mapping(self):
+        source = "model.layers.43.attn.wkv.weight"
+        self.assertEqual(
+            dspark.map_dspark_stacked_param_name(source),
+            ("model.layers.43.attn.fused_wqa_wkv.weight", 1),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- map Stage-C DSpark shared-expert `w1`/`w3` checkpoint tensors into `gate_up_proj` shards 0/1
- cover shared weights/scales, routed experts, `markov_w1`, and existing attention mappings
- assert the mapping inside the rebuilt overlay image

The default Anemll 0.1.1 image already carries equivalent generic loader mappings; this fixes parity for the optional Stage-C overlay only.

## Verification
- `./scripts/ci-validate.sh` at exact head `0bafd3e`
- overlay image build: `sha256:b84fb398e29a3d0716bce503b2ab9557c9a50c70864186ec9f15d6478c5e44cf`
- in-image mapping assertion passed
- six independent FREN reviews plus HELP and CYBERGLM decision gate; no unresolved loader defect

## Deployment
Requires rebuilding the Stage-C image on both nodes. No default Anemll runtime change and no live restart performed.