### PR TITLE
fix(vision): treat RGB CHW with width 1/3/4 as channels-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- **Vision-Exp `as_pil` no longer turns RGB CHW with width 1/3/4 into a black image**: the old last-axis `{1,3,4}` ⇒ HWC rule treated `np.transpose(pil, (2,0,1))` of a 4-wide RGB array as 3-pixel-tall RGBA. Leading C=3 is now CHW (unit test `(3, 6, 4)` → `(0, 22, 0)`). Normal photos (W∉{1,3,4}) were already correct. Restart both ranks so `/opt/dspark-patches/vision_exp` reloads.
 - **Vision-Exp role check no longer 400s on the literal substring `<image>` ([Issue #165](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/165))**: system/assistant text that *mentions* the tag (opencode and other agent prompts) is allowed; only a paired `<image>…</image>` reference or a real `image`/`image_url` part is treated as an image. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
 
 ### Changed

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -12,7 +12,7 @@ import io
 import math
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, TYPE_CHECKING
+from typing import Any, Sequence, TYPE_CHECKING
 from urllib.request import urlopen
 
 if TYPE_CHECKING:
@@ -105,6 +105,27 @@ def is_unregistered_router_bias(name: str, param_names: Any) -> bool:
     )
 
 
+def looks_like_chw(shape: Sequence[int]) -> bool:
+    """True when a 3-D array should be treated as C×H×W rather than H×W×C.
+
+    Last axis in ``{1, 3, 4}`` also looks like HWC. The old check therefore
+    skipped transpose whenever width was 1, 3, or 4, so RGB CHW from
+    ``np.transpose(pil, (2, 0, 1))`` of a 4-wide image became a black
+    3-pixel-tall RGBA. Prefer CHW when the leading axis is RGB (C=3), which
+    matches vLLM's layout and the ``(3, 6, 4)`` unit test. Gray/RGBA leading
+    1/4 still use the unambiguous rule (last axis not a channel count).
+    """
+    if len(shape) != 3:
+        return False
+    channels = (1, 3, 4)
+    c, _h, w = int(shape[0]), int(shape[1]), int(shape[2])
+    if c not in channels:
+        return False
+    if w not in channels:
+        return True
+    return c == 3
+
+
 def as_pil(item: Any) -> PILImage.Image:
     """Normalize vLLM image items (PIL, HWC/CHW array, tensor, dict) to RGB PIL."""
     Image, _ImageOps = _pil()
@@ -133,7 +154,7 @@ def as_pil(item: Any) -> PILImage.Image:
     arr = np.asarray(array)
     if arr.ndim == 2:
         arr = np.stack([arr, arr, arr], axis=-1)
-    elif arr.ndim == 3 and arr.shape[-1] not in (1, 3, 4) and arr.shape[0] in (1, 3, 4):
+    elif looks_like_chw(arr.shape):
         arr = np.transpose(arr, (1, 2, 0))
     if arr.ndim != 3:
         raise TypeError(f"Unsupported image array shape: {arr.shape!r}")

--- a/scripts/test-dsv4-vision-exp-hotfix.py
+++ b/scripts/test-dsv4-vision-exp-hotfix.py
@@ -21,6 +21,7 @@ from vision_exp.image_processor import (  # noqa: E402
     image_block_num_tokens,
     is_unregistered_router_bias,
     is_vision_exp_weight_name,
+    looks_like_chw,
     salt_mm_image_hash,
     vision_args_from_config,
 )
@@ -137,10 +138,34 @@ class VisionExpLayoutTest(unittest.TestCase):
             return
         hwc = np.zeros((6, 4, 3), dtype="uint8")
         hwc[..., 0] = 11
+        self.assertEqual(as_pil(hwc).size, (4, 6))
         self.assertEqual(as_pil(hwc).getpixel((0, 0)), (11, 0, 0))
         chw = np.zeros((3, 6, 4), dtype="uint8")
         chw[1] = 22
-        self.assertEqual(as_pil(chw).getpixel((0, 0)), (0, 22, 0))
+        got_chw = as_pil(chw)
+        self.assertEqual(got_chw.size, (4, 6))
+        self.assertEqual(got_chw.getpixel((0, 0)), (0, 22, 0))
+        chw_w3 = np.zeros((3, 8, 3), dtype="uint8")
+        chw_w3[1] = 22
+        self.assertEqual(as_pil(chw_w3).size, (3, 8))
+        self.assertEqual(as_pil(chw_w3).getpixel((0, 0)), (0, 22, 0))
+        chw_wide = np.zeros((3, 8, 5), dtype="uint8")
+        chw_wide[1] = 22
+        self.assertEqual(as_pil(chw_wide).getpixel((0, 0)), (0, 22, 0))
+
+    def test_looks_like_chw_width_in_channel_set(self):
+        self.assertTrue(looks_like_chw((3, 6, 4)))
+        self.assertTrue(looks_like_chw((3, 8, 3)))
+        self.assertTrue(looks_like_chw((3, 8, 1)))
+        self.assertTrue(looks_like_chw((3, 8, 5)))
+        self.assertTrue(looks_like_chw((3, 8, 8)))
+        self.assertTrue(looks_like_chw((4, 100, 200)))
+        self.assertTrue(looks_like_chw((1, 100, 200)))
+        self.assertFalse(looks_like_chw((8, 5, 3)))
+        self.assertFalse(looks_like_chw((6, 4, 3)))
+        self.assertFalse(looks_like_chw((4, 100, 3)))
+        self.assertFalse(looks_like_chw((1, 100, 3)))
+        self.assertFalse(looks_like_chw((6, 4)))
 
     def test_vision_weight_names_bypass_stacked_w1(self):
         self.assertTrue(is_vision_exp_weight_name("aligner.w1.bias"))


### PR DESCRIPTION
## Summary

- `as_pil` treated any last axis in `{1,3,4}` as HWC, so RGB CHW from `np.transpose(pil, (2,0,1))` with width 1/3/4 became a black 3-pixel-tall RGBA. The shipped unit test `(3, 6, 4)` → `(0, 22, 0)` was skipped in CI (no Pillow).
- Leading C=3 is now CHW. Unambiguous HWC photos and gray/RGBA CHW with a non-channel width are unchanged.
- Live-verified on the pair after restart: `(3,6,4)` and `(3,8,3)` return `(0, 22, 0)`; HWC still `(11, 0, 0)`; `image_url` still 200 with 125 image tokens.

## Test plan

- [x] `python3 scripts/test-dsv4-vision-exp-hotfix.py -q` (includes `looks_like_chw` without Pillow)
- [x] In-container `as_pil` on `(3,6,4)`, `(3,8,3)`, vLLM transpose of a 4-wide RGB, HWC control
- [x] Live `image_url` after restart
- [ ] After merge: restart both ranks so `/opt/dspark-patches/vision_exp` reloads (mounted file; stop/start not required for this one)


Made with [Cursor](https://cursor.com)