### PR TITLE
fix(vision): salt encoder cache with image block length (issue #172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Vision-Exp role check no longer 400s when a tool result quotes image markers ([Issue #167](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/167))**: `tool` / `function` message *text* is opaque (grep/cat of the hotfix, commit messages that mention `<image>`). Only a structured `image` / `image_url` part in those roles is rejected. System/assistant still use the issue #165 paired-tag + placeholder scan. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
 
+- **Vision-Exp 40×19 image grids no longer merge 124 embeddings into 125 placeholders ([Issue #172](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/172))**: N-layout block length is `122 + compress_pad` and `compress_pad` depends on `start_pos % 4`. vLLM's encoder cache hashed image bytes only, so the same photo at a shifted offset reused the wrong pad and killed EngineCore. Processor hashes are now salted with `num_tokens`; `embed_input_ids` rejects a count mismatch instead of doing a strict index-put. Recreate both containers after pull. Independent Docker `unless-stopped` restarts can still split a TP=2 pair (`DSPARK_RESTART_POLICY=no` + `./stop`/`./start` together).
+
 ## 2026-08-31
 
 ### Fixed

--- a/patches/vision_exp/apply.py
+++ b/patches/vision_exp/apply.py
@@ -122,6 +122,15 @@ def merge_one_image(
     return block
 
 
+def _mm_embed_rows(multimodal_embeddings: Any) -> int:
+    if hasattr(multimodal_embeddings, "shape"):
+        return int(multimodal_embeddings.shape[0])
+    total = 0
+    for part in multimodal_embeddings:
+        total += _mm_embed_rows(part)
+    return total
+
+
 def embed_multimodal(self, **kwargs: object):
     pixel_values = kwargs.get("pixel_values")
     if pixel_values is None:
@@ -261,10 +270,20 @@ def apply_vision_exp(
         from vllm.model_executor.models.interfaces import _require_is_multimodal
         from vllm.model_executor.models.utils import _merge_multimodal_embeddings
 
+        is_mm = _require_is_multimodal(is_multimodal)
+        n_placeholders = int(is_mm.sum().item()) if hasattr(is_mm, "sum") else int(is_mm)
+        n_embeds = _mm_embed_rows(multimodal_embeddings)
+        if n_placeholders != n_embeds:
+            raise ValueError(
+                "Vision-Exp placeholder/embedding mismatch: "
+                f"{n_embeds} multimodal tokens vs {n_placeholders} placeholders. "
+                "Image block length depends on start_pos%4; a content-only encoder "
+                "cache hit can reuse the wrong compress_pad (issue #172)."
+            )
         return _merge_multimodal_embeddings(
             inputs_embeds=text_embeds,
             multimodal_embeddings=multimodal_embeddings,
-            is_multimodal=_require_is_multimodal(is_multimodal),
+            is_multimodal=is_mm,
         )
 
     DeepseekV4ForCausalLM.embed_input_ids = embed_input_ids

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -34,6 +34,35 @@ def _pil():
 IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
 COMPRESS_PAD_TO = 4
 IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+# Encoder-cache identity suffix. Layout length depends on start_pos % 4;
+# vLLM's mm hash is image bytes only (issue #172).
+LAYOUT_HASH_TAG = "vlexp-ntok"
+
+
+def compress_pad_tokens(start_pos: int) -> int:
+    """IMAGE_PAD tokens prepended so the image block starts on a 4-token boundary."""
+    return COMPRESS_PAD_TO - 1 - int(start_pos) % COMPRESS_PAD_TO
+
+
+def image_block_num_tokens(n_llm_h: int, n_llm_w: int, start_pos: int) -> int:
+    """LLM tokens in one N-layout block (start/end, row newlines, compress pad).
+
+    A 40×19 ViT grid (patch 14, downsample 3) is a 7×14 LLM grid: 122 plus
+    compress_pad 0–3 → 122–125. Issue #172 was 125 placeholders vs 124 embeds.
+    """
+    n_llm_h = int(n_llm_h)
+    n_llm_w = int(n_llm_w)
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = (rows // 2 * row_len % 2) * 2
+    core = n_llm_h * row_len + row_len * pad_h
+    return compress_pad_tokens(start_pos) + 1 + core + pad_last + 1
+
+
+def salt_mm_image_hash(digest: str, num_tokens: int) -> str:
+    """Fold block length into vLLM's content-only mm hash (issue #172)."""
+    return f"{digest}:{LAYOUT_HASH_TAG}{int(num_tokens)}"
 
 
 def is_vision_exp_weight_name(name: str) -> bool:
@@ -305,7 +334,7 @@ def build_image_block(n_llm_h: int, n_llm_w: int, start_pos: int):
     """Builds the N-layout token types (final order) and the aligner-row order for IMAGE slots."""
     import torch
 
-    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    compress_pad = compress_pad_tokens(start_pos)
     pad_h = n_llm_h % 2
     rows = n_llm_h + pad_h
     row_len = n_llm_w + 1

--- a/patches/vision_exp/processor.py
+++ b/patches/vision_exp/processor.py
@@ -29,6 +29,7 @@ from .image_processor import (
     as_pil,
     build_image_block,
     pil_to_patches,
+    salt_mm_image_hash,
     vision_args_from_config,
 )
 
@@ -44,6 +45,34 @@ def _image_token_id(tokenizer) -> int:
         return int(vocab[IMAGE_PLACEHOLDER])
     # Vision-Exp added-token id (vocab_size 129280; placeholder is in the tail).
     return 129264
+
+
+def _as_int(value: Any) -> int:
+    raw = value.data if hasattr(value, "data") else value
+    if hasattr(raw, "reshape"):
+        return int(raw.reshape(-1)[0].item())
+    return int(raw)
+
+
+def _salt_image_mm_hashes(hashes: Any, mm_kwargs: Any) -> Any:
+    """vLLM hashes raw image bytes. Block length depends on start_pos % 4."""
+    if not hashes or "image" not in hashes:
+        return hashes
+    try:
+        items = mm_kwargs["image"]
+    except Exception:
+        return hashes
+    salted = []
+    for i, digest in enumerate(hashes["image"]):
+        try:
+            ntok = _as_int(items[i]["num_tokens"])
+        except Exception:
+            salted.append(digest)
+            continue
+        salted.append(salt_mm_image_hash(str(digest), ntok))
+    out = dict(hashes)
+    out["image"] = salted
+    return out
 
 
 def _collect_images(mm_data: Mapping[str, object]) -> list[Any]:
@@ -115,8 +144,15 @@ class DeepseekV4VisionExpMultiModalProcessor(
     ) -> tuple[list[int], Any, bool]:
         # compress_pad depends on the expanded token position of each image,
         # so a content-only processor cache would reuse the wrong layout.
+        # The GPU encoder cache is also keyed by image bytes; salt hashes with
+        # num_tokens so a 40×19 grid at start_pos%4==0 (125) cannot reuse a
+        # block encoded at %4==1 (124). See issue #172.
         if inputs.mm_data_items.get_count("image", strict=False) > 0:
-            return self._apply_hf_processor(inputs, timing_ctx)
+            prompt_ids, mm_info, applied = self._apply_hf_processor(inputs, timing_ctx)
+            salted = _salt_image_mm_hashes(mm_info.hashes, mm_info.kwargs)
+            if salted is not mm_info.hashes:
+                mm_info = mm_info._replace(hashes=salted)
+            return prompt_ids, mm_info, applied
         return super()._cached_apply_hf_processor(inputs, timing_ctx)
 
     def _call_hf_processor(
@@ -241,12 +277,7 @@ class DeepseekV4VisionExpMultiModalProcessor(
 
         def get_replacement(item_idx: int):
             item = out_mm_kwargs["image"][item_idx]
-            raw = item["num_tokens"]
-            num_tokens = raw.data if hasattr(raw, "data") else raw
-            if hasattr(num_tokens, "reshape"):
-                num_tokens = int(num_tokens.reshape(-1)[0].item())
-            else:
-                num_tokens = int(num_tokens)
+            num_tokens = _as_int(item["num_tokens"])
             if num_tokens <= 0:
                 raise ValueError(f"Image {item_idx} produced 0 vision tokens")
             return [image_token_id] * num_tokens

--- a/scripts/test-dsv4-vision-exp-hotfix.py
+++ b/scripts/test-dsv4-vision-exp-hotfix.py
@@ -16,9 +16,12 @@ from vision_exp.image_processor import (  # noqa: E402
     IMAGE_START,
     as_pil,
     build_image_block,
+    compress_pad_tokens,
     grid_tokens,
+    image_block_num_tokens,
     is_unregistered_router_bias,
     is_vision_exp_weight_name,
+    salt_mm_image_hash,
     vision_args_from_config,
 )
 
@@ -59,6 +62,40 @@ class VisionExpLayoutTest(unittest.TestCase):
         n_h, n_w, n_tok = grid_tokens(756, 756, 14, 3)
         self.assertEqual((n_h, n_w), (18, 18))
         self.assertLessEqual(n_tok, 384)
+
+    def test_issue172_40x19_block_lengths_are_122_plus_compress_pad(self):
+        n_h, n_w, base = grid_tokens(19 * 14, 40 * 14, 14, 3)
+        self.assertEqual((n_h, n_w, base), (7, 14, 122))
+        expected = {0: 125, 1: 124, 2: 123, 3: 122}
+        for start, ntok in expected.items():
+            self.assertEqual(compress_pad_tokens(start), 3 - start)
+            self.assertEqual(image_block_num_tokens(7, 14, start), ntok)
+            self.assertEqual(image_block_num_tokens(7, 14, start + 4), ntok)
+
+    def test_issue172_encoder_cache_hash_includes_block_length(self):
+        a = salt_mm_image_hash("deadbeef", 125)
+        b = salt_mm_image_hash("deadbeef", 124)
+        self.assertNotEqual(a, b)
+        self.assertTrue(a.endswith("vlexp-ntok125"))
+        self.assertTrue(b.endswith("vlexp-ntok124"))
+
+    def test_issue172_processor_salts_encoder_cache_hash(self):
+        text = (ROOT / "patches" / "vision_exp" / "processor.py").read_text()
+        self.assertIn("salt_mm_image_hash", text)
+        self.assertIn("_salt_image_mm_hashes", text)
+        self.assertIn("mm_info._replace(hashes=salted)", text)
+
+    def test_issue172_embed_rejects_placeholder_mismatch(self):
+        text = (ROOT / "patches" / "vision_exp" / "apply.py").read_text()
+        self.assertIn("placeholder/embedding mismatch", text)
+        self.assertIn("issue #172", text)
+
+    @unittest.skipUnless(HAS_TORCH, "torch not installed on this host")
+    def test_issue172_build_image_block_matches_num_tokens_helper(self):
+        for start in range(8):
+            types, perm = build_image_block(7, 14, start_pos=start)
+            self.assertEqual(int(types.numel()), image_block_num_tokens(7, 14, start))
+            self.assertEqual(int(perm.numel()), 7 * 14)
 
     @unittest.skipUnless(HAS_TORCH, "torch not installed on this host")
     def test_build_image_block_starts_and_ends(self):


### PR DESCRIPTION
## Summary
- Vision-Exp N-layout block length is `122 + compress_pad`, and `compress_pad` depends on `start_pos % 4`. A 40×19 ViT grid (7×14 LLM) is 125/124/123/122 tokens.
- vLLM's encoder cache hashed image bytes only, so the same photo after a shifted prefix reused the wrong pad, merged 124 embeds into 125 placeholders, and killed EngineCore (then `unless-stopped` brought the head back alone).
- Processor hashes are now salted with `num_tokens`; `embed_input_ids` rejects a count mismatch instead of a silent index-put. Recreate both containers after pull (`./stop` then `./start`).

## Test plan
- [x] `python3 scripts/test-dsv4-vision-exp-hotfix.py` (21 ran, 3 skipped without torch)
- [ ] Recreate the pair and send a 40×19 (or wide non-square) image twice: once with a prefix that shifts `start_pos % 4`, confirm no EngineDeadError


Made with [Cursor](https://cursor.com)