### PR TITLE
fix(compose): healthcheck uses VLLM_HOST (issue #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2026-09-02
+
+### Fixed
+
+- **Compose healthcheck probes `VLLM_HOST`, not hardcoded `127.0.0.1` ([Issue #185](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/185))**: with `network_mode: host`, vLLM binds only `--host ${VLLM_HOST}`. A LAN-IP bind (not `0.0.0.0` / `127.0.0.1`) left `/health` off loopback, so Docker reported permanent `unhealthy` while the API served. Compose bakes `VLLM_HOST` at config time (it is not in the container `environment:`); wildcards still map to `127.0.0.1`. Recreate (`./stop` then `./start`) so the healthcheck Test is re-baked; a container restart keeps the old probe.
+
 ## 2026-09-01
 
 ### Fixed

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -16,8 +16,13 @@ services:
     # (double) is evaluated in the container at runtime; ${VLLM_PORT:-8888} is
     # resolved by Compose. start_period covers cold model load (~6 min measured;
     # raise it if your storage is slower).
+    # ${VLLM_HOST:-127.0.0.1} is resolved by Compose too; the in-container guard
+    # maps a wildcard 0.0.0.0 / :: bind back to 127.0.0.1 so LAN-IP deployments
+    # probe the interface the server actually bound (issue #185). Do not defer
+    # $$VLLM_HOST: that env is compose-only and is not in the container
+    # environment: block (only VLLM_HOST_IP is).
     healthcheck:
-      test: ["CMD-SHELL", "if [ -n \"$$HEADLESS\" ]; then exit 0; fi; curl -fsS http://127.0.0.1:${VLLM_PORT:-8888}/health || exit 1"]
+      test: ["CMD-SHELL", "if [ -n \"$$HEADLESS\" ]; then exit 0; fi; urlhost='${VLLM_HOST:-127.0.0.1}'; case \"$$urlhost\" in 0.0.0.0|::|'[::]') urlhost=127.0.0.1 ;; esac; curl -fsS http://$$urlhost:${VLLM_PORT:-8888}/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -372,12 +372,14 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-# Healthcheck present and worker-gated (rank 1 is headless; must not false-unhealthy)
+# Healthcheck present, worker-gated, and probing the compose-time VLLM_HOST
+# (rank 1 is headless; a hardcoded 127.0.0.1 probe is wrong for a LAN-IP bind).
 if grep -q "healthcheck:" docker-compose.dspark.yml \
-  && grep -qF 'if [ -n \"$$HEADLESS\" ]' docker-compose.dspark.yml; then
-  ok "compose healthcheck present and HEADLESS-gated"
+  && grep -qF 'if [ -n \"$$HEADLESS\" ]' docker-compose.dspark.yml \
+  && grep -qF "urlhost='\${VLLM_HOST:-127.0.0.1}'" docker-compose.dspark.yml; then
+  ok "compose healthcheck present, HEADLESS-gated, and VLLM_HOST-aware"
 else
-  bad "compose healthcheck missing or not HEADLESS-gated"
+  bad "compose healthcheck missing, not HEADLESS-gated, or still hardcoded to 127.0.0.1"
 fi
 
 echo "CI validate passed (CPU recipe gates only)."


### PR DESCRIPTION
## Summary
- Compose healthcheck was hardcoded to `127.0.0.1` while vLLM binds `--host ${VLLM_HOST}`. With `network_mode: host`, a LAN-IP bind does not listen on loopback, so Docker reported permanent `unhealthy` while `/health` on the bind address returned 200.
- Bake `VLLM_HOST` at compose-config time (it is not in the container `environment:`), map `0.0.0.0`/`::` back to `127.0.0.1`, keep the `HEADLESS` worker gate. CI now fails if the probe regresses to a hardcoded loopback.

Fixes #185

## Test plan
- [x] `scripts/ci-validate.sh` (healthcheck gate now requires `urlhost='${VLLM_HOST:-127.0.0.1}'`)
- [ ] Recreate: `./stop-deepseek-v4-flash-dspark.sh` then `./start-deepseek-v4-flash-dspark.sh` (restart keeps old Healthcheck.Test)
- [ ] `docker inspect` Healthcheck.Test contains the resolved bind host (or 127.0.0.1 for 0.0.0.0)
- [ ] Head container reaches `healthy`; worker stays healthy via HEADLESS


Made with [Cursor](https://cursor.com)