### PR TITLE
fix(example): default DEFAULT_THINKING to low, matching docker-compose

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -313,8 +313,10 @@ MTP_NUM_TOKENS=6
 # DSpark draft sampling: probabilistic (default) or greedy.
 # DRAFT_SAMPLE_METHOD=probabilistic
 # Default reasoning mode: off, low, high, or max. "max" enables full
-# thinking/reasoning effort by default; request-level overrides still win.
-DEFAULT_THINKING=max
+# thinking/reasoning effort by default and costs ~3x per-request latency on
+# identical hardware vs "low" (measured on 2x DGX Spark, Vision-Exp). "low"
+# matches the docker-compose default. Request-level overrides still win.
+DEFAULT_THINKING=low
 
 # Issue #22 hotfix: automatically patches nvfp4_ds_mla long-context decode
 # regression on every start.  Set to 1 to skip (e.g. if you've already


### PR DESCRIPTION
## Summary

The example environment file `.env.dspark.example` ships `DEFAULT_THINKING=max`, which silently forces **maximum reasoning effort on every request** for anyone who follows the documented setup path (*"Copy to .env.dspark on each node"*, stated in the example's own header). This is inconsistent with the repository's own compose default of `low`, and it costs roughly **3x per-request latency** on identical hardware.

## The inconsistency

- `docker-compose.dspark.yml` (line 240): `DEFAULT_THINKING: "${DEFAULT_THINKING:-low}"` → compose default is **`low`**.
- `.env.dspark.example` (line 317): `DEFAULT_THINKING=max` → the example overrides compose to **`max`**.

The two shipped defaults disagree. The example wins when a user copies it, as instructed.

## Measured impact (2x DGX Spark / GB10, DeepSeek-V4-Flash-Vision-Exp)

Controlled comparison — identical hardware, model, ~12K-token context, isolated single request. Only `reasoning_effort` differs:

| reasoning_effort | end-to-end latency |
|---|---|
| `low` | **3.4s** |
| `max` | **10.6s** |

That is a **~3.1x** per-request latency penalty for `max` over `low`, measured live on our 2x Spark cluster. The effect compounds under concurrency and on long-context agent loops.

Also verified: **request-level `reasoning_effort` overrides win** over the serve default (the existing comment's claim holds), so this change only affects the *default* every user inherits from the example.

## Change

Change `.env.dspark.example` `DEFAULT_THINKING=max` → `low`, matching the compose default, and note the measured cost of `max` in the comment so future readers don't unknowingly flip it back.

Request-level overrides still win, so users who explicitly want `max` or `high` reasoning for interactive/vision work are unaffected — they just pass `reasoning_effort` per request.

## Why this matters

Anyone who clones and follows the setup instructions inherits forced `max` reasoning, degrading an otherwise well-tuned 2x GB10 deployment to ~3x slower per request with no indication. This is a one-line fix that prevents the footgun for every future user.

## Verification

- Confirmed present on current `main` (head `d97c808`): `.env.dspark.example` line 317 `DEFAULT_THINKING=max` vs compose default `low`.
- Fix applied to `.env.dspark.example`; single-line functional change (plus comment).
