### PR TITLE
Fix global top-k Triton recompilation family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-24
+
+### Fixed
+
+- **Bounded `_compute_global_topk_indices_and_lens_kernel` to two deterministic Triton compile variants ([Issue #133](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/133))**: mixed prefill slices the `int32` token-to-request map and `bool` validity mask at the same traffic-dependent token offset, so their pointer-alignment specialization produced three cache-key states; the observed effective block sizes 64 and 2 doubled that family to six. The kernel now disables alignment specialization only for those two scalar-loaded pointers and treats its stable strides, top-k width, and block size as compile-time constants, matching upstream vLLM's kernel optimization without padding fixed-address CUDA-graph metadata or copying slices per step. A driverless Triton 3.6 regression test proves the three alignment classes share a key, only block size remains as a two-member axis, and both variants compile for SM121; an optional CUDA case checks bit-exact outputs across all former alignment classes when a device is available.
+
 ## 2026-08-23
 
 ### Added

--- a/recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -430,18 +430,23 @@ def compute_global_topk_indices_and_lens(
     return global_topk_indices, topk_lens
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize_on_alignment=[
+        "token_to_req_indices_ptr",
+        "is_valid_token_ptr",
+    ]
+)
 def _compute_global_topk_indices_and_lens_kernel(
     global_topk_indices_ptr,
-    global_topk_indices_stride,
+    global_topk_indices_stride: tl.constexpr,
     topk_lens_ptr,
     topk_indices_ptr,
-    topk_indices_stride,
-    topk,
+    topk_indices_stride: tl.constexpr,
+    topk: tl.constexpr,
     token_to_req_indices_ptr,
     block_table_ptr,
-    block_table_stride,
-    block_size,
+    block_table_stride: tl.constexpr,
+    block_size: tl.constexpr,
     is_valid_token_ptr,
     num_blocks,
     TRITON_BLOCK_SIZE: tl.constexpr,

--- a/tests/test_issue133_triton_specialization.py
+++ b/tests/test_issue133_triton_specialization.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Driverless regression test for issue #133's Triton specialization family."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+try:
+    import torch
+    import triton
+    import triton.language as tl
+    from triton.backends.compiler import GPUTarget
+    from triton.compiler import ASTSource, make_backend
+    from triton.compiler import compile as triton_compile
+    from triton.runtime.jit import MockTensor, create_function_from_signature
+except ModuleNotFoundError:
+    torch = None
+    triton = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CACHE_UTILS = (
+    REPO_ROOT / "recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py"
+)
+
+
+@unittest.skipIf(triton is None, "requires the pinned vLLM/Triton runtime")
+class Issue133SpecializationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        triton_utils = types.ModuleType("vllm.triton_utils")
+        triton_utils.triton = triton
+        triton_utils.tl = tl
+        import_utils = types.ModuleType("vllm.utils.import_utils")
+        import_utils.has_cutedsl = lambda: False
+        vllm = types.ModuleType("vllm")
+        vllm.__path__ = []
+        vllm_utils = types.ModuleType("vllm.utils")
+        vllm_utils.__path__ = []
+        vllm.triton_utils = triton_utils
+        vllm.utils = vllm_utils
+        vllm_utils.import_utils = import_utils
+        stub_modules = {
+            "vllm": vllm,
+            "vllm.triton_utils": triton_utils,
+            "vllm.utils": vllm_utils,
+            "vllm.utils.import_utils": import_utils,
+        }
+        missing = object()
+        previous_modules = {
+            name: sys.modules.get(name, missing) for name in stub_modules
+        }
+        try:
+            sys.modules.update(stub_modules)
+            spec = importlib.util.spec_from_file_location(
+                "issue133_cache_utils", CACHE_UTILS
+            )
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"cannot load {CACHE_UTILS}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        finally:
+            for name, previous in previous_modules.items():
+                if previous is missing:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = previous
+        cls.kernel = module._compute_global_topk_indices_and_lens_kernel
+        cls.module = module
+        cls.target = GPUTarget("cuda", 121, 32)
+        cls.backend = make_backend(cls.target)
+        cls.binder = create_function_from_signature(
+            cls.kernel.signature, cls.kernel.params, cls.backend
+        )
+
+    def _specialization(self, token_offset: int, block_size: int):
+        class OffsetTensor(MockTensor):
+            def __init__(self, dtype, address: int) -> None:
+                super().__init__(dtype)
+                self.address = address
+
+            def data_ptr(self) -> int:
+                return self.address
+
+        aligned_i32 = OffsetTensor(torch.int32, 0)
+        token_to_req_indices = OffsetTensor(torch.int32, 4 * token_offset)
+        is_valid_token = OffsetTensor(torch.bool, token_offset)
+        params, specialization, _ = type(self).binder(
+            aligned_i32,
+            1024,
+            aligned_i32,
+            aligned_i32,
+            1024,
+            1024,
+            token_to_req_indices,
+            aligned_i32,
+            1024,
+            block_size,
+            is_valid_token,
+            4096,
+            1024,
+        )
+        return params, specialization
+
+    def test_slice_alignment_does_not_change_specialization(self) -> None:
+        # Same-slice offsets cover both aligned, int32-only aligned, and neither.
+        offsets = (0, 4, 1, 16)
+        for block_size in (64, 2):
+            specializations = [
+                self._specialization(offset, block_size)[1] for offset in offsets
+            ]
+            self.assertTrue(
+                all(item == specializations[0] for item in specializations[1:])
+            )
+
+    def test_block_size_is_the_only_remaining_key_axis(self) -> None:
+        specialization_64 = self._specialization(0, 64)[1]
+        specialization_2 = self._specialization(0, 2)[1]
+        differing_parameters = [
+            parameter.name
+            for parameter, left, right in zip(
+                type(self).kernel.params, specialization_64, specialization_2
+            )
+            if left != right
+        ]
+        self.assertEqual(differing_parameters, ["block_size"])
+
+    def test_both_block_sizes_compile_for_sm121(self) -> None:
+        for block_size in (64, 2):
+            params, specialization = self._specialization(0, block_size)
+            options, signature, constexprs, attrs = type(self).kernel._pack_args(
+                type(self).backend, {}, params, specialization, {}
+            )
+            source = ASTSource(type(self).kernel, signature, constexprs, attrs)
+            compiled = triton_compile(
+                source,
+                target=type(self).target,
+                options=options.__dict__,
+            )
+            ttir = compiled.asm["ttir"]
+            self.assertIn("_compute_global_topk_indices_and_lens_kernel", ttir)
+
+    @unittest.skipUnless(
+        torch is not None and torch.cuda.is_available(),
+        "requires a CUDA device for numerical validation",
+    )
+    def test_outputs_match_reference_for_all_alignment_classes(self) -> None:
+        device = torch.device("cuda")
+        num_blocks = 8
+        block_table = torch.tensor(
+            [
+                [1, 2, -1, 30, 4, 5, 6, 7],
+                [3, 4, 5, 6, 7, -1, 30, 0],
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+        req_indices = (0, 1, 0)
+        valid_tokens = (True, False, True)
+
+        for block_size in (64, 2):
+            topk_indices = torch.tensor(
+                [
+                    [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                    [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                    [1, block_size, block_size + 1, 3 * block_size, -1, 9999, 0, 2],
+                ],
+                dtype=torch.int32,
+                device=device,
+            )
+
+            expected_indices = torch.full_like(topk_indices, -1)
+            expected_lens = torch.zeros(
+                len(req_indices), dtype=torch.int32, device=device
+            )
+            for token_idx, (req_idx, is_valid) in enumerate(
+                zip(req_indices, valid_tokens)
+            ):
+                if not is_valid:
+                    continue
+                valid_count = 0
+                for topk_idx, local_idx in enumerate(topk_indices[token_idx].tolist()):
+                    if local_idx < 0:
+                        continue
+                    block_idx = local_idx // block_size
+                    if block_idx >= block_table.shape[1]:
+                        continue
+                    block_number = int(block_table[req_idx, block_idx].item())
+                    if block_number < 0 or block_number >= num_blocks:
+                        continue
+                    expected_indices[token_idx, topk_idx] = (
+                        block_number * block_size + local_idx % block_size
+                    )
+                    valid_count += 1
+                expected_lens[token_idx] = valid_count
+
+            for token_offset in (0, 4, 1, 16):
+                token_parent = torch.empty(
+                    token_offset + len(req_indices),
+                    dtype=torch.int32,
+                    device=device,
+                )
+                valid_parent = torch.empty(
+                    token_offset + len(valid_tokens),
+                    dtype=torch.bool,
+                    device=device,
+                )
+                token_to_req_indices = token_parent[token_offset:]
+                is_valid_token = valid_parent[token_offset:]
+                token_to_req_indices.copy_(
+                    torch.tensor(req_indices, dtype=torch.int32, device=device)
+                )
+                is_valid_token.copy_(
+                    torch.tensor(valid_tokens, dtype=torch.bool, device=device)
+                )
+
+                actual_indices, actual_lens = type(
+                    self
+                ).module.compute_global_topk_indices_and_lens(
+                    topk_indices,
+                    token_to_req_indices,
+                    block_table,
+                    block_size,
+                    is_valid_token,
+                    num_blocks,
+                )
+                self.assertTrue(torch.equal(actual_indices, expected_indices))
+                self.assertTrue(torch.equal(actual_lens, expected_lens))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- disable Triton alignment specialization for the sliced `token_to_req_indices_ptr` and `is_valid_token_ptr` metadata pointers
- port the stable `tl.constexpr` annotations from merged vLLM PR [#51967](https://github.com/vllm-project/vllm/pull/51967)
- add a driverless Triton 3.6 regression test for cache-key closure and SM121 compilation, plus an optional CUDA numerical case

Closes #133.

## Why this fixes the six-entry family

Mixed prefill slices the `int32` token-to-request map and the `bool` validity mask at the same token offset `k`.

- the `int32` pointer is 16-byte aligned when `k % 4 == 0`
- the `bool` pointer is 16-byte aligned when `k % 16 == 0`

Because both slices share `k`, only three pointer states are possible: both aligned, only the `int32` pointer aligned, or neither aligned. The observed effective block sizes 64 and 2 form the other compile-time axis, producing the six persistent-cache entries from #133:

`3 pointer states × 2 block sizes = 6 variants`

Both affected pointers feed scalar loads only. Their 16-byte alignment does not enable vectorized memory access, so specializing on it creates traffic-dependent compile keys without improving this kernel. Current vLLM uses the same narrow decorator for sliced scalar-loaded metadata in its [MiniMax M3 index kernel](https://github.com/vllm-project/vllm/blob/79bb395eea64dbfef99a55f010d2854db71f8571/vllm/models/minimax_m3/common/ops/index_topk.py#L88-L92).

The patch therefore keeps the existing buffers and callers intact:

```python
@triton.jit(
    do_not_specialize_on_alignment=[
        "token_to_req_indices_ptr",
        "is_valid_token_ptr",
    ]
)
```

Stable strides, `topk`, and `block_size` become `tl.constexpr`, matching upstream vLLM #51967. That leaves two deterministic compiled variants, one for each effective block size, instead of padding fixed-address CUDA-graph metadata or copying slices per scheduler step.

## Verification

Exact commit `88c4c4e`:

- `docker run --rm -v "$PWD:/work:ro" --entrypoint python3 ghcr.io/anemll/dspark-vllm-gx10:0.1.1 /work/tests/test_issue133_triton_specialization.py -v`
  - Triton 3.6 specialization-key test: passed
  - SM121 driverless compile for block sizes 64 and 2: passed
  - CUDA numerical test: skipped because this validation intentionally did not attach a GPU
- `python3 -m unittest discover -s tests -v`: 13 passed/skipped as expected; no failures
- `ruff check tests/test_issue133_triton_specialization.py`: passed
- `ruff check --ignore I001,RUF100 recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py`: passed; the ignored findings predate this patch
- pushed-commit secret scan: no matches

The driverless test constructs same-slice offsets `0`, `4`, `1`, and `16`, covering both aligned, `int32`-only aligned, and neither aligned. It proves those offsets share one specialization for each block size and that `block_size` is the only remaining key difference.

## Live gates before merge

This draft deliberately does not claim live serving closure yet. Before merge on a spare GPU/pair:

1. run the included CUDA numerical case for offsets `0`, `1`, `4`, and `16` with block sizes 2 and 64;
2. start from an isolated empty Triton cache and confirm all former combinations produce exactly two entries whose mtimes remain stable;
3. run a fresh-cache TP=2 warmup plus mixed prefill/decode soak and require zero post-warmup compilation of this kernel, pair loss, or NCCL watchdog termination.

This closes the dynamic-JIT family proven in #133. It does not claim to resolve every silent-stall mechanism tracked by #117.