### PR TITLE
fix(boot): make Spark recovery durable (DGX-8)

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -2,6 +2,7 @@ services:
   vllm-dspark:
     image: ${DSPARK_VLLM_IMAGE:-ghcr.io/anemll/dspark-vllm-gx10:0.1.1}
     pull_policy: if_not_present
+    init: true
     entrypoint: []
     network_mode: host
     ipc: host
@@ -9,7 +10,7 @@ services:
     # Issue #38/#39: bring a crashed worker back. Keep grace short — vLLM
     # ignores SIGTERM while loading and a long period hangs `compose stop`.
     restart: ${DSPARK_RESTART_POLICY:-unless-stopped}
-    stop_grace_period: ${DSPARK_STOP_GRACE:-10s}
+    stop_grace_period: ${DSPARK_STOP_GRACE:-30s}
 
     # Only rank 0 serves HTTP; the worker runs HEADLESS with no :8888 listener.
     # Gate on $HEADLESS so the worker is not marked unhealthy forever. $$HEADLESS

--- a/ops/dgx-recovery/90-dgx-recovery.conf
+++ b/ops/dgx-recovery/90-dgx-recovery.conf
@@ -1,0 +1,3 @@
+# Reboot after a kernel oops instead of remaining remotely unreachable.
+kernel.panic_on_oops = 1
+kernel.panic = 10

--- a/ops/dgx-recovery/90-dgx-watchdog.conf
+++ b/ops/dgx-recovery/90-dgx-watchdog.conf
@@ -1,0 +1,2 @@
+[Manager]
+RuntimeWatchdogSec=60s

--- a/ops/dgx-recovery/99-nccl-memlock.conf
+++ b/ops/dgx-recovery/99-nccl-memlock.conf
@@ -1,0 +1,2 @@
+* soft memlock unlimited
+* hard memlock unlimited

--- a/ops/dgx-recovery/README.md
+++ b/ops/dgx-recovery/README.md
@@ -1,0 +1,47 @@
+# DGX Spark recovery controls
+
+The MT7925 driver came from the stock `linux-modules-*-nvidia` package. Kernel
+6.17 is affected by CVE-2026-68307, whose reset-path crash matches these nodes.
+Keep Wi-Fi disabled until NVIDIA ships a DGX-tested kernel containing the fix.
+
+Install idempotently after configuring the wired default route:
+
+```bash
+sudo ./ops/dgx-recovery/install.sh head    # head Spark
+sudo ./ops/dgx-recovery/install.sh worker  # worker Spark
+sudo reboot
+./ops/dgx-recovery/verify.sh head --wait 900
+```
+
+The installer enables Docker at boot, disables the failing Wi-Fi driver, sets
+kernel-oops recovery and the system watchdog, raises NCCL memlock limits, and
+installs the worker orphan guard. Compose uses an init process and a bounded
+30-second shutdown grace period.
+
+The worker guard defaults match the reference two-Spark deployment. Override
+them for another pair in `/etc/default/mia-worker-orphan-guard`:
+
+```bash
+MIA_CONTAINER=deepseek-v4-flash-vllm-dspark-1
+MIA_API_HOST=100.125.193.22
+MIA_API_PORT=8888
+MIA_MASTER_HOST=192.168.200.12
+MIA_MASTER_PORT=25000
+```
+
+The Wi-Fi driver is disabled because its reset work oopsed twice in
+`mt7925_mac_reset_work`, wedging RTNL and every network-dependent service.
+A wired interface must be the default route or installation fails closed.
+
+`--wait` is the boot-readiness hook: it checks the recovery contract and waits
+up to 15 minutes for the API without starting another model load. `verify.sh`
+accepts `MIA_CONTAINER`, `MIA_API_HOST`, and `MIA_API_PORT` overrides too.
+
+Run the installed two-node NCCL proof from the head after adapting hosts and
+interfaces to the target pair:
+
+```bash
+mpirun --allow-run-as-root -np 2 -H 192.168.200.12:1,192.168.200.13:1 \
+  -x NCCL_SOCKET_IFNAME=enP7s7 -x NCCL_IB_HCA=rocep1s0f0,rocep1s0f1 \
+  ~/.local/src/nccl-tests/build/all_reduce_perf -b 8M -e 1G -f 2 -g 1
+```

--- a/ops/dgx-recovery/blacklist-mt7925-dgx.conf
+++ b/ops/dgx-recovery/blacklist-mt7925-dgx.conf
@@ -1,0 +1,3 @@
+# The DGX Spark MT7925 reset path oopses in kernel 6.17.0-1031-nvidia and
+# wedges RTNL, which blocks networking, Tailscale SSH, and GPU workers.
+blacklist mt7925e

--- a/ops/dgx-recovery/install.sh
+++ b/ops/dgx-recovery/install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+role="${1:-}"
+case "$role" in
+  head|worker) ;;
+  *) echo "usage: sudo $0 head|worker" >&2; exit 2 ;;
+esac
+[ "$(id -u)" -eq 0 ] || { echo "run with sudo" >&2; exit 2; }
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+route="$(ip route show default | head -n1)"
+iface="$(awk '{for (i=1;i<=NF;i++) if ($i=="dev") print $(i+1)}' <<<"$route")"
+[ -n "$iface" ] || { echo "no default route; refusing to disable Wi-Fi" >&2; exit 1; }
+case "$iface" in wl*) echo "default route uses Wi-Fi ($iface); configure wired networking first" >&2; exit 1;; esac
+
+grep -Fq 'init: true' "$root/docker-compose.dspark.yml"
+grep -Eq 'stop_grace_period:.*30s' "$root/docker-compose.dspark.yml"
+
+install -m 0644 "$here/blacklist-mt7925-dgx.conf" /etc/modprobe.d/blacklist-mt7925-dgx.conf
+install -m 0644 "$here/90-dgx-recovery.conf" /etc/sysctl.d/90-dgx-recovery.conf
+install -D -m 0644 "$here/90-dgx-watchdog.conf" /etc/systemd/system.conf.d/90-dgx-watchdog.conf
+install -m 0644 "$here/99-nccl-memlock.conf" /etc/security/limits.d/99-nccl-memlock.conf
+
+systemctl enable docker.service
+sysctl --system >/dev/null
+update-initramfs -u
+
+if [ "$role" = worker ]; then
+  install -m 0755 "$here/mia-worker-orphan-guard" /usr/local/sbin/mia-worker-orphan-guard
+  install -m 0644 "$here/mia-worker-orphan-guard.service" /etc/systemd/system/mia-worker-orphan-guard.service
+  systemctl daemon-reload
+  systemctl enable mia-worker-orphan-guard.service
+fi
+
+echo "installed DGX recovery controls for $role; reboot once, then run: $here/verify.sh $role --wait 900"

--- a/ops/dgx-recovery/mia-worker-orphan-guard
+++ b/ops/dgx-recovery/mia-worker-orphan-guard
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -u
+
+container="${MIA_CONTAINER:-deepseek-v4-flash-vllm-dspark-1}"
+api_host="${MIA_API_HOST:-100.125.193.22}"
+api_port="${MIA_API_PORT:-8888}"
+master_host="${MIA_MASTER_HOST:-192.168.200.12}"
+master_port="${MIA_MASTER_PORT:-25000}"
+seen_api=0
+failures=0
+
+port_open() {
+  timeout 2 bash -c "</dev/tcp/$1/$2" 2>/dev/null
+}
+
+while sleep 5; do
+  running="$(timeout 3 docker inspect "$container" --format '{{.State.Running}}' 2>/dev/null || true)"
+
+  if [ "$running" != true ]; then
+    seen_api=0
+    failures=0
+    if port_open "$master_host" "$master_port"; then
+      timeout 20 docker start "$container" >/dev/null 2>&1 &&
+        logger -t mia-worker-orphan-guard "started $container for a waiting head rank"
+    fi
+    continue
+  fi
+
+  if port_open "$api_host" "$api_port"; then
+    if [ "$seen_api" = 0 ]; then
+      logger -t mia-worker-orphan-guard "armed after the MIA API became reachable"
+    fi
+    seen_api=1
+    failures=0
+  elif [ "$seen_api" = 1 ]; then
+    failures=$((failures + 1))
+    if [ "$failures" -ge 6 ]; then
+      logger -t mia-worker-orphan-guard "head API unavailable for 30 seconds; stopping $container"
+      if ! timeout 45 docker stop -t 30 "$container" >/dev/null 2>&1; then
+        logger -t mia-worker-orphan-guard "graceful stop failed; trying docker kill"
+        if ! timeout 10 docker kill "$container" >/dev/null 2>&1; then
+          logger -t mia-worker-orphan-guard "Docker cannot reap the rank; forcing host reboot"
+          systemctl reboot --force --force
+        fi
+      fi
+      seen_api=0
+      failures=0
+    fi
+  fi
+done

--- a/ops/dgx-recovery/mia-worker-orphan-guard.service
+++ b/ops/dgx-recovery/mia-worker-orphan-guard.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Recover the MIA worker after head loss
+After=docker.service network-online.target
+Wants=docker.service network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/mia-worker-orphan-guard
+ExecStart=/usr/local/sbin/mia-worker-orphan-guard
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/dgx-recovery/verify.sh
+++ b/ops/dgx-recovery/verify.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+role="${1:-}"
+case "$role" in
+  head|worker) ;;
+  *) echo "usage: $0 head|worker [--wait seconds]" >&2; exit 2 ;;
+esac
+wait_seconds=0
+if [ "${2:-}" = --wait ]; then
+  wait_seconds="${3:-900}"
+  [[ "$wait_seconds" =~ ^[0-9]+$ ]] || { echo "wait duration must be seconds" >&2; exit 2; }
+fi
+
+container="${MIA_CONTAINER:-deepseek-v4-flash-vllm-dspark-1}"
+api_host="${MIA_API_HOST:-100.125.193.22}"
+api_port="${MIA_API_PORT:-8888}"
+fail=0
+check() { if "$@" >/dev/null 2>&1; then printf 'ok   %s\n' "$*"; else printf 'FAIL %s\n' "$*"; fail=1; fi; }
+
+iface="$(ip route show default | awk 'NR==1 {for (i=1;i<=NF;i++) if ($i=="dev") print $(i+1)}')"
+case "$iface" in ""|wl*) echo "FAIL wired default route (found: ${iface:-none})"; fail=1;; *) echo "ok   wired default route ($iface)";; esac
+check test -f /etc/modprobe.d/blacklist-mt7925-dgx.conf
+check sh -c '! lsmod | grep -q "^mt7925e"'
+check test "$(sysctl -n kernel.panic_on_oops)" = 1
+check test "$(sysctl -n kernel.panic)" = 10
+check sh -c 'systemctl show --property=RuntimeWatchdogUSec --value | grep -Eq "^(1min|60000000)$"'
+check systemctl is-enabled docker.service
+check systemctl is-active docker.service
+check test "$(docker inspect "$container" --format '{{.HostConfig.Init}}' 2>/dev/null)" = true
+check test "$(docker inspect "$container" --format '{{.State.Running}}' 2>/dev/null)" = true
+
+if [ "$role" = worker ]; then
+  check systemctl is-enabled mia-worker-orphan-guard.service
+  check systemctl is-active mia-worker-orphan-guard.service
+fi
+
+if [ "$wait_seconds" -gt 0 ]; then
+  api="http://${api_host}:${api_port}/v1/models"
+  started=$SECONDS
+  while ! curl -fsS --max-time 3 "$api" >/dev/null 2>&1; do
+    if [ $((SECONDS - started)) -ge "$wait_seconds" ]; then
+      echo "FAIL API was not ready after ${wait_seconds}s"
+      fail=1
+      break
+    fi
+    sleep 5
+  done
+  [ "$fail" -ne 0 ] || echo "ok   API ready after $((SECONDS - started))s"
+fi
+
+exit "$fail"

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -27,6 +27,8 @@ for f in \
   scripts/test-boot-shape-warmup.sh \
   lmcache/run-lmcache-server.sh \
   scripts/test-lmcache-compose-gate.sh \
+  ops/dgx-recovery/*.sh \
+  ops/dgx-recovery/mia-worker-orphan-guard \
   patches/*.sh
 do
   [ -e "$f" ] || continue
@@ -285,6 +287,12 @@ if grep -q 'restart: ${DSPARK_RESTART_POLICY:-unless-stopped}' docker-compose.ds
   ok "compose restart unless-stopped"
 else
   bad "compose missing restart: unless-stopped"
+fi
+if grep -Fq 'init: true' docker-compose.dspark.yml \
+  && grep -Eq 'stop_grace_period:.*30s' docker-compose.dspark.yml; then
+  ok "compose has init + bounded stop grace"
+else
+  bad "compose missing init: true or 30-second stop grace"
 fi
 if grep -q 'exit 3' start-deepseek-v4-flash-dspark.sh \
   && grep -q 'SuccessExitStatus=3' start-deepseek-v4-flash-dspark.sh \


### PR DESCRIPTION
## Summary

- add idempotent head/worker recovery installation and verification commands for DGX Spark
- recover from the observed MT7925 kernel-oops failure mode with a wired-route guard, kernel panic recovery, and the system watchdog
- make Docker lifecycle deterministic with an init process, bounded shutdown grace, and a configurable worker orphan guard

Linear: [DGX-8](https://linear.app/ticketfi/issue/DGX-8/make-dgx-spark-boot-and-inference-recovery-durable)

## Why

The two-node MIA deployment repeatedly became unreachable after the stock MT7925 reset path oopsed and wedged RTNL. A physical reboot restored it, but the same boot/Docker/orphan-rank conditions could recur. These controls were installed and verified on both affected Sparks before being rebased onto current upstream `main`.

## Test strategy

```test-strategy
bash -n ops/dgx-recovery/install.sh ops/dgx-recovery/verify.sh ops/dgx-recovery/mia-worker-orphan-guard scripts/ci-validate.sh
docker compose -f docker-compose.dspark.yml config --quiet
ops/dgx-recovery/install.sh invalid  # exits 2
ops/dgx-recovery/verify.sh invalid   # exits 2
git diff --check
```

The repository's full CPU validation passes the changed shell/config gates on macOS, then hits an existing GNU/BSD `sed` incompatibility in `scripts/test-numeric-knob-validation.py`; the required GitHub Linux workflow remains the authoritative full gate.

## Runtime evidence

- recovery verifier passed on both installed Sparks after reboot
- DeepSeek V4 Flash `/v1/models` and inference recovered
- two-node NCCL `all_reduce_perf` remained correct (`#wrong=0`), peaking at 23.68 GB/s bus bandwidth

## Safety

- install fails closed when the default route is Wi-Fi
- no secrets or machine environment files are committed
- host/container/API addresses remain overridable for another Spark pair
