### PR TITLE
fix(build): digest-pinned DSPARK_VLLM_IMAGE is not a docker -t (issue #173)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -183,8 +183,11 @@ WORKER_VLLM_HOST_IP=worker-roce-ip
 #   2) get its manifest digest (docker inspect --format '{{index .RepoDigests 0}}')
 #   3) update the @sha256: below.
 DSPARK_VLLM_IMAGE=ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8
-# Alternative: build locally with ./build-dspark-vllm-runtime.sh → vllm-dspark-runtime:dspark-nvfp4-stage-c
-# and merge docker-compose.stage-c.override.yml (see docs/ENVS.md).
+# Alternative: build locally with ./build-dspark-vllm-runtime.sh. A digest pin
+# cannot be docker build -t (issue #173); the script tags
+# vllm-dspark-runtime:dspark-nvfp4-stage-c and does not retag this Anemll image.
+# Serve Stage-C by pointing DSPARK_VLLM_IMAGE at that tag and merging
+# docker-compose.stage-c.override.yml (see docs/ENVS.md).
 
 # Serving profile. DSpark k must be >= checkpoint dspark_block_size (5);
 # k<5 truncates draft blocks (silent on Anemll 0.25.2, rejected on stock 0.26+).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **Vision-Exp role check no longer 400s when assistant/system prose quotes `<image>…</image>` ([Issue #181](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/181))**: the #165 paired-tag scan ran on replayed assistant text, so a reply that documented the tag poisoned the session. Outside `user`, only a structured `image` / `image_url` part or the raw placeholder token is an image. Recreate both containers after pull (`./stop` then `./start`); restart keeps the old encoder bytes.
 
+- **`./build-dspark-vllm-runtime.sh` no longer passes a digest-pinned `DSPARK_VLLM_IMAGE` to `docker build -t` ([Issue #173](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/173))**: BuildKit rejects `name:tag@sha256:…`. The Anemll serve pin is left alone; Stage-C is tagged `vllm-dspark-runtime:dspark-nvfp4-stage-c`. Point `DSPARK_VLLM_IMAGE` at that tag only if you intend to serve the local build.
+
 ### Changed
 
 - **README documents that structured `image_url` on `tool` / `function` is HTTP 400 ([Issue #178](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/178))**: same official user-only-images rule as `system` / `assistant`. Vision-tool results must go on a `user` turn; a 400'd tool image stays in history and blocks the session. Serve behavior is unchanged.

--- a/build-dspark-vllm-runtime.sh
+++ b/build-dspark-vllm-runtime.sh
@@ -4,6 +4,34 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.dspark}"
 
+DEFAULT_BASE_IMAGE="vllm-dspark-runtime:mia-raf-pr1"
+DEFAULT_STAGE_C_IMAGE="vllm-dspark-runtime:dspark-nvfp4-stage-c"
+
+# docker build -t cannot include @digest (BuildKit: "build tag cannot contain a
+# digest", issue #173). Do not strip the digest and keep name:tag — that would
+# retag the digest-pinned Anemll serve image as Stage-C.
+dspark_docker_build_tag() {
+  local ref="${1:?}"
+  local fallback="${2:?}"
+  case "$ref" in
+    *@*) printf '%s' "$fallback" ;;
+    *) printf '%s' "$ref" ;;
+  esac
+}
+
+if [ "${1:-}" = "--tag-selftest" ]; then
+  _fail=0
+  _got="$(dspark_docker_build_tag \
+    'ghcr.io/anemll/dspark-vllm-gx10:0.1.1@sha256:deadbeef' \
+    "$DEFAULT_STAGE_C_IMAGE")"
+  [ "$_got" = "$DEFAULT_STAGE_C_IMAGE" ] || _fail=1
+  _got="$(dspark_docker_build_tag "$DEFAULT_STAGE_C_IMAGE" "$DEFAULT_STAGE_C_IMAGE")"
+  [ "$_got" = "$DEFAULT_STAGE_C_IMAGE" ] || _fail=1
+  _got="$(dspark_docker_build_tag "$DEFAULT_BASE_IMAGE" "$DEFAULT_BASE_IMAGE")"
+  [ "$_got" = "$DEFAULT_BASE_IMAGE" ] || _fail=1
+  exit "$_fail"
+fi
+
 if [ -f "$ENV_FILE" ]; then
   set -a
   # shellcheck disable=SC1090
@@ -11,9 +39,20 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
-DSPARK_VLLM_IMAGE="${DSPARK_VLLM_IMAGE:-vllm-dspark-runtime:dspark-nvfp4-stage-c}"
-DSPARK_BASE_IMAGE="${DSPARK_BASE_IMAGE:-vllm-dspark-runtime:mia-raf-pr1}"
+DSPARK_VLLM_IMAGE="${DSPARK_VLLM_IMAGE:-$DEFAULT_STAGE_C_IMAGE}"
+DSPARK_BASE_IMAGE="${DSPARK_BASE_IMAGE:-$DEFAULT_BASE_IMAGE}"
 WORKER_BUILD="${WORKER_BUILD:-1}"
+
+overlay_tag="$(dspark_docker_build_tag "$DSPARK_BASE_IMAGE" "$DEFAULT_BASE_IMAGE")"
+stage_c_tag="$(dspark_docker_build_tag "$DSPARK_VLLM_IMAGE" "$DEFAULT_STAGE_C_IMAGE")"
+if [ "$overlay_tag" != "$DSPARK_BASE_IMAGE" ]; then
+  echo "DSPARK_BASE_IMAGE has a digest; docker build -t cannot use it (issue #173)." >&2
+  echo "Tagging overlay as $overlay_tag (will not retag the digest-pinned ref)." >&2
+fi
+if [ "$stage_c_tag" != "$DSPARK_VLLM_IMAGE" ]; then
+  echo "DSPARK_VLLM_IMAGE has a digest; docker build -t cannot use it (issue #173)." >&2
+  echo "Tagging Stage-C as $stage_c_tag. Point DSPARK_VLLM_IMAGE at that tag to serve it; the digest pin is unchanged." >&2
+fi
 
 "$SCRIPT_DIR/scripts/verify-overlay-sources.sh"
 
@@ -23,26 +62,26 @@ build_one() {
   if [ "$host" = "local" ]; then
     docker build \
       -f "$SCRIPT_DIR/recipe/Dockerfile.dspark-runtime-overlay" \
-      -t "$DSPARK_BASE_IMAGE" \
+      -t "$overlay_tag" \
       "$SCRIPT_DIR/recipe/overlay"
-    docker run --rm --entrypoint /opt/env/bin/python "$DSPARK_BASE_IMAGE" -c \
+    docker run --rm --entrypoint /opt/env/bin/python "$overlay_tag" -c \
       "import vllm.v1.spec_decode.dspark as d; import vllm.v1.spec_decode.dspark_proposer as p; assert d.map_dspark_stacked_param_name('model.layers.0.ffn.shared_experts.w1.weight') == ('model.layers.0.ffn.shared_experts.gate_up_proj.weight', 0); print('dspark overlay ok', d.__name__, p.__name__)"
     docker build \
-      --build-arg BASE_IMAGE="$DSPARK_BASE_IMAGE" \
+      --build-arg BASE_IMAGE="$overlay_tag" \
       -f "$SCRIPT_DIR/recipe/nvfp4/Dockerfile.stage-a" \
-      -t "$DSPARK_BASE_IMAGE-nvfp4-a" \
+      -t "$overlay_tag-nvfp4-a" \
       "$SCRIPT_DIR"
     docker build \
-      --build-arg BASE_IMAGE="$DSPARK_BASE_IMAGE-nvfp4-a" \
+      --build-arg BASE_IMAGE="$overlay_tag-nvfp4-a" \
       -f "$SCRIPT_DIR/recipe/nvfp4/Dockerfile.stage-b" \
-      -t "$DSPARK_BASE_IMAGE-nvfp4-b" \
+      -t "$overlay_tag-nvfp4-b" \
       "$SCRIPT_DIR"
     docker build \
-      --build-arg BASE_IMAGE="$DSPARK_BASE_IMAGE-nvfp4-b" \
+      --build-arg BASE_IMAGE="$overlay_tag-nvfp4-b" \
       -f "$SCRIPT_DIR/recipe/nvfp4/Dockerfile.stage-c" \
-      -t "$DSPARK_VLLM_IMAGE" \
+      -t "$stage_c_tag" \
       "$SCRIPT_DIR"
-    docker run --rm --entrypoint /opt/env/bin/python "$DSPARK_VLLM_IMAGE" -c \
+    docker run --rm --entrypoint /opt/env/bin/python "$stage_c_tag" -c \
       "import vllm; print('dspark nvfp4 stage-c image ok', vllm.__version__)"
   else
     ssh "$host" "mkdir -p '$checkout'"

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -16,6 +16,7 @@ for f in \
   stop-deepseek-v4-flash-dspark.sh \
   validate-dspark-config.sh \
   prepare-dspark-model-cache.sh \
+  build-dspark-vllm-runtime.sh \
   files/nfs-share.sh \
   files/nfs-server/entrypoint.sh \
   smoke-deepseek-v4-flash-dspark.sh \
@@ -35,6 +36,12 @@ do
   bash -n "$f" || bad "bash -n $f"
   ok "bash -n $f"
 done
+
+if "$ROOT/build-dspark-vllm-runtime.sh" --tag-selftest; then
+  ok "build-dspark-vllm-runtime digest is not a docker -t (issue #173)"
+else
+  bad "build-dspark-vllm-runtime --tag-selftest"
+fi
 
 echo "== python compile (patches + unit scripts) =="
 mapfile -t py_files < <(find patches -name '*.py' -not -path '*/__pycache__/*' | sort)


### PR DESCRIPTION
## Summary
- `./build-dspark-vllm-runtime.sh` sourced the digest-pinned Anemll `DSPARK_VLLM_IMAGE` and passed it to `docker build -t`, which BuildKit rejects (`build tag cannot contain a digest`). Overlay / Stage A/B used `DSPARK_BASE_IMAGE` (no digest) so they succeeded; Stage C failed immediately.
- Lowest-risk fix: if the ref contains `@`, tag the documented local image (`vllm-dspark-runtime:dspark-nvfp4-stage-c` / overlay fallback) instead of stripping the digest and retagging Anemll `0.1.1`. Serve pin in `.env` is unchanged. `--tag-selftest` covers the helper.

Fixes #173

## Test plan
- [x] `./build-dspark-vllm-runtime.sh --tag-selftest`
- [ ] `./build-dspark-vllm-runtime.sh` with stock digest-pinned `.env.dspark` completes Stage C as `vllm-dspark-runtime:dspark-nvfp4-stage-c`
- [ ] Anemll `DSPARK_VLLM_IMAGE=…@sha256:…` still used by `./start-…` unless you point it at the Stage-C tag


Made with [Cursor](https://cursor.com)