### PR TITLE
docs: tool/function image_url is HTTP 400 (issue #178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Vision-Exp role check no longer 400s when assistant/system prose quotes `<image>…</image>` ([Issue #181](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/181))**: the #165 paired-tag scan ran on replayed assistant text, so a reply that documented the tag poisoned the session. Outside `user`, only a structured `image` / `image_url` part or the raw placeholder token is an image. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
 
+### Changed
+
+- **README documents that structured `image_url` on `tool` / `function` is HTTP 400 ([Issue #178](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/178))**: same official user-only-images rule as `system` / `assistant`. Vision-tool results must go on a `user` turn; a 400'd tool image stays in history and blocks the session. Serve behavior is unchanged.
+
 ## 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -222,8 +222,15 @@ python3 scripts/overlay-vision-exp-ablit-cache.py
 The 0731 abliterated freeze stays on branch `0731-ablit`.
 
 Images: OpenAI `image_url` (JPEG/PNG/GIF/WebP; GIF is still-frame). No video.
-Images belong in **`user` messages only** — `system` or `assistant` returns HTTP 400.
-Default cap 8 images (`LIMIT_MM_PER_PROMPT` is JSON `{"image":8}`; `image=8` is converted). Example:
+Images belong in **`user` messages only**. A structured `image` / `image_url`
+part (or the raw `<｜deepseek_image｜>` token) on `system`, `assistant`,
+`tool`, or `function` returns HTTP 400. Tool/function *text* that quotes
+`<image>` tags is allowed; putting a vision-tool result on `role: "tool"` as
+`image_url` is not. That 400 is not retried by typical OpenAI clients, and
+the rejected turn stays in history, so later messages keep failing until
+that tool message is dropped ([issue #178](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/178)).
+Put screenshots on a **`user`** turn instead. Default cap 8 images
+(`LIMIT_MM_PER_PROMPT` is JSON `{"image":8}`; `image=8` is converted). Example:
 
 ```json
 {"model":"deepseek-v4-flash-vision-exp","messages":[{"role":"user","content":[


### PR DESCRIPTION
## Summary
- README now states the official user-only-images rule for `tool` / `function` as well as `system` / `assistant`.
- Documents that a 400'd tool `image_url` stays in history and blocks later turns; put screenshots on a `user` message. Serve behavior is unchanged.

Fixes #178

## Test plan
- [x] Docs-only; no encoder/compose change
- [ ] Agents: move vision-tool results onto a `user` turn instead of `role: tool` + `image_url`


Made with [Cursor](https://cursor.com)