### PR TITLE
fix(vision): do not 400 when tool results quote image markers (issue #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-09-01
+
+### Fixed
+
+- **Vision-Exp role check no longer 400s when a tool result quotes image markers ([Issue #167](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/167))**: `tool` / `function` message *text* is opaque (grep/cat of the hotfix, commit messages that mention `<image>`). Only a structured `image` / `image_url` part in those roles is rejected. System/assistant still use the issue #165 paired-tag + placeholder scan. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
+
 ## 2026-08-31
 
 ### Fixed

--- a/patches/hotfix-dsv4-vision-exp.py
+++ b/patches/hotfix-dsv4-vision-exp.py
@@ -14,6 +14,9 @@ startup patch:
    ``<｜deepseek_image｜>`` text so OpenAI ``image_url`` parts survive
    vLLM's chat parser, then restores the official Chat Completions rule:
    images in ``user`` messages only (``system`` / ``assistant`` → 400).
+   ``tool`` / ``function`` *result text* is not scanned for image markers
+   (a ``cat`` of this file must not 400). Structured ``image`` /
+   ``image_url`` parts in those roles still 400.
 
 Video is not wired: the official weights, ``encoding/``, and ``inference/``
 have no video encoder. GIF is decoded as a still RGB frame.
@@ -41,6 +44,7 @@ MODEL_MARK = "# [vision-exp-hotfix] native DeepSeek-V4-Flash-Vision-Exp image to
 ENC_MARK = "# [vision-exp-hotfix] allow vLLM-inserted image placeholders"
 ENC_ROLE_MARK = "# [vision-exp-hotfix] images only in user messages"
 ENC_ROLE_PAIRED_MARK = "# [vision-exp-hotfix] paired <image> tag (issue 165)"
+ENC_ROLE_TOOL_MARK = "# [vision-exp-hotfix] tool text is not an image (issue 167)"
 DSPARK_MARK = "# [vision-exp-hotfix] remap ffn.gate.bias_vl"
 
 DSPARK_GATE_BIAS_OLD = '''                if name.endswith(".ffn.gate.bias"):
@@ -95,6 +99,7 @@ TEXT_CHECK_NEW = f"if False and IMAGE_PLACEHOLDER in text:  {ENC_MARK}"
 ENC_ROLE_INJECT = f'''
 {ENC_ROLE_MARK}
 {ENC_ROLE_PAIRED_MARK}
+{ENC_ROLE_TOOL_MARK}
 def _dspark_vision_text_has_image(text: str) -> bool:
     if IMAGE_PLACEHOLDER in text:
         return True
@@ -109,9 +114,9 @@ def _dspark_vision_text_has_image(text: str) -> bool:
         start = i + len(needle)
 
 
-def _dspark_vision_value_has_image(value) -> bool:
+def _dspark_vision_value_has_image(value, scan_text: bool = True) -> bool:
     if isinstance(value, str):
-        return _dspark_vision_text_has_image(value)
+        return bool(scan_text) and _dspark_vision_text_has_image(value)
     if not isinstance(value, list):
         return False
     for block in value:
@@ -119,11 +124,14 @@ def _dspark_vision_value_has_image(value) -> bool:
             continue
         if block.get("type") in ("image", "image_url"):
             return True
-        text = block.get("text") or ""
-        if isinstance(text, str) and _dspark_vision_text_has_image(text):
-            return True
+        if scan_text:
+            text = block.get("text") or ""
+            if isinstance(text, str) and _dspark_vision_text_has_image(text):
+                return True
         nested = block.get("content")
-        if isinstance(nested, list) and _dspark_vision_value_has_image(nested):
+        if isinstance(nested, list) and _dspark_vision_value_has_image(
+            nested, scan_text
+        ):
             return True
     return False
 
@@ -139,9 +147,10 @@ def _validate_no_image_sp_tokens(msg):
     role = msg.get("role")
     if role in ("user", "developer"):
         return
-    if _dspark_vision_value_has_image(msg.get("content")) or _dspark_vision_value_has_image(
-        msg.get("content_blocks")
-    ):
+    scan_text = role not in ("tool", "function")
+    if _dspark_vision_value_has_image(
+        msg.get("content"), scan_text
+    ) or _dspark_vision_value_has_image(msg.get("content_blocks"), scan_text):
         raise ValueError(
             "Images are supported in user messages only: "
             "images in " + repr(role) + " messages return a 400 error."
@@ -164,6 +173,7 @@ def patch_encoding_text(source: str) -> tuple[str, str]:
         ENC_MARK in source
         and ENC_ROLE_MARK in source
         and ENC_ROLE_PAIRED_MARK in source
+        and ENC_ROLE_TOOL_MARK in source
         and CONTENT_CHECK_NEW in source
     ):
         return source, "skipped"
@@ -182,7 +192,9 @@ def patch_encoding_text(source: str) -> tuple[str, str]:
             source = source.replace(old, new, 1)
         if missing:
             return source, "drift:" + ",".join(missing)
-    if ENC_ROLE_MARK in source and ENC_ROLE_PAIRED_MARK not in source:
+    if ENC_ROLE_MARK in source and (
+        ENC_ROLE_PAIRED_MARK not in source or ENC_ROLE_TOOL_MARK not in source
+    ):
         source = source[: source.rfind(ENC_ROLE_MARK)].rstrip() + "\n"
     if ENC_ROLE_MARK not in source:
         source = source.rstrip() + "\n" + ENC_ROLE_INJECT
@@ -225,6 +237,7 @@ def main() -> int:
             "APPLIED"
             if ENC_MARK in encoding and ENC_ROLE_MARK in encoding
             and ENC_ROLE_PAIRED_MARK in encoding
+            and ENC_ROLE_TOOL_MARK in encoding
             else "NOT APPLIED",
         )
         print(
@@ -236,6 +249,7 @@ def main() -> int:
             and ENC_MARK in encoding
             and ENC_ROLE_MARK in encoding
             and ENC_ROLE_PAIRED_MARK in encoding
+            and ENC_ROLE_TOOL_MARK in encoding
             and DSPARK_MARK in dspark
         )
         return 0 if ok else 1

--- a/scripts/test-dsv4-vision-exp-hotfix.py
+++ b/scripts/test-dsv4-vision-exp-hotfix.py
@@ -49,6 +49,7 @@ patch_dspark_text = _mod.patch_dspark_text
 ENC_MARK = _mod.ENC_MARK
 ENC_ROLE_MARK = _mod.ENC_ROLE_MARK
 ENC_ROLE_PAIRED_MARK = _mod.ENC_ROLE_PAIRED_MARK
+ENC_ROLE_TOOL_MARK = _mod.ENC_ROLE_TOOL_MARK
 MODEL_MARK = _mod.MODEL_MARK
 DSPARK_MARK = _mod.DSPARK_MARK
 
@@ -263,6 +264,51 @@ def _process_image_blocks(blocks):
                 }
             )
         self.assertIn("user messages only", str(paired_err.exception))
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "tool",
+                "tool_call_id": "chatcmpl-tool-9fce887f3da696ed",
+                "content": (
+                    "The 0.1.1 image's DeepseekV4ForCausalLM is text-only. "
+                    "Vision-Exp ships a 32-layer ViT + Aligner and "
+                    + placeholder
+                    + " prompt tokens."
+                ),
+            }
+        )
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "tool",
+                "content": (
+                    "aa25c89ea 2026-08-31 fix(vision): require paired "
+                    "<image> tags in the role check (issue #165)"
+                ),
+            }
+        )
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "function",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "docs mention " + placeholder + " and <image>x</image>",
+                    }
+                ],
+            }
+        )
+        with self.assertRaises(ValueError) as tool_img_err:
+            ns["_validate_no_image_sp_tokens"](
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://x/y.png"},
+                        }
+                    ],
+                }
+            )
+        self.assertIn("tool", str(tool_img_err.exception))
 
     def test_encoding_role_check_upgrades_bare_image_substring(self):
         src = '''
@@ -314,6 +360,7 @@ def _validate_no_image_sp_tokens(msg):
         upgraded, status2 = patch_encoding_text(stale)
         self.assertEqual(status2, "applied")
         self.assertIn(ENC_ROLE_PAIRED_MARK, upgraded)
+        self.assertIn(ENC_ROLE_TOOL_MARK, upgraded)
         ns: dict = {}
         exec(compile(upgraded, "encoding.py", "exec"), ns)
         ns["_validate_no_image_sp_tokens"](
@@ -322,6 +369,84 @@ def _validate_no_image_sp_tokens(msg):
                 "content": "Markdown images look like <image> tags.",
             }
         )
+
+    def test_encoding_role_check_upgrades_tool_text_scan(self):
+        src = '''
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+def _validate_no_image_sp_tokens(msg):
+    content = msg.get("content")
+    if isinstance(content, str) and IMAGE_PLACEHOLDER in content:
+        raise ValueError("bad")
+    reasoning_content = msg.get("reasoning_content")
+    if isinstance(reasoning_content, str) and IMAGE_PLACEHOLDER in reasoning_content:
+        raise ValueError("bad-reason")
+
+def _process_image_blocks(blocks):
+    text = blocks[0].get("text") or ""
+    if IMAGE_PLACEHOLDER in text:
+        raise ValueError("bad-text")
+'''
+        first, status = patch_encoding_text(src)
+        self.assertEqual(status, "applied")
+        stale_inject = f'''
+{ENC_ROLE_MARK}
+{ENC_ROLE_PAIRED_MARK}
+def _dspark_vision_text_has_image(text: str) -> bool:
+    if IMAGE_PLACEHOLDER in text:
+        return True
+    needle, close = "<image>", "</image>"
+    start = 0
+    while True:
+        i = text.find(needle, start)
+        if i < 0:
+            return False
+        if text.find(close, i + len(needle)) >= 0:
+            return True
+        start = i + len(needle)
+
+
+def _dspark_vision_value_has_image(value) -> bool:
+    if isinstance(value, str):
+        return _dspark_vision_text_has_image(value)
+    return False
+
+
+def _validate_no_image_sp_tokens(msg):
+    role = msg.get("role")
+    if role in ("user", "developer"):
+        return
+    if _dspark_vision_value_has_image(msg.get("content")):
+        raise ValueError(
+            "Images are supported in user messages only: "
+            "images in " + repr(role) + " messages return a 400 error."
+        )
+'''
+        stale = first[: first.rfind(ENC_ROLE_MARK)] + stale_inject
+        self.assertIn(ENC_ROLE_PAIRED_MARK, stale)
+        self.assertNotIn(ENC_ROLE_TOOL_MARK, stale)
+        ns_stale: dict = {}
+        exec(compile(stale, "encoding.py", "exec"), ns_stale)
+        placeholder = ns_stale["IMAGE_PLACEHOLDER"]
+        with self.assertRaises(ValueError):
+            ns_stale["_validate_no_image_sp_tokens"](
+                {"role": "tool", "content": "mentions " + placeholder}
+            )
+        upgraded, status2 = patch_encoding_text(stale)
+        self.assertEqual(status2, "applied")
+        self.assertIn(ENC_ROLE_TOOL_MARK, upgraded)
+        skipped, status3 = patch_encoding_text(upgraded)
+        self.assertEqual(status3, "skipped")
+        self.assertEqual(upgraded, skipped)
+        ns: dict = {}
+        exec(compile(upgraded, "encoding.py", "exec"), ns)
+        ns["_validate_no_image_sp_tokens"](
+            {"role": "tool", "content": "mentions " + ns["IMAGE_PLACEHOLDER"]}
+        )
+        with self.assertRaises(ValueError):
+            ns["_validate_no_image_sp_tokens"](
+                {"role": "assistant", "content": ns["IMAGE_PLACEHOLDER"]}
+            )
 
     def test_dspark_remaps_bias_vl_before_lookup(self):
         src = '''


### PR DESCRIPTION
## Summary

- Fixes [#167](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/167): after #165 the Vision-Exp role check still scanned `tool` / `function` *text* for `IMAGE_PLACEHOLDER` and paired `<image>…</image>`, so a `cat` of the hotfix (or any grep that quotes `<｜deepseek_image｜>`) returned HTTP 400.
- Skip that text scan for `tool` / `function` only. Structured `image` / `image_url` parts in those roles still 400. System/assistant keep the #165 paired-tag + placeholder scan (narrower than scanning no strings at all).
- Existing container copies still have the old inject; `--status` now requires the issue-167 mark, and the patcher rewrites a stale encoding.py on recreate (`./stop` then `./start`; `docker compose restart` keeps the old bytes).

## Test plan

- [x] `python3 scripts/test-dsv4-vision-exp-hotfix.py -q` (reporter placeholder-in-tool, unpaired `<image>` in a commit subject, function text parts, structured `image_url` on tool still raises, upgrade from the #165 inject)
- [x] Live pair after recreate: tool result quoting `<｜deepseek_image｜>` → 200; unpaired `<image>` in tool text → 200; paired `<image>…</image>` in a system message → 400


Made with [Cursor](https://cursor.com)