### PR TITLE
Fix global top-k Triton recompilation family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-24
+
+### Fixed
+
+- **Bounded `_compute_global_topk_indices_and_lens_kernel` to two deterministic Triton compile variants ([Issue #133](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/133))**: mixed prefill slices the `int32` token-to-request map and `bool` validity mask at the same traffic-dependent token offset, so their pointer-alignment specialization produced three cache-key states; the observed effective block sizes 64 and 2 doubled that family to six. The kernel now disables alignment specialization only for those two scalar-loaded pointers and treats its stable strides, top-k width, and block size as compile-time constants, matching upstream vLLM's kernel optimization without padding fixed-address CUDA-graph metadata or copying slices per step. A driverless Triton 3.6 regression test proves the three alignment classes share a key, only block size remains as a two-member axis, and both variants compile for SM121; an optional CUDA case checks bit-exact outputs across all former alignment classes when a device is available. The Anemll `0.1.1` image is patched at startup by `patches/hotfix-dsv4-issue133-triton-specialization.py` (fail-closed compose entrypoint + worker sync), because that runtime does not load `recipe/overlay/`.
+
 ## 2026-08-23
 
 ### Added

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -53,6 +53,8 @@ services:
       - ${DSPARK_ISSUE43_HOTFIX:-./patches/hotfix-dsv4-issue43-decode-fairness-and-diag.py}:/opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py:ro
       # Issue #26/#36 hybrid coordinator: SWA may shrink the common hit (v2).
       - ${DSPARK_ISSUE26_HOTFIX:-./patches/hotfix-dsv4-issue26-hybrid-swa-min.py}:/opt/hotfix-dsv4-issue26-hybrid-swa-min.py:ro
+      # Issue #133: stop global top-k Triton recompiles on sliced-pointer alignment.
+      - ${DSPARK_ISSUE133_HOTFIX:-./patches/hotfix-dsv4-issue133-triton-specialization.py}:/opt/hotfix-dsv4-issue133-triton-specialization.py:ro
       # Client stop strings stay dormant until </think> (Tony/Capicua25x Patch 5).
       - ${DSPARK_SUPPRESS_STOPS_HOTFIX:-./patches/hotfix-dsv4-suppress-stops-in-reasoning.py}:/opt/hotfix-dsv4-suppress-stops-in-reasoning.py:ro
       # A request ending with an assistant message must still get a generation
@@ -241,7 +243,7 @@ services:
         if [ "$${DSPARK_SKIP_SPIN_WAIT_HOTFIX:-0}" != "1" ]; then if [ ! -f /opt/dspark-patches/hotfix-gb10-spin-wait.sh ]; then echo "FATAL: /opt/dspark-patches/hotfix-gb10-spin-wait.sh missing" >&2; exit 1; fi; bash /opt/dspark-patches/hotfix-gb10-spin-wait.sh || exit 1; fi;
         if [ "$${DSPARK_SKIP_HOTFIX:-0}" != "1" ]; then for _hf in hotfix-dsv4-mtp-buffer-50312.sh hotfix-dsv4-skip-topk-49486.sh hotfix-dsv4-dense-prefill-indexer-48407.sh hotfix-dsv4-skip-empty-c128-48957.sh hotfix-dsv4-flashmla-workspace-50298.sh hotfix-dsv4-grammar-advance.sh; do if [ ! -f /opt/dspark-patches/$${_hf} ]; then echo "FATAL: /opt/dspark-patches/$${_hf} missing" >&2; exit 1; fi; bash /opt/dspark-patches/$${_hf} || exit 1; done; fi;
         if [ "$${_dspark_keys_set}" = "1" ] || [ -n "$${VLLM_API_KEY:-}" ]; then bash /opt/dspark-patches/hotfix-vllm-redact-api-key-log.sh || exit 1; bash /opt/dspark-patches/hotfix-vllm-redact-api-key-log.sh --status || exit 1; fi;
-        python3 /opt/hotfix-vllm-empty-encoder-output.py || exit 1; python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py || exit 1; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py || exit 1; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py || exit 1; fi; VLLM_QUANTIZATION_ARGS="";
+        python3 /opt/hotfix-vllm-empty-encoder-output.py || exit 1; python3 /opt/hotfix-dsv4-issue27-partial-prefill-concurrency.py || exit 1; python3 /opt/hotfix-dsv4-issue43-decode-fairness-and-diag.py || exit 1; python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1; python3 /opt/hotfix-dsv4-issue133-triton-specialization.py || exit 1; if [ "$${DSPARK_SKIP_SUPPRESS_STOPS_HOTFIX:-0}" != "1" ]; then python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py || exit 1; fi; VLLM_QUANTIZATION_ARGS="";
         if [ "$${DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX:-0}" = "1" ]; then python3 /opt/hotfix-dsv4-assistant-final-continuation.py || exit 1; fi;
         if [ "$${ENABLE_VLLM_GB10_PATCH:-0}" = "1" ]; then
           python3 -m pip install -e /opt/vllm-gb10-hybrid-nvfp4 --no-deps;

--- a/patches/hotfix-dsv4-issue133-triton-specialization.py
+++ b/patches/hotfix-dsv4-issue133-triton-specialization.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Disable traffic-dependent Triton alignment specialization on global top-k.
+
+Issue #133: mixed prefill slices token_to_req_indices and is_valid_token at the
+same token offset, so Triton's 16-byte alignment specialization produced three
+pointer-key states. Combined with effective block sizes 64 and 2 that became
+six persistent-cache entries and mid-serve JIT. Both pointers are scalar loads,
+so alignment specialization does not vectorize them.
+
+This startup patch matches the overlay in recipe/overlay/.../cache_utils.py
+against the Anemll 0.1.1 kernel signature (no num_blocks bound).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+P = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/models/deepseek_v4/common/ops/cache_utils.py"
+)
+MARK = "# [issue133-hotfix] do_not_specialize_on_alignment for sliced metadata ptrs"
+
+OLD = """@triton.jit
+def _compute_global_topk_indices_and_lens_kernel(
+    global_topk_indices_ptr,
+    global_topk_indices_stride,
+    topk_lens_ptr,
+    topk_indices_ptr,
+    topk_indices_stride,
+    topk,
+    token_to_req_indices_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    is_valid_token_ptr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+):
+"""
+
+NEW = """@triton.jit(
+    do_not_specialize_on_alignment=[
+        "token_to_req_indices_ptr",
+        "is_valid_token_ptr",
+    ]
+)
+def _compute_global_topk_indices_and_lens_kernel(
+    global_topk_indices_ptr,
+    global_topk_indices_stride: tl.constexpr,
+    topk_lens_ptr,
+    topk_indices_ptr,
+    topk_indices_stride: tl.constexpr,
+    topk: tl.constexpr,
+    token_to_req_indices_ptr,
+    block_table_ptr,
+    block_table_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    is_valid_token_ptr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+):
+""" + MARK + "\n"
+
+
+def patch_text(source: str) -> tuple[str, str]:
+    if MARK in source and "do_not_specialize_on_alignment" in source:
+        return source, "skipped"
+    if source.count(OLD) != 1:
+        return source, f"drift:old={source.count(OLD)}"
+    updated = source.replace(OLD, NEW, 1)
+    compile(updated, "cache_utils.py", "exec")
+    return updated, "applied"
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--status":
+        status_src = P.read_text() if P.is_file() else ""
+        print(
+            "issue133 triton specialization     :",
+            "APPLIED" if MARK in status_src else "NOT APPLIED",
+        )
+        return 0
+    if not P.is_file():
+        print(f"[issue133-hotfix] missing {P}", file=sys.stderr)
+        return 1
+    src = P.read_text()
+    updated, status = patch_text(src)
+    if status == "skipped":
+        print(f"[issue133-hotfix] already applied to {P}")
+        return 0
+    if status != "applied":
+        print(f"[issue133-hotfix] refusing to patch ({status})", file=sys.stderr)
+        return 1
+    P.write_text(updated)
+    print(f"[issue133-hotfix] applied to {P}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -430,18 +430,23 @@ def compute_global_topk_indices_and_lens(
     return global_topk_indices, topk_lens
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize_on_alignment=[
+        "token_to_req_indices_ptr",
+        "is_valid_token_ptr",
+    ]
+)
 def _compute_global_topk_indices_and_lens_kernel(
     global_topk_indices_ptr,
-    global_topk_indices_stride,
+    global_topk_indices_stride: tl.constexpr,
     topk_lens_ptr,
     topk_indices_ptr,
-    topk_indices_stride,
-    topk,
+    topk_indices_stride: tl.constexpr,
+    topk: tl.constexpr,
     token_to_req_indices_ptr,
     block_table_ptr,
-    block_table_stride,
-    block_size,
+    block_table_stride: tl.constexpr,
+    block_size: tl.constexpr,
     is_valid_token_ptr,
     num_blocks,
     TRITON_BLOCK_SIZE: tl.constexpr,

--- a/scripts/ab-issue133-triton-specialization.py
+++ b/scripts/ab-issue133-triton-specialization.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""A/B the issue #133 Triton specialization family: baseline vs patched overlay.
+
+Compares compile-key cardinality, SM121 compilation, and (when CUDA is present)
+bit-exact kernel outputs against a Python reference and against each other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import torch
+import triton
+import triton.language as tl
+from triton.backends.compiler import GPUTarget
+from triton.compiler import ASTSource, make_backend
+from triton.compiler import compile as triton_compile
+from triton.runtime.jit import MockTensor, create_function_from_signature
+
+OFFSETS = (0, 4, 1, 16)
+BLOCK_SIZES = (64, 2)
+NUM_BLOCKS = 8
+REQ_INDICES = (0, 1, 0)
+VALID_TOKENS = (True, False, True)
+
+
+def _stub_and_load(path: Path, module_name: str):
+    triton_utils = types.ModuleType("vllm.triton_utils")
+    triton_utils.triton = triton
+    triton_utils.tl = tl
+    import_utils = types.ModuleType("vllm.utils.import_utils")
+    import_utils.has_cutedsl = lambda: False
+    vllm = types.ModuleType("vllm")
+    vllm.__path__ = []
+    vllm_utils = types.ModuleType("vllm.utils")
+    vllm_utils.__path__ = []
+    vllm.triton_utils = triton_utils
+    vllm.utils = vllm_utils
+    vllm_utils.import_utils = import_utils
+    stub_modules = {
+        "vllm": vllm,
+        "vllm.triton_utils": triton_utils,
+        "vllm.utils": vllm_utils,
+        "vllm.utils.import_utils": import_utils,
+    }
+    missing = object()
+    previous = {name: sys.modules.get(name, missing) for name in stub_modules}
+    try:
+        sys.modules.update(stub_modules)
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"cannot load {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in previous.items():
+            if prev is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+    return module
+
+
+def _specialize(kernel, backend, binder, token_offset: int, block_size: int):
+    class OffsetTensor(MockTensor):
+        def __init__(self, dtype, address: int) -> None:
+            super().__init__(dtype)
+            self.address = address
+
+        def data_ptr(self) -> int:
+            return self.address
+
+    aligned_i32 = OffsetTensor(torch.int32, 0)
+    token_to_req_indices = OffsetTensor(torch.int32, 4 * token_offset)
+    is_valid_token = OffsetTensor(torch.bool, token_offset)
+    params, specialization, _ = binder(
+        aligned_i32,
+        1024,
+        aligned_i32,
+        aligned_i32,
+        1024,
+        1024,
+        token_to_req_indices,
+        aligned_i32,
+        1024,
+        block_size,
+        is_valid_token,
+        4096,
+        1024,
+    )
+    named = {
+        parameter.name: item
+        for parameter, item in zip(kernel.params, specialization)
+    }
+    return params, specialization, named
+
+
+def _key(named: dict) -> str:
+    return json.dumps(named, default=str, sort_keys=True)
+
+
+def _analyze(label: str, path: Path, compile_sm121: bool) -> dict:
+    module = _stub_and_load(path, f"issue133_{label}")
+    kernel = module._compute_global_topk_indices_and_lens_kernel
+    target = GPUTarget("cuda", 121, 32)
+    backend = make_backend(target)
+    binder = create_function_from_signature(kernel.signature, kernel.params, backend)
+    rows = []
+    unique = {}
+    for block_size in BLOCK_SIZES:
+        for offset in OFFSETS:
+            params, specialization, named = _specialize(
+                kernel, backend, binder, offset, block_size
+            )
+            digest = hashlib.sha256(_key(named).encode()).hexdigest()[:12]
+            unique.setdefault(digest, {"named": named, "cases": []})
+            unique[digest]["cases"].append({"offset": offset, "block_size": block_size})
+            rows.append(
+                {
+                    "offset": offset,
+                    "block_size": block_size,
+                    "i32_aligned_16": (4 * offset) % 16 == 0,
+                    "bool_aligned_16": offset % 16 == 0,
+                    "key": digest,
+                    "named": {k: str(v) for k, v in named.items()},
+                }
+            )
+            if compile_sm121 and offset == 0:
+                options, signature, constexprs, attrs = kernel._pack_args(
+                    backend, {}, params, specialization, {}
+                )
+                compiled = triton_compile(
+                    ASTSource(kernel, signature, constexprs, attrs),
+                    target=target,
+                    options=options.__dict__,
+                )
+                ttir = compiled.asm["ttir"]
+                unique[digest]["ttir_has_kernel"] = (
+                    "_compute_global_topk_indices_and_lens_kernel" in ttir
+                )
+                unique[digest]["ttir_sha256"] = hashlib.sha256(ttir.encode()).hexdigest()[
+                    :16
+                ]
+    return {
+        "label": label,
+        "path": str(path),
+        "unique_keys": len(unique),
+        "rows": rows,
+        "families": [
+            {
+                "key": digest,
+                "cases": payload["cases"],
+                "ttir_has_kernel": payload.get("ttir_has_kernel"),
+                "ttir_sha256": payload.get("ttir_sha256"),
+            }
+            for digest, payload in unique.items()
+        ],
+        "module": module,
+    }
+
+
+def _reference(topk_indices, block_table, block_size, req_indices, valid_tokens):
+    expected_indices = torch.full_like(topk_indices, -1)
+    expected_lens = torch.zeros(len(req_indices), dtype=torch.int32, device=topk_indices.device)
+    for token_idx, (req_idx, is_valid) in enumerate(zip(req_indices, valid_tokens)):
+        if not is_valid:
+            continue
+        valid_count = 0
+        for topk_idx, local_idx in enumerate(topk_indices[token_idx].tolist()):
+            if local_idx < 0:
+                continue
+            block_idx = local_idx // block_size
+            if block_idx >= block_table.shape[1]:
+                continue
+            block_number = int(block_table[req_idx, block_idx].item())
+            if block_number < 0 or block_number >= NUM_BLOCKS:
+                continue
+            expected_indices[token_idx, topk_idx] = (
+                block_number * block_size + local_idx % block_size
+            )
+            valid_count += 1
+        expected_lens[token_idx] = valid_count
+    return expected_indices, expected_lens
+
+
+def _numerical(baseline_mod, patched_mod) -> dict:
+    device = torch.device("cuda")
+    block_table = torch.tensor(
+        [
+            [1, 2, -1, 30, 4, 5, 6, 7],
+            [3, 4, 5, 6, 7, -1, 30, 0],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    mismatches = []
+    cases = 0
+    for block_size in BLOCK_SIZES:
+        topk_indices = torch.tensor(
+            [
+                [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                [1, block_size, block_size + 1, 3 * block_size, -1, 9999, 0, 2],
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+        expected_indices, expected_lens = _reference(
+            topk_indices, block_table, block_size, REQ_INDICES, VALID_TOKENS
+        )
+        for token_offset in OFFSETS:
+            token_parent = torch.empty(
+                token_offset + len(REQ_INDICES), dtype=torch.int32, device=device
+            )
+            valid_parent = torch.empty(
+                token_offset + len(VALID_TOKENS), dtype=torch.bool, device=device
+            )
+            token_to_req_indices = token_parent[token_offset:]
+            is_valid_token = valid_parent[token_offset:]
+            token_to_req_indices.copy_(
+                torch.tensor(REQ_INDICES, dtype=torch.int32, device=device)
+            )
+            is_valid_token.copy_(
+                torch.tensor(VALID_TOKENS, dtype=torch.bool, device=device)
+            )
+            kwargs = dict(
+                topk_indices=topk_indices,
+                token_to_req_indices=token_to_req_indices,
+                block_table=block_table,
+                block_size=block_size,
+                is_valid_token=is_valid_token,
+                num_blocks=NUM_BLOCKS,
+            )
+            b_idx, b_lens = baseline_mod.compute_global_topk_indices_and_lens(**kwargs)
+            p_idx, p_lens = patched_mod.compute_global_topk_indices_and_lens(**kwargs)
+            cases += 1
+            if not torch.equal(b_idx, expected_indices) or not torch.equal(
+                b_lens, expected_lens
+            ):
+                mismatches.append(
+                    {"side": "baseline", "offset": token_offset, "block_size": block_size}
+                )
+            if not torch.equal(p_idx, expected_indices) or not torch.equal(
+                p_lens, expected_lens
+            ):
+                mismatches.append(
+                    {"side": "patched", "offset": token_offset, "block_size": block_size}
+                )
+            if not torch.equal(b_idx, p_idx) or not torch.equal(b_lens, p_lens):
+                mismatches.append(
+                    {
+                        "side": "baseline_vs_patched",
+                        "offset": token_offset,
+                        "block_size": block_size,
+                    }
+                )
+    return {
+        "cuda": True,
+        "cases": cases,
+        "mismatches": mismatches,
+        "ok": not mismatches,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--patched", type=Path, required=True)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--no-compile", action="store_true")
+    args = parser.parse_args()
+
+    compile_sm121 = not args.no_compile
+    baseline = _analyze("baseline", args.baseline, compile_sm121)
+    patched = _analyze("patched", args.patched, compile_sm121)
+    numerical = {"cuda": False, "skipped": True}
+    if torch.cuda.is_available():
+        numerical = _numerical(baseline["module"], patched["module"])
+
+    baseline.pop("module")
+    patched.pop("module")
+    report = {
+        "triton": getattr(triton, "__version__", "unknown"),
+        "cuda_available": bool(torch.cuda.is_available()),
+        "baseline_unique_keys": baseline["unique_keys"],
+        "patched_unique_keys": patched["unique_keys"],
+        "key_family_collapsed": baseline["unique_keys"] == 6
+        and patched["unique_keys"] == 2,
+        "baseline": baseline,
+        "patched": patched,
+        "numerical": numerical,
+    }
+    text = json.dumps(report, indent=2)
+    print(text)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n")
+
+    ok = patched["unique_keys"] == 2 and baseline["unique_keys"] > patched["unique_keys"]
+    if compile_sm121:
+        ok = ok and all(fam.get("ttir_has_kernel") for fam in patched["families"])
+    if numerical.get("cuda"):
+        ok = ok and numerical["ok"]
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -53,7 +53,9 @@ py_files+=(
   scripts/test-empty-encoder-output-hotfix.py
   scripts/ruler-lite.py
   scripts/verify-dsv4-027-equality-gate.py
+  scripts/ab-issue133-triton-specialization.py
   tests/test_dspark_stacked_mapping.py
+  tests/test_issue133_triton_specialization.py
 )
 python3 -m py_compile "${py_files[@]}"
 ok "py_compile ${#py_files[@]} files"
@@ -93,6 +95,8 @@ python3 tests/test_issue27_inflight_cap.py -q
 ok "test_issue27_inflight_cap"
 python3 tests/test_dspark_stacked_mapping.py -q
 ok "test_dspark_stacked_mapping"
+python3 tests/test_issue133_triton_specialization.py -q
+ok "test_issue133_triton_specialization"
 python3 scripts/verify-dsv4-027-equality-gate.py
 ok "verify-dsv4-027-equality-gate"
 bash scripts/verify-overlay-sources.sh
@@ -172,6 +176,13 @@ if grep -Fq 'python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1' docke
 else
   bad "compose must apply #26 + #27 with || exit 1"
 fi
+if grep -Fq 'hotfix-dsv4-issue133-triton-specialization.py}:/opt/hotfix-dsv4-issue133-triton-specialization.py:ro' docker-compose.dspark.yml \
+  && grep -Fq 'python3 /opt/hotfix-dsv4-issue133-triton-specialization.py || exit 1' docker-compose.dspark.yml \
+  && grep -Fq 'scp "$DSPARK_ISSUE133_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue133-triton-specialization.py"' start-deepseek-v4-flash-dspark.sh; then
+  ok "issue133 triton specialization hotfix is mounted, fail-closed, and worker-synced"
+else
+  bad "issue133 hotfix wiring is incomplete"
+fi
 if grep -Fq 'python3 /opt/hotfix-dsv4-suppress-stops-in-reasoning.py || exit 1' docker-compose.dspark.yml; then
   ok "compose applies suppress-stops-in-reasoning fail-closed"
 else
@@ -232,6 +243,7 @@ for p in \
   patches/hotfix-dsv4-issue55-tool-truncation.py \
   patches/hotfix-dsv4-issue26-hybrid-swa-min.py \
   patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py \
+  patches/hotfix-dsv4-issue133-triton-specialization.py \
   patches/hotfix-vllm-empty-encoder-output.py \
   patches/hotfix-nvfp4-ds-mla-issue22.sh \
   patches/hotfix-gb10-spin-wait.sh \

--- a/scripts/test-python-hotfix-failclosed.py
+++ b/scripts/test-python-hotfix-failclosed.py
@@ -194,6 +194,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
                 "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
                 "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
                 "hotfix-dsv4-issue26-hybrid-swa-min.py",
+                "hotfix-dsv4-issue133-triton-specialization.py",
                 "hotfix-dsv4-suppress-stops-in-reasoning.py",
             ],
         )
@@ -205,6 +206,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
             "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
             "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
             "hotfix-dsv4-issue26-hybrid-swa-min.py",
+            "hotfix-dsv4-issue133-triton-specialization.py",
             "hotfix-dsv4-suppress-stops-in-reasoning.py",
         ]
         for step in order:
@@ -230,6 +232,7 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
                 "hotfix-dsv4-issue27-partial-prefill-concurrency.py",
                 "hotfix-dsv4-issue43-decode-fairness-and-diag.py",
                 "hotfix-dsv4-issue26-hybrid-swa-min.py",
+                "hotfix-dsv4-issue133-triton-specialization.py",
             ],
         )
         self.assertTrue(reached)

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -788,6 +788,7 @@ print_resolved_profile() {
   echo "  mtp speculative tokens: ${MTP_NUM_TOKENS:-5} (dspark_block_size min is 5)"
   echo "  default thinking: $DEFAULT_THINKING (off/low/high/max)"
   echo "  issue31 GPU thinking_token_budget hotfix: ${DSPARK_ENABLE_ISSUE31_GPU_HOTFIX:-0} (0=stock V2 / 1=apply)"
+  echo "  issue133 Triton specialization hotfix: will apply on start"
   echo "  cudagraph capture size: $(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-5} + 1) ))"
   echo "  API bind: $VLLM_HOST:$VLLM_PORT"
   echo "  API probe: $API_URL"
@@ -1000,6 +1001,12 @@ if [ -f "$DSPARK_ISSUE26_HOTFIX" ]; then
   echo "Syncing Issue #26 hybrid-SWA-min hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"
   ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
   scp "$DSPARK_ISSUE26_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue26-hybrid-swa-min.py"
+fi
+DSPARK_ISSUE133_HOTFIX="${DSPARK_ISSUE133_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-issue133-triton-specialization.py}"
+if [ -f "$DSPARK_ISSUE133_HOTFIX" ]; then
+  echo "Syncing Issue #133 Triton specialization hotfix to ${WORKER_HOST}:${WORKER_DIR}/patches/"
+  ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
+  scp "$DSPARK_ISSUE133_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue133-triton-specialization.py"
 fi
 DSPARK_SUPPRESS_STOPS_HOTFIX="${DSPARK_SUPPRESS_STOPS_HOTFIX:-$SCRIPT_DIR/patches/hotfix-dsv4-suppress-stops-in-reasoning.py}"
 if [ -f "$DSPARK_SUPPRESS_STOPS_HOTFIX" ]; then

--- a/tests/test_issue133_triton_specialization.py
+++ b/tests/test_issue133_triton_specialization.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Driverless regression test for issue #133's Triton specialization family."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+try:
+    import torch
+    import triton
+    import triton.language as tl
+    from triton.backends.compiler import GPUTarget
+    from triton.compiler import ASTSource, make_backend
+    from triton.compiler import compile as triton_compile
+    from triton.runtime.jit import MockTensor, create_function_from_signature
+except ModuleNotFoundError:
+    torch = None
+    triton = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CACHE_UTILS = (
+    REPO_ROOT / "recipe/overlay/vllm/models/deepseek_v4/common/ops/cache_utils.py"
+)
+
+
+@unittest.skipIf(triton is None, "requires the pinned vLLM/Triton runtime")
+class Issue133SpecializationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        triton_utils = types.ModuleType("vllm.triton_utils")
+        triton_utils.triton = triton
+        triton_utils.tl = tl
+        import_utils = types.ModuleType("vllm.utils.import_utils")
+        import_utils.has_cutedsl = lambda: False
+        vllm = types.ModuleType("vllm")
+        vllm.__path__ = []
+        vllm_utils = types.ModuleType("vllm.utils")
+        vllm_utils.__path__ = []
+        vllm.triton_utils = triton_utils
+        vllm.utils = vllm_utils
+        vllm_utils.import_utils = import_utils
+        stub_modules = {
+            "vllm": vllm,
+            "vllm.triton_utils": triton_utils,
+            "vllm.utils": vllm_utils,
+            "vllm.utils.import_utils": import_utils,
+        }
+        missing = object()
+        previous_modules = {
+            name: sys.modules.get(name, missing) for name in stub_modules
+        }
+        try:
+            sys.modules.update(stub_modules)
+            spec = importlib.util.spec_from_file_location(
+                "issue133_cache_utils", CACHE_UTILS
+            )
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"cannot load {CACHE_UTILS}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        finally:
+            for name, previous in previous_modules.items():
+                if previous is missing:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = previous
+        cls.kernel = module._compute_global_topk_indices_and_lens_kernel
+        cls.module = module
+        cls.target = GPUTarget("cuda", 121, 32)
+        cls.backend = make_backend(cls.target)
+        cls.binder = create_function_from_signature(
+            cls.kernel.signature, cls.kernel.params, cls.backend
+        )
+
+    def _specialization(self, token_offset: int, block_size: int):
+        class OffsetTensor(MockTensor):
+            def __init__(self, dtype, address: int) -> None:
+                super().__init__(dtype)
+                self.address = address
+
+            def data_ptr(self) -> int:
+                return self.address
+
+        aligned_i32 = OffsetTensor(torch.int32, 0)
+        token_to_req_indices = OffsetTensor(torch.int32, 4 * token_offset)
+        is_valid_token = OffsetTensor(torch.bool, token_offset)
+        params, specialization, _ = type(self).binder(
+            aligned_i32,
+            1024,
+            aligned_i32,
+            aligned_i32,
+            1024,
+            1024,
+            token_to_req_indices,
+            aligned_i32,
+            1024,
+            block_size,
+            is_valid_token,
+            4096,
+            1024,
+        )
+        return params, specialization
+
+    def test_slice_alignment_does_not_change_specialization(self) -> None:
+        # Same-slice offsets cover both aligned, int32-only aligned, and neither.
+        offsets = (0, 4, 1, 16)
+        for block_size in (64, 2):
+            specializations = [
+                self._specialization(offset, block_size)[1] for offset in offsets
+            ]
+            self.assertTrue(
+                all(item == specializations[0] for item in specializations[1:])
+            )
+
+    def test_block_size_is_the_only_remaining_key_axis(self) -> None:
+        specialization_64 = self._specialization(0, 64)[1]
+        specialization_2 = self._specialization(0, 2)[1]
+        differing_parameters = [
+            parameter.name
+            for parameter, left, right in zip(
+                type(self).kernel.params, specialization_64, specialization_2
+            )
+            if left != right
+        ]
+        self.assertEqual(differing_parameters, ["block_size"])
+
+    def test_both_block_sizes_compile_for_sm121(self) -> None:
+        for block_size in (64, 2):
+            params, specialization = self._specialization(0, block_size)
+            options, signature, constexprs, attrs = type(self).kernel._pack_args(
+                type(self).backend, {}, params, specialization, {}
+            )
+            source = ASTSource(type(self).kernel, signature, constexprs, attrs)
+            compiled = triton_compile(
+                source,
+                target=type(self).target,
+                options=options.__dict__,
+            )
+            ttir = compiled.asm["ttir"]
+            self.assertIn("_compute_global_topk_indices_and_lens_kernel", ttir)
+
+    @unittest.skipUnless(
+        torch is not None and torch.cuda.is_available(),
+        "requires a CUDA device for numerical validation",
+    )
+    def test_outputs_match_reference_for_all_alignment_classes(self) -> None:
+        device = torch.device("cuda")
+        num_blocks = 8
+        block_table = torch.tensor(
+            [
+                [1, 2, -1, 30, 4, 5, 6, 7],
+                [3, 4, 5, 6, 7, -1, 30, 0],
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+        req_indices = (0, 1, 0)
+        valid_tokens = (True, False, True)
+
+        for block_size in (64, 2):
+            topk_indices = torch.tensor(
+                [
+                    [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                    [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3],
+                    [1, block_size, block_size + 1, 3 * block_size, -1, 9999, 0, 2],
+                ],
+                dtype=torch.int32,
+                device=device,
+            )
+
+            expected_indices = torch.full_like(topk_indices, -1)
+            expected_lens = torch.zeros(
+                len(req_indices), dtype=torch.int32, device=device
+            )
+            for token_idx, (req_idx, is_valid) in enumerate(
+                zip(req_indices, valid_tokens)
+            ):
+                if not is_valid:
+                    continue
+                valid_count = 0
+                for topk_idx, local_idx in enumerate(topk_indices[token_idx].tolist()):
+                    if local_idx < 0:
+                        continue
+                    block_idx = local_idx // block_size
+                    if block_idx >= block_table.shape[1]:
+                        continue
+                    block_number = int(block_table[req_idx, block_idx].item())
+                    if block_number < 0 or block_number >= num_blocks:
+                        continue
+                    expected_indices[token_idx, topk_idx] = (
+                        block_number * block_size + local_idx % block_size
+                    )
+                    valid_count += 1
+                expected_lens[token_idx] = valid_count
+
+            for token_offset in (0, 4, 1, 16):
+                token_parent = torch.empty(
+                    token_offset + len(req_indices),
+                    dtype=torch.int32,
+                    device=device,
+                )
+                valid_parent = torch.empty(
+                    token_offset + len(valid_tokens),
+                    dtype=torch.bool,
+                    device=device,
+                )
+                token_to_req_indices = token_parent[token_offset:]
+                is_valid_token = valid_parent[token_offset:]
+                token_to_req_indices.copy_(
+                    torch.tensor(req_indices, dtype=torch.int32, device=device)
+                )
+                is_valid_token.copy_(
+                    torch.tensor(valid_tokens, dtype=torch.bool, device=device)
+                )
+
+                actual_indices, actual_lens = type(
+                    self
+                ).module.compute_global_topk_indices_and_lens(
+                    topk_indices,
+                    token_to_req_indices,
+                    block_table,
+                    block_size,
+                    is_valid_token,
+                    num_blocks,
+                )
+                self.assertTrue(torch.equal(actual_indices, expected_indices))
+                self.assertTrue(torch.equal(actual_lens, expected_lens))
+
+    @unittest.skipUnless(
+        torch is not None and torch.cuda.is_available(),
+        "requires a CUDA device for persistent-cache validation",
+    )
+    def test_fresh_triton_cache_has_two_stable_entries(self) -> None:
+        cache_dir = tempfile.mkdtemp(prefix="issue133-triton-cache-")
+        env = os.environ.copy()
+        env["TRITON_CACHE_DIR"] = cache_dir
+        completed = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve()), "--cache-gate"],
+            cwd=str(REPO_ROOT),
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            self.fail(completed.stdout + completed.stderr)
+        report = json.loads(completed.stdout.strip().splitlines()[-1])
+        self.assertEqual(report["unique_kernel_dirs"], 2)
+        self.assertTrue(report["mtimes_stable"])
+
+
+def _kernel_cache_dirs(cache_root: Path) -> dict[Path, float]:
+    found: dict[Path, float] = {}
+    if not cache_root.exists():
+        return found
+    for child in cache_root.iterdir():
+        if not child.is_dir():
+            continue
+        files = [path for path in child.rglob("*") if path.is_file()]
+        if not any(
+            "_compute_global_topk_indices_and_lens_kernel" in path.read_text(errors="ignore")
+            for path in files
+        ):
+            continue
+        found[child] = max(path.stat().st_mtime for path in files)
+    return found
+
+
+def _launch_alignment_family(module) -> None:
+    device = torch.device("cuda")
+    num_blocks = 8
+    block_table = torch.tensor(
+        [[1, 2, -1, 30, 4, 5, 6, 7], [3, 4, 5, 6, 7, -1, 30, 0]],
+        dtype=torch.int32,
+        device=device,
+    )
+    req_indices = (0, 1, 0)
+    valid_tokens = (True, False, True)
+    # Production DSV4-Flash index_topk is 512; keep a short row so the
+    # constexpr top-k axis matches the live C4A buffer width.
+    topk = 512
+    for block_size in (64, 2):
+        row = [0, 1, block_size, block_size + 1, -1, 2 * block_size + 1, 9999, 3]
+        topk_indices = torch.full((3, topk), -1, dtype=torch.int32, device=device)
+        topk_indices[:, : len(row)] = torch.tensor(row, dtype=torch.int32, device=device)
+        for token_offset in (0, 4, 1, 16):
+            token_parent = torch.empty(
+                token_offset + len(req_indices), dtype=torch.int32, device=device
+            )
+            valid_parent = torch.empty(
+                token_offset + len(valid_tokens), dtype=torch.bool, device=device
+            )
+            token_to_req_indices = token_parent[token_offset:]
+            is_valid_token = valid_parent[token_offset:]
+            token_to_req_indices.copy_(
+                torch.tensor(req_indices, dtype=torch.int32, device=device)
+            )
+            is_valid_token.copy_(
+                torch.tensor(valid_tokens, dtype=torch.bool, device=device)
+            )
+            module.compute_global_topk_indices_and_lens(
+                topk_indices,
+                token_to_req_indices,
+                block_table,
+                block_size,
+                is_valid_token,
+                num_blocks,
+            )
+    torch.cuda.synchronize()
+
+
+def _cache_gate_main() -> int:
+    cache_root = Path(os.environ["TRITON_CACHE_DIR"])
+    cache_root.mkdir(parents=True, exist_ok=True)
+    if any(cache_root.iterdir()):
+        raise SystemExit(f"TRITON_CACHE_DIR is not empty: {cache_root}")
+    Issue133SpecializationTest.setUpClass()
+    _launch_alignment_family(Issue133SpecializationTest.module)
+    first = _kernel_cache_dirs(cache_root)
+    time.sleep(1.1)
+    _launch_alignment_family(Issue133SpecializationTest.module)
+    second = _kernel_cache_dirs(cache_root)
+    report = {
+        "unique_kernel_dirs": len(first),
+        "dirs": [str(path) for path in sorted(first)],
+        "mtimes_stable": first == second,
+        "first_mtimes": {str(path): mtime for path, mtime in first.items()},
+        "second_mtimes": {str(path): mtime for path, mtime in second.items()},
+    }
+    print(json.dumps(report))
+    return 0 if report["unique_kernel_dirs"] == 2 and report["mtimes_stable"] else 1
+
+
+if __name__ == "__main__":
+    if "--cache-gate" in sys.argv:
+        raise SystemExit(_cache_gate_main())
+    unittest.main()


### PR DESCRIPTION
## Summary
- Overlay: disable Triton alignment specialization on sliced `token_to_req_indices_ptr` / `is_valid_token_ptr` and mark stable strides, top-k, and block size as `tl.constexpr`.
- Anemll 0.1.1 startup hotfix so the live pair actually runs that kernel (compose fail-closed + worker sync).
- Driverless + CUDA regression tests, empty-cache two-entry gate, and live TP=2 warmup/soak with zero post-warmup JIT of this kernel.

Closes #133.

Supersedes draft overlay-only #134 with the Anemll hotfix and live verification.