### PR TITLE
fix: ship pi example with thinking_token_budget capability off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-27
+
+### Fixed
+
+- **`pi-models.dspark.example.json` no longer advertises `thinking_token_budget` against a server that rejects it**: issue #66 made the GPU budget hotfix opt-in (`DSPARK_ENABLE_ISSUE31_GPU_HOTFIX`, default `0`) on the premise that fresh clones omit the field, but the shipped pi model entry kept `compat.supportsThinkingTokenBudget: true`. A clone that followed the README on both sides — `.env.dspark.example` for the server, `pi-models.dspark.example.json` into `~/.pi/agent/models.json` for the client — therefore failed every pi request with `thinking_token_budget is not yet supported by the V2 model runner`, and the error's own advice (`VLLM_USE_V2_MODEL_RUNNER=0`) points at a knob this recipe does not expose. The example now ships `false`, matching the server default; the README's pi section states that the budget needs the boot flag *and* the client capability, quotes the error produced by an out-of-step pair, and documents the reverse direction (turn the capability off, keep `DEFAULT_THINKING` and the `reasoning_effort` mapping, leave `maxTokens` generous enough for reasoning to finish).
+
 ## 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -347,34 +347,34 @@ curl :8888/v1/chat/completions -H 'Content-Type: application/json' -d '{
 }'
 ```
 
-**pi** — set a reasoning budget in the model entry, and pi sends the field
-for you on every request where you enable thinking. Copy
-[`pi-models.dspark.example.json`](pi-models.dspark.example.json) to
-`~/.pi/agent/models.json`, then add a `thinkingTokenBudget` (in tokens) to the
-`deepseek-v4-flash-0731` model:
+**pi** — the budget needs the boot flag **and** the pi model entry, so
+[`pi-models.dspark.example.json`](pi-models.dspark.example.json) ships
+`supportsThinkingTokenBudget: false` to match the server default
+(`DSPARK_ENABLE_ISSUE31_GPU_HOTFIX=0`). Copy it to `~/.pi/agent/models.json`;
+once the boot flag is `1`, flip the capability on the `deepseek-v4-flash-0731`
+model and pi attaches a `thinking_token_budget` whenever thinking is enabled:
 
 ```json
 {
   "id": "deepseek-v4-flash-0731",
   "reasoning": true,
-  "thinkingTokenBudget": 1024,
   "compat": {
     "supportsThinkingTokenBudget": true,
     "thinkingFormat": "chat-template",
     "chatTemplateKwargs": {
       "thinking":       { "$var": "thinking.enabled" },
-      "reasoning_effort": { "$var": "thinking.effort", "omitWhenOff": true },
-      "thinking_token_budget": { "$var": "model.thinkingTokenBudget", "omitWhenUnset": true }
+      "reasoning_effort": { "$var": "thinking.effort", "omitWhenOff": true }
     }
   }
 }
 ```
 
-`supportsThinkingTokenBudget: true` advertises the capability so pi will send
-the field; `"$var": "model.thinkingTokenBudget"` with `omitWhenUnset: true`
-means the budget is only attached when you set one in the model — otherwise the
-stock fast path runs. Remove the `thinkingTokenBudget` line (or set it to `0`)
-to let the model reason freely again.
+pi sizes the budget from per-level defaults (`minimal` 1024 / `low` 2048 /
+`medium` 8192 / `high` 16384), always leaving room for the answer; override
+values with the pi `thinkingBudgets` setting. If the capability is `true` while
+the boot flag is `0`, every pi request fails with `thinking_token_budget is not
+yet supported by the V2 model runner` — so keep the capability `false` unless
+`DSPARK_ENABLE_ISSUE31_GPU_HOTFIX=1`.
 
 ---
 

--- a/pi-models.dspark.example.json
+++ b/pi-models.dspark.example.json
@@ -33,7 +33,7 @@
             "cacheWrite": 0
           },
           "compat": {
-            "supportsThinkingTokenBudget": true,
+            "supportsThinkingTokenBudget": false,
             "thinkingFormat": "chat-template",
             "chatTemplateKwargs": {
               "thinking": {


### PR DESCRIPTION
## What

`pi-models.dspark.example.json` shipped `compat.supportsThinkingTokenBudget: true` while the server default after #66 is `DSPARK_ENABLE_ISSUE31_GPU_HOTFIX=0`. On the default server, vLLM's stock V2 runner rejects every request carrying `thinking_token_budget` with `thinking_token_budget is not yet supported by the V2 model runner`, and the error's own advice (`VLLM_USE_V2_MODEL_RUNNER=0`) points at a knob this recipe does not expose.

A fresh clone that followed the README on both sides — `.env.dspark.example` for the server, `pi-models.dspark.example.json` → `~/.pi/agent/models.json` for the client — therefore failed **every** pi request in which thinking was enabled.

This PR:
- ships the example with `supportsThinkingTokenBudget: false` to match the server default (`DSPARK_ENABLE_ISSUE31_GPU_HOTFIX=0`),
- rewrites the README's pi section to describe the mechanism pi actually implements: the boot flag **and** the client capability are both required, and pi sizes the budget from per-level defaults overridable through the pi `thinkingBudgets` setting — there is no per-model `thinkingTokenBudget` field (the previous docs referenced a mechanism pi does not implement, and `omitWhenUnset`/`$var: "model.thinkingTokenBudget"` are not pi keys),
- documents the failure mode and the reverse direction,
- adds a CHANGELOG entry.

## Verification

- Example JSON stays valid; `supportsThinkingTokenBudget` ships `false`.
- Statements cross-checked against pi internals (`@earendil-works/pi-ai`):
  - pi attaches a top-level `thinking_token_budget` when `supportsThinkingTokenBudget` is true and thinking is enabled,
  - default budgets: `minimal` 1024 / `low` 2048 / `medium` 8192 / `high` 16384, clamped so the answer always keeps room; overridable via the `thinkingBudgets` setting,
  - `omitWhenUnset` and `$var: "model.thinkingTokenBudget"` do not exist in pi.
- The quoted error string matches `patches/hotfix-dsv4-issue31-v2-thinking-budget-gpu.py`.

## Not verified live

The "on" direction (boot flag `1` + capability `true`) was checked against the pi code paths cited above but not re-benchmarked on live hardware in this PR. The README states the budgets pi will use by default; if you run with the capability on, please report back so the docs can be confirmed end-to-end.