### PR TITLE
fix(sched): restore safe single-prefill default

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -190,21 +190,19 @@ MAX_NUM_BATCHED_TOKENS=8192
 # from ~46x to ~1.05x. Safe across MAX_NUM_SEQS and prompt lengths.
 LONG_PREFILL_TOKEN_THRESHOLD=1024
 
-# Issue #43: max concurrent in-flight partial prefills. Raising to 2/3
-# overlaps prefills and is the lever that improves the whole-request min/max
-# decode rate #43 reports. NOTE: --max-num-partial-prefills is NOT available
-# on dspark-vllm-gx10:0.1.1 — vLLM's _check_feature_supported() rejects
-# Concurrent Partial Prefill before engine init. Do NOT pass that flag.
-# The #27 hotfix instead reads DSPARK_MAX_INFLIGHT_PREFILLS once during
-# Scheduler construction. Values 1-3 are accepted; values above 3 clamp to 3.
-# Blank, whitespace-only, nonpositive, or malformed values fall back to
-# SchedulerConfig.max_num_partial_prefills (stock 1); malformed values warn
-# once instead of crashing admission. Default 2: live 32K×c4 decode left the
-# ~8 tok/s floor (~25 tok/s) with #43 floor on and
-# LONG_PREFILL_TOKEN_THRESHOLD=1024. Set 1 to restore the original
-# serialize-one-prefill gate. Image upgrade for real concurrent partial
-# prefill is issue #45.
-DSPARK_MAX_INFLIGHT_PREFILLS=2
+# Issue #27: max concurrent in-flight partial prefills. The hotfix reads this
+# once during Scheduler construction because Anemll 0.1.1 rejects
+# --max-num-partial-prefills before engine init. Values 1-3 are accepted;
+# values above 3 clamp to 3. Blank, whitespace-only, nonpositive, or malformed
+# values fall back to SchedulerConfig.max_num_partial_prefills (stock 1);
+# malformed values warn once instead of crashing admission.
+#
+# Keep the shipped value at 1. On this 2x GB10 stack, repeated 4x8K fairness
+# waves at 2 produced 3.72-5.14x lane spread, while the same code freshly
+# booted at 1 produced 1.68-2.04x and passed the full fairness gate at 1.71x.
+# Values 2-3 remain explicit opt-ins for operators who benchmark their own
+# traffic.
+DSPARK_MAX_INFLIGHT_PREFILLS=1
 
 # Issue #43: bounded decode service during mixed prefill steps + scheduler
 # diagnostics. The hotfix layers on #27 and guarantees no decode-active lane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-08-28
+
+### Fixed
+
+- **Restored the safe single-prefill default after the Issue #27 concurrency opt-in regressed mixed-request fairness ([Issue #154](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/154))**: `DSPARK_MAX_INFLIGHT_PREFILLS` now defaults to `1` in both `.env.dspark.example` and the Compose fallback; values `2-3` remain explicit operator overrides. Same-code fresh-boot A/B at merge `195744887` isolated the knob: three four-lane 8K waves at `2` had fairness spreads `3.72x`, `5.14x`, and `4.94x`, while `1` produced `2.04x`, `1.68x`, and `1.69x`; the frozen full Gate26 passed at `1` with `1.71x` spread and zero preemptions. CI now locks both shipped defaults together.
+
 ## 2026-08-27
 
 ### Added

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -91,9 +91,9 @@ services:
       # (scheduled prefill/decode tokens per request + zero-token decode
       # skips) when set to 1. Off by default (zero overhead).
       DSPARK_ISSUE43_SCHED_DIAG: "${DSPARK_ISSUE43_SCHED_DIAG:-0}"
-      # In-flight partial-prefill cap for the #27 hotfix (1-3, default 2).
-      # Do NOT pass --max-num-partial-prefills (Anemll 0.1.1 rejects it).
-      DSPARK_MAX_INFLIGHT_PREFILLS: "${DSPARK_MAX_INFLIGHT_PREFILLS:-2}"
+      # In-flight partial-prefill cap for the #27 hotfix (1-3, default 1).
+      # Values 2-3 are opt-in; Anemll 0.1.1 rejects the native CLI flag.
+      DSPARK_MAX_INFLIGHT_PREFILLS: "${DSPARK_MAX_INFLIGHT_PREFILLS:-1}"
       # Pin HF revision (issue #19). Empty → tip of default branch / refs/main.
       DSPARK_REVISION: "${DSPARK_REVISION:-}"
       DSPARK_ENCODING_FILE: "${DSPARK_ENCODING_FILE:-}"

--- a/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
+++ b/patches/hotfix-dsv4-issue27-partial-prefill-concurrency.py
@@ -15,7 +15,7 @@ grows with prompt length. (Issue #27.)
 
 Fix: at the top of the waiting-admission loop, break (don't admit a new
 prefill request) once the number of in-flight partial prefills has reached
-the cap. The cap is ``DSPARK_MAX_INFLIGHT_PREFILLS`` (1-3, default 2 via
+the cap. The cap is ``DSPARK_MAX_INFLIGHT_PREFILLS`` (1-3, default 1 via
 compose) because this image rejects ``--max-num-partial-prefills``. It is
 parsed once during ``Scheduler`` construction; unset, blank, nonpositive, or
 malformed values fall back to ``SchedulerConfig.max_num_partial_prefills``

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -192,6 +192,13 @@ if grep -Fq 'python3 /opt/hotfix-dsv4-issue26-hybrid-swa-min.py || exit 1' docke
 else
   bad "compose must apply #26 + #27 with || exit 1"
 fi
+# The safe #27 cap must agree across the fresh-clone env and Compose fallback.
+if grep -Fxq 'DSPARK_MAX_INFLIGHT_PREFILLS=1' .env.dspark.example \
+  && grep -Fq 'DSPARK_MAX_INFLIGHT_PREFILLS: "${DSPARK_MAX_INFLIGHT_PREFILLS:-1}"' docker-compose.dspark.yml; then
+  ok "issue27 in-flight prefill cap defaults to 1"
+else
+  bad "issue27 in-flight prefill cap must default to 1 in env example and compose"
+fi
 if grep -Fq 'hotfix-dsv4-issue133-triton-specialization.py}:/opt/hotfix-dsv4-issue133-triton-specialization.py:ro' docker-compose.dspark.yml \
   && grep -Fq 'python3 /opt/hotfix-dsv4-issue133-triton-specialization.py || exit 1' docker-compose.dspark.yml \
   && grep -Fq 'scp "$DSPARK_ISSUE133_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-dsv4-issue133-triton-specialization.py"' start-deepseek-v4-flash-dspark.sh; then


### PR DESCRIPTION
## Problem
PR #90 changed the shipped `DSPARK_MAX_INFLIGHT_PREFILLS` default from 1 to 2. Same-code fresh-boot A/B at merge `195744887` isolated that value as the Gate26 fairness regression: value 2 produced 3.72x, 5.14x, and 4.94x spreads; value 1 produced 2.04x, 1.68x, and 1.69x.

## Fix
Restore the fresh-clone and Compose fallback default to 1. Keep values 2-3 available as explicit operator overrides. Lock both defaults together in CPU CI.

## Verification
- `bash scripts/ci-validate.sh`
- Full frozen Gate26 at value 1: PASS, fairness spread 1.705x, zero preemptions

Closes #154