### PR TITLE
fix(vision): quoted <image> tags in assistant/system are prose (issue #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Compose healthcheck probes `VLLM_HOST`, not hardcoded `127.0.0.1` ([Issue #185](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/185))**: with `network_mode: host`, vLLM binds only `--host ${VLLM_HOST}`. A LAN-IP bind (not `0.0.0.0` / `127.0.0.1`) left `/health` off loopback, so Docker reported permanent `unhealthy` while the API served. Compose bakes `VLLM_HOST` at config time (it is not in the container `environment:`); wildcards still map to `127.0.0.1`. Recreate (`./stop` then `./start`) so the healthcheck Test is re-baked; a container restart keeps the old probe.
 
+- **Vision-Exp role check no longer 400s when assistant/system prose quotes `<image>…</image>` ([Issue #181](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/181))**: the #165 paired-tag scan ran on replayed assistant text, so a reply that documented the tag poisoned the session. Outside `user`, only a structured `image` / `image_url` part or the raw placeholder token is an image. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
+
 ## 2026-09-01
 
 ### Fixed

--- a/patches/hotfix-dsv4-vision-exp.py
+++ b/patches/hotfix-dsv4-vision-exp.py
@@ -17,8 +17,10 @@ startup patch:
    vLLM's chat parser, then restores the official Chat Completions rule:
    images in ``user`` messages only (``system`` / ``assistant`` → 400).
    ``tool`` / ``function`` *result text* is not scanned for image markers
-   (a ``cat`` of this file must not 400). Structured ``image`` /
-   ``image_url`` parts in those roles still 400.
+   (a ``cat`` of this file must not 400). Quoted ``<image>…</image>`` in
+   ``system`` / ``assistant`` prose is also not an image (the served path
+   only accepts structured ``image`` / ``image_url`` parts). Structured
+   parts and the raw placeholder token in those roles still 400.
 
 Video is not wired: the official weights, ``encoding/``, and ``inference/``
 have no video encoder. GIF is decoded as a still RGB frame.
@@ -47,6 +49,9 @@ ENC_MARK = "# [vision-exp-hotfix] allow vLLM-inserted image placeholders"
 ENC_ROLE_MARK = "# [vision-exp-hotfix] images only in user messages"
 ENC_ROLE_PAIRED_MARK = "# [vision-exp-hotfix] paired <image> tag (issue 165)"
 ENC_ROLE_TOOL_MARK = "# [vision-exp-hotfix] tool text is not an image (issue 167)"
+ENC_ROLE_QUOTE_MARK = (
+    "# [vision-exp-hotfix] quoted paired tags are prose (issue 181)"
+)
 DSPARK_MARK = "# [vision-exp-hotfix] remap ffn.gate.bias_vl"
 
 DSPARK_GATE_BIAS_OLD = '''                if name.endswith(".ffn.gate.bias"):
@@ -102,18 +107,11 @@ ENC_ROLE_INJECT = f'''
 {ENC_ROLE_MARK}
 {ENC_ROLE_PAIRED_MARK}
 {ENC_ROLE_TOOL_MARK}
+{ENC_ROLE_QUOTE_MARK}
 def _dspark_vision_text_has_image(text: str) -> bool:
-    if IMAGE_PLACEHOLDER in text:
-        return True
-    needle, close = "<image>", "</image>"
-    start = 0
-    while True:
-        i = text.find(needle, start)
-        if i < 0:
-            return False
-        if text.find(close, i + len(needle)) >= 0:
-            return True
-        start = i + len(needle)
+    # Serve path has no tagged-text expander: only the raw placeholder
+    # token in non-user prose is an image. Quoted <image>…</image> is not.
+    return IMAGE_PLACEHOLDER in text
 
 
 def _dspark_vision_value_has_image(value, scan_text: bool = True) -> bool:
@@ -170,12 +168,19 @@ def patch_model_text(source: str) -> tuple[str, str]:
     return updated, "applied"
 
 
+def _encoding_role_complete(source: str) -> bool:
+    return (
+        ENC_ROLE_MARK in source
+        and ENC_ROLE_PAIRED_MARK in source
+        and ENC_ROLE_TOOL_MARK in source
+        and ENC_ROLE_QUOTE_MARK in source
+    )
+
+
 def patch_encoding_text(source: str) -> tuple[str, str]:
     if (
         ENC_MARK in source
-        and ENC_ROLE_MARK in source
-        and ENC_ROLE_PAIRED_MARK in source
-        and ENC_ROLE_TOOL_MARK in source
+        and _encoding_role_complete(source)
         and CONTENT_CHECK_NEW in source
     ):
         return source, "skipped"
@@ -194,9 +199,7 @@ def patch_encoding_text(source: str) -> tuple[str, str]:
             source = source.replace(old, new, 1)
         if missing:
             return source, "drift:" + ",".join(missing)
-    if ENC_ROLE_MARK in source and (
-        ENC_ROLE_PAIRED_MARK not in source or ENC_ROLE_TOOL_MARK not in source
-    ):
+    if ENC_ROLE_MARK in source and not _encoding_role_complete(source):
         source = source[: source.rfind(ENC_ROLE_MARK)].rstrip() + "\n"
     if ENC_ROLE_MARK not in source:
         source = source.rstrip() + "\n" + ENC_ROLE_INJECT
@@ -237,9 +240,7 @@ def main() -> int:
         print(
             "vision-exp encoding.py                 :",
             "APPLIED"
-            if ENC_MARK in encoding and ENC_ROLE_MARK in encoding
-            and ENC_ROLE_PAIRED_MARK in encoding
-            and ENC_ROLE_TOOL_MARK in encoding
+            if ENC_MARK in encoding and _encoding_role_complete(encoding)
             else "NOT APPLIED",
         )
         print(
@@ -249,9 +250,7 @@ def main() -> int:
         ok = (
             MODEL_MARK in model
             and ENC_MARK in encoding
-            and ENC_ROLE_MARK in encoding
-            and ENC_ROLE_PAIRED_MARK in encoding
-            and ENC_ROLE_TOOL_MARK in encoding
+            and _encoding_role_complete(encoding)
             and DSPARK_MARK in dspark
         )
         return 0 if ok else 1

--- a/scripts/test-dsv4-vision-exp-hotfix.py
+++ b/scripts/test-dsv4-vision-exp-hotfix.py
@@ -56,6 +56,7 @@ ENC_MARK = _mod.ENC_MARK
 ENC_ROLE_MARK = _mod.ENC_ROLE_MARK
 ENC_ROLE_PAIRED_MARK = _mod.ENC_ROLE_PAIRED_MARK
 ENC_ROLE_TOOL_MARK = _mod.ENC_ROLE_TOOL_MARK
+ENC_ROLE_QUOTE_MARK = _mod.ENC_ROLE_QUOTE_MARK
 MODEL_MARK = _mod.MODEL_MARK
 DSPARK_MARK = _mod.DSPARK_MARK
 
@@ -310,6 +311,7 @@ def _process_image_blocks(blocks):
         self.assertEqual(status, "applied")
         self.assertIn(ENC_MARK, updated)
         self.assertIn(ENC_ROLE_MARK, updated)
+        self.assertIn(ENC_ROLE_QUOTE_MARK, updated)
         skipped, status2 = patch_encoding_text(updated)
         self.assertEqual(status2, "skipped")
         self.assertEqual(updated, skipped)
@@ -353,14 +355,18 @@ def _process_image_blocks(blocks):
         ns["_validate_no_image_sp_tokens"](
             {"role": "assistant", "content": "example: <image> in markdown"}
         )
-        with self.assertRaises(ValueError) as paired_err:
-            ns["_validate_no_image_sp_tokens"](
-                {
-                    "role": "system",
-                    "content": "load <image>/tmp/shot.png</image> now",
-                }
-            )
-        self.assertIn("user messages only", str(paired_err.exception))
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "system",
+                "content": "load <image>/tmp/shot.png</image> now",
+            }
+        )
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "assistant",
+                "content": "yes — OpenAI `image_url` parts and `<image>path</image>` tags",
+            }
+        )
         ns["_validate_no_image_sp_tokens"](
             {
                 "role": "tool",
@@ -458,12 +464,19 @@ def _validate_no_image_sp_tokens(msg):
         self.assertEqual(status2, "applied")
         self.assertIn(ENC_ROLE_PAIRED_MARK, upgraded)
         self.assertIn(ENC_ROLE_TOOL_MARK, upgraded)
+        self.assertIn(ENC_ROLE_QUOTE_MARK, upgraded)
         ns: dict = {}
         exec(compile(upgraded, "encoding.py", "exec"), ns)
         ns["_validate_no_image_sp_tokens"](
             {
                 "role": "system",
                 "content": "Markdown images look like <image> tags.",
+            }
+        )
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "assistant",
+                "content": "yes — `<image>path</image>` tags",
             }
         )
 
@@ -532,6 +545,7 @@ def _validate_no_image_sp_tokens(msg):
         upgraded, status2 = patch_encoding_text(stale)
         self.assertEqual(status2, "applied")
         self.assertIn(ENC_ROLE_TOOL_MARK, upgraded)
+        self.assertIn(ENC_ROLE_QUOTE_MARK, upgraded)
         skipped, status3 = patch_encoding_text(upgraded)
         self.assertEqual(status3, "skipped")
         self.assertEqual(upgraded, skipped)
@@ -540,9 +554,105 @@ def _validate_no_image_sp_tokens(msg):
         ns["_validate_no_image_sp_tokens"](
             {"role": "tool", "content": "mentions " + ns["IMAGE_PLACEHOLDER"]}
         )
+        ns["_validate_no_image_sp_tokens"](
+            {
+                "role": "assistant",
+                "content": "yes — OpenAI `image_url` parts and `<image>path</image>` tags",
+            }
+        )
         with self.assertRaises(ValueError):
             ns["_validate_no_image_sp_tokens"](
                 {"role": "assistant", "content": ns["IMAGE_PLACEHOLDER"]}
+            )
+
+    def test_encoding_role_check_upgrades_quoted_paired_tags(self):
+        src = '''
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+def _validate_no_image_sp_tokens(msg):
+    content = msg.get("content")
+    if isinstance(content, str) and IMAGE_PLACEHOLDER in content:
+        raise ValueError("bad")
+    reasoning_content = msg.get("reasoning_content")
+    if isinstance(reasoning_content, str) and IMAGE_PLACEHOLDER in reasoning_content:
+        raise ValueError("bad-reason")
+
+def _process_image_blocks(blocks):
+    text = blocks[0].get("text") or ""
+    if IMAGE_PLACEHOLDER in text:
+        raise ValueError("bad-text")
+'''
+        first, status = patch_encoding_text(src)
+        self.assertEqual(status, "applied")
+        stale_inject = f'''
+{ENC_ROLE_MARK}
+{ENC_ROLE_PAIRED_MARK}
+{ENC_ROLE_TOOL_MARK}
+def _dspark_vision_text_has_image(text: str) -> bool:
+    if IMAGE_PLACEHOLDER in text:
+        return True
+    needle, close = "<image>", "</image>"
+    start = 0
+    while True:
+        i = text.find(needle, start)
+        if i < 0:
+            return False
+        if text.find(close, i + len(needle)) >= 0:
+            return True
+        start = i + len(needle)
+
+
+def _dspark_vision_value_has_image(value, scan_text: bool = True) -> bool:
+    if isinstance(value, str):
+        return bool(scan_text) and _dspark_vision_text_has_image(value)
+    return False
+
+
+def _validate_no_image_sp_tokens(msg):
+    role = msg.get("role")
+    if role in ("user", "developer"):
+        return
+    scan_text = role not in ("tool", "function")
+    if _dspark_vision_value_has_image(msg.get("content"), scan_text):
+        raise ValueError(
+            "Images are supported in user messages only: "
+            "images in " + repr(role) + " messages return a 400 error."
+        )
+'''
+        stale = first[: first.rfind(ENC_ROLE_MARK)] + stale_inject
+        self.assertIn(ENC_ROLE_TOOL_MARK, stale)
+        self.assertNotIn(ENC_ROLE_QUOTE_MARK, stale)
+        ns_stale: dict = {}
+        exec(compile(stale, "encoding.py", "exec"), ns_stale)
+        quoted = "yes — OpenAI `image_url` parts and `<image>path</image>` tags"
+        with self.assertRaises(ValueError):
+            ns_stale["_validate_no_image_sp_tokens"](
+                {"role": "assistant", "content": quoted}
+            )
+        upgraded, status2 = patch_encoding_text(stale)
+        self.assertEqual(status2, "applied")
+        self.assertIn(ENC_ROLE_QUOTE_MARK, upgraded)
+        skipped, status3 = patch_encoding_text(upgraded)
+        self.assertEqual(status3, "skipped")
+        self.assertEqual(upgraded, skipped)
+        ns: dict = {}
+        exec(compile(upgraded, "encoding.py", "exec"), ns)
+        ns["_validate_no_image_sp_tokens"]({"role": "assistant", "content": quoted})
+        ns["_validate_no_image_sp_tokens"](
+            {"role": "system", "content": "load <image>/tmp/shot.png</image> now"}
+        )
+        with self.assertRaises(ValueError):
+            ns["_validate_no_image_sp_tokens"](
+                {"role": "assistant", "content": ns["IMAGE_PLACEHOLDER"]}
+            )
+        with self.assertRaises(ValueError):
+            ns["_validate_no_image_sp_tokens"](
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "http://x/y.png"}}
+                    ],
+                }
             )
 
     def test_dspark_remaps_bias_vl_before_lookup(self):


### PR DESCRIPTION
## Summary
- After #165/#167, `system`/`assistant` prose that quotes `<image>path</image>` still 400'd. Replaying that assistant turn poisoned the whole session.
- Outside `user`, only a structured `image`/`image_url` part or the raw `<｜deepseek_image｜>` token is an image. The serve path has no tagged-text expander.
- Encoder inject upgrades from the #167 mark (`ENC_ROLE_QUOTE_MARK`); CPU tests cover the reported assistant quote and the upgrade from a #167-era inject.

Fixes #181

## Test plan
- [x] `python3 scripts/test-dsv4-vision-exp-hotfix.py`
- [ ] Recreate: `./stop-deepseek-v4-flash-dspark.sh` then `./start-deepseek-v4-flash-dspark.sh` (restart keeps old encoder bytes)
- [ ] Replay the issue curl (assistant content quotes `` `<image>path</image>` ``) → 200, not 400
- [ ] Structured `image_url` in assistant still 400; user `image_url` still works


Made with [Cursor](https://cursor.com)