### PR TITLE
fix: select one model alias for startup probes

### DIFF
--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -51,6 +51,7 @@ py_files+=(
   scripts/test-spec-acceptance.py
   scripts/test-ruler-lite-pad.py
   scripts/test-env-normalisation.py
+  scripts/test-served-model-alias.py
   scripts/test-dspark-api-keys.py
   scripts/test-redact-api-key-log.py
   scripts/test-hotfix-atomic-transaction.py
@@ -96,6 +97,8 @@ python3 scripts/test-numeric-knob-validation.py -q
 ok "test-numeric-knob-validation"
 python3 scripts/test-env-normalisation.py -q
 ok "test-env-normalisation"
+python3 scripts/test-served-model-alias.py -q
+ok "test-served-model-alias"
 python3 scripts/test-dspark-api-keys.py -q
 ok "test-dspark-api-keys"
 python3 scripts/test-redact-api-key-log.py -q

--- a/scripts/test-served-model-alias.py
+++ b/scripts/test-served-model-alias.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""CPU regressions for model selection in startup probes and warmup."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "start-deepseek-v4-flash-dspark.sh"
+SOURCE = LAUNCHER.read_text(encoding="utf-8")
+SELECTION_BEGIN = "# Probe/warmup model selection (begin)."
+SELECTION_END = "# Probe/warmup model selection (end)."
+
+
+def extract_selection() -> str:
+    start = SOURCE.index(SELECTION_BEGIN)
+    end = SOURCE.index(SELECTION_END, start) + len(SELECTION_END)
+    return SOURCE[start:end]
+
+
+class SelectionBehaviorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.selection = extract_selection()
+
+    def select(self, value: str | None) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env.pop("SERVED_MODEL_NAME", None)
+        if value is not None:
+            env["SERVED_MODEL_NAME"] = value
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                "set -euo pipefail\n"
+                f"{self.selection}\n"
+                "printf '%s\\n' \"$PROBE_MODEL\"\n",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def assert_selection(self, value: str | None, expected: str) -> None:
+        result = self.select(value)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, expected + "\n")
+
+    def test_unset_and_empty_use_default(self) -> None:
+        for value in (None, "", "   "):
+            with self.subTest(value=value):
+                self.assert_selection(value, "deepseek-v4-flash-dspark")
+
+    def test_single_alias_is_unchanged(self) -> None:
+        self.assert_selection("deepseek-v4-flash-0731", "deepseek-v4-flash-0731")
+
+    def test_multiple_aliases_select_first(self) -> None:
+        self.assert_selection(
+            "deepseek-v4-flash-0731 deepseek-v4-flash-dspark",
+            "deepseek-v4-flash-0731",
+        )
+
+    def test_shell_whitespace_is_normalized(self) -> None:
+        self.assert_selection("  alias-a\t alias-b  ", "alias-a")
+
+
+class LauncherWiringTest(unittest.TestCase):
+    def test_every_ready_probe_uses_selected_alias(self) -> None:
+        start = SOURCE.index(SELECTION_BEGIN)
+        ready_block = SOURCE[start : SOURCE.index("    exit 0", start)]
+        after_selection = ready_block[ready_block.index(SELECTION_END) :]
+
+        self.assertNotIn("${SERVED_MODEL_NAME", after_selection)
+        self.assertEqual(
+            ready_block.count("'\"${PROBE_MODEL}\"'"),
+            2,
+            "both startup chat payloads must use the selected alias",
+        )
+        self.assertIn(
+            '"${CHAT_URL%/v1/chat/completions}" "$PROBE_MODEL"',
+            ready_block,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(
+        verbosity=0 if "-q" in sys.argv else 2,
+        argv=[argument for argument in sys.argv if argument != "-q"],
+    )

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -1181,17 +1181,23 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
         remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.vl-sidecar.yml logs --tail=80" >&2 || true
       fi
     fi
+    # Probe/warmup model selection (begin).
+    # vLLM accepts one served alias per request. SERVED_MODEL_NAME may contain
+    # multiple space-separated aliases, so use the first advertised name.
+    read -r PROBE_MODEL _ <<< "${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
+    PROBE_MODEL="${PROBE_MODEL:-deepseek-v4-flash-dspark}"
+    # Probe/warmup model selection (end).
     if [ "${DSPARK_ENABLE_ISSUE31_GPU_HOTFIX:-0}" = "1" ]; then
       echo "Running minimal OpenAI-compatible thinking-budget chat request..."
       curl -fsS --max-time 60 "${AUTH_HEADER_ARGS[@]}" "$CHAT_URL" \
         -H "Content-Type: application/json" \
-        -d '{"model":"'"${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"thinking_token_budget":1,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
+        -d '{"model":"'"${PROBE_MODEL}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"thinking_token_budget":1,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
       echo "Minimal thinking-budget chat request succeeded."
     else
       echo "Running minimal OpenAI-compatible chat request (stock V2; no thinking_token_budget)..."
       curl -fsS --max-time 60 "${AUTH_HEADER_ARGS[@]}" "$CHAT_URL" \
         -H "Content-Type: application/json" \
-        -d '{"model":"'"${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
+        -d '{"model":"'"${PROBE_MODEL}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":32,"temperature":0.6,"top_p":0.95,"chat_template_kwargs":{"thinking":true,"reasoning_effort":"low"}}' >/dev/null
       echo "Minimal chat request succeeded."
     fi
     # Issue #117: burn the spec-decode/prefill Triton shape buckets before real
@@ -1224,7 +1230,7 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
         DSPARK_WARMUP_BEARER="$_warmup_bearer" \
         DSPARK_WARMUP_TRITON_CACHE_DIR="$_warmup_tcache_host" \
         bash "$SCRIPT_DIR/scripts/boot-shape-warmup.sh" \
-        "${CHAT_URL%/v1/chat/completions}" "${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}" || \
+        "${CHAT_URL%/v1/chat/completions}" "$PROBE_MODEL" || \
         echo "WARN: boot shape warmup incomplete — uncovered shapes may JIT mid-serve (issue #117)" >&2
     else
       echo "Boot shape warmup: SKIPPED (DSPARK_BOOT_SHAPE_WARMUP=0)"


### PR DESCRIPTION
## Summary

- select the first advertised model when `SERVED_MODEL_NAME` contains multiple space-separated aliases
- use that single alias for both startup chat probes and the boot-shape warmup
- preserve the existing default and single-alias behavior
- add CPU-only behavioral regression coverage and register it in `ci-validate.sh`

## Problem

vLLM accepts one served model identifier per request, while its launcher accepts multiple aliases through `--served-model-name`. With a value such as:

```env
SERVED_MODEL_NAME="deepseek-v4-flash-0731 deepseek-v4-flash-dspark"
```

the launcher currently sends the complete string as the request's `model`. The startup probe receives HTTP 404, and the warmup cannot exercise any of its intended shapes.

This patch resolves one probe model once, using normal shell whitespace rules, and reuses it for both call sites.

## Validation

- `python3 scripts/test-served-model-alias.py -q`
- `bash scripts/ci-validate.sh`

The regression suite covers unset, empty, whitespace-only, single-alias, multi-alias, and mixed-whitespace values, and verifies both startup chat branches plus warmup are wired to the selected alias.

The same change was also exercised on a two-node DGX Spark deployment configured with two served aliases: the startup chat succeeded, boot-shape warmup completed 47/47 requests, and three repeated post-start acceptance passes succeeded.
