### PR TITLE
Optional 3-node TP=3 launcher (`./start-tp3.sh`)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -7,6 +7,19 @@
 
 # Cluster
 WORKER_HOST=worker-host-or-roce-ip
+# Third Spark for optional ./start-tp3.sh (ignored by the 2-node start).
+# On a QSFP ring this node is a different CX /24 than WORKER_HOST — set
+# WORKER2_NCCL_* to spark3's facing port toward the head, and
+# WORKER2_NFS_SERVER_IP to the head CX IP on that link (not 10.0.22.1).
+# ./start-tp3.sh --max-num-seqs overrides TP3_MAX_NUM_SEQS; 2-node keeps MAX_NUM_SEQS.
+# WORKER2_HOST=worker2-host-or-roce-ip
+# WORKER2_VLLM_HOST_IP=
+# WORKER2_DIR=
+# WORKER2_HF_CACHE=
+# WORKER2_NCCL_IB_HCA=
+# WORKER2_NCCL_SOCKET_IFNAME=
+# WORKER2_NFS_SERVER_IP=10.0.23.1
+# TP3_MAX_NUM_SEQS=16
 # Worker-local checkout/deployment path. Leave blank to mirror the head path.
 WORKER_DIR=
 # Optional explicit worker checkout path. This is useful when the worker clone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2026-09-02
 
+### Added
+
+- **Optional 3-node TP=3 via `./start-tp3.sh`**: default `./start-deepseek-v4-flash-dspark.sh` still forces TP=2 / nnodes=2. Three Sparks pad attention groups 8→9 (vendored from localaiguyy, MIT), SSH a third rank (`WORKER2_HOST`), and on a QSFP ring use a second NFS `/24`, Gloo on `enP7s7` (not `lo`), both CX HCAs, and NCCL subnet-aware routing at prefix 24. CLI `--max-num-seqs` / `TP3_MAX_NUM_SEQS` apply only on that path. Recreate after overlay or seqs changes. See [docs/TP3.md](docs/TP3.md).
+
 ### Fixed
 
 - **`NCCL_IB_GID_AUTO=1` now validates sysfs GIDs and leaves `NCCL_IB_GID_INDEX` unset instead of pinning a resolved "common" index (tonyd2wild #38)**: a pin is one global value per rank, while the usable RoCEv2 GID index differs per HCA and drifts after link/fw events — any pin, including the previously resolved intersection pick, can later wedge NCCL init (`ibv_modify_qp 61`) on dual-HCA nodes. Auto mode keeps the per-member fail-closed validation (a selected HCA/port with no usable RoCEv2/IPv4 GID still aborts the launch, with per-member usable-set logs) but no longer requires members to share an index — disjoint usable sets are accepted — and clears `NCCL_IB_GID_INDEX` / `WORKER_NCCL_IB_GID_INDEX` so NCCL selects the GID per HCA; stale pins in `.env.dspark` are reported and ignored. `NCCL_IB_GID_AUTO=0` still pins verbatim. Empty is not absent for NCCL (a defined-empty value reads as GID index 0 and would mask `/etc/nccl.conf`), so `remote_nccl_env` keeps emitting the key — empty — so a stale worker `.env.dspark` pin is masked instead of resurfacing, and the shared compose entrypoint normalization now also unsets a defined-empty `NCCL_IB_GID_INDEX` on both ranks. Recreate both ranks (`./stop` then `./start`) so the in-container pin disappears.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -60,6 +60,14 @@ repo builds from:
 
 - https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark
 
+## Three-Node TP=3 Padding
+
+Optional `./start-tp3.sh` vendors the attention-group pad (8→9) from:
+
+- https://github.com/localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark
+
+That work is independent of this 2-node recipe. See [docs/TP3.md](docs/TP3.md).
+
 ## Upstream Foundations
 
 This work also relies on:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Qwen3.8-Flash-vLLM).
    One-shot bind override: `./start-deepseek-v4-flash-dspark.sh --host 0.0.0.0 --port 9000`.
    After a reboot, dockerd may already have restored the ranks (`restart: unless-stopped`); start then exits **3** (already running), not 1. That is expected — do not `./stop` unless you want a cold start. systemd: `SuccessExitStatus=3`.
 
+   Optional **three Sparks (TP=3)** is a separate launcher so `.env` cannot flip the 2-node path: `./start-tp3.sh` (needs `WORKER2_HOST`; see [docs/TP3.md](docs/TP3.md)).
+
 6. **Check it is up**
 
    ```bash

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -77,6 +77,9 @@ services:
       # output_text items replayed through the Responses API.
       - ${DSPARK_ISSUE138_HOTFIX:-./patches/hotfix-vllm-issue138-responses-history.py}:/opt/hotfix-vllm-issue138-responses-history.py:ro
       - ${DSPARK_PATCHES_DIR:-./patches}:/opt/dspark-patches:ro
+      # TP=3 group-pad patch (no-op unless TP_SIZE=3). Sourced from
+      # localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark.
+      - ${TP3_PATCH_DIR:-./patches/tp3}:/opt/dsv4-tp3:ro
       - ${DSPARK_TMP_HOST:-${HOME}/.cache/dspark-tmp}:/tmp
 
     # Env surface is split by runtime image:
@@ -231,12 +234,16 @@ services:
       # so NCCL selects the RoCEv2/IPv4 GID per HCA.
       # See docs/ENVS.md for what each knob actually controls.
       NCCL_IB_MERGE_NICS: "${NCCL_IB_MERGE_NICS:-}"
+      NCCL_IB_SUBNET_AWARE_ROUTING: "${NCCL_IB_SUBNET_AWARE_ROUTING:-}"
+      NCCL_IB_SUBNET_PREFIX_LEN: "${NCCL_IB_SUBNET_PREFIX_LEN:-}"
       NCCL_NET_GDR_LEVEL: "${NCCL_NET_GDR_LEVEL:-}"
       NCCL_NET_GDR_READ: "${NCCL_NET_GDR_READ:-}"
       NCCL_DMABUF_ENABLE: "${NCCL_DMABUF_ENABLE:-}"
 
       NODE_RANK: "${NODE_RANK}"
       HEADLESS: "${HEADLESS:-}"
+      TP_SIZE: "${TP_SIZE:-2}"
+      NNODES: "${NNODES:-2}"
       MASTER_ADDR: "${MASTER_ADDR}"
       MASTER_PORT: "${MASTER_PORT:-25000}"
       # Checkpoint dspark_block_size is 5; k<5 truncates draft blocks (silent on 0.25.2 image).
@@ -291,6 +298,8 @@ services:
         export LD_LIBRARY_PATH="/usr/local/cuda/lib64:$${LD_LIBRARY_PATH:-}";
         API_KEY_ARGS=(); case "$${DSPARK_API_KEYS:-}" in *[$$'\r\n\v\f']*) echo "error: DSPARK_API_KEYS must be a single-line space-separated list" >&2; exit 2 ;; *\\*) echo "error: DSPARK_API_KEYS must not contain backslashes" >&2; exit 2 ;; esac; _dspark_keys_set=0; case "$${DSPARK_API_KEYS:-}" in *[!$$' \t']*) _dspark_keys_set=1 ;; esac; if [ -n "$${VLLM_API_KEY:-}" ] && [ "$${_dspark_keys_set}" = "1" ]; then echo "error: VLLM_API_KEY and DSPARK_API_KEYS are both set; set exactly one of them" >&2; exit 2; fi; if [ "$${_dspark_keys_set}" = "1" ]; then read -r -a _dspark_keys <<< "$${DSPARK_API_KEYS}"; for _dspark_key in "$${_dspark_keys[@]}"; do case "$${_dspark_key}" in -*) echo "error: DSPARK_API_KEYS contains a token beginning with '-'" >&2; exit 2 ;; esac; done; API_KEY_ARGS=(--api-key "$${_dspark_keys[@]}"); fi;
         if [ -z "$${NCCL_IB_MERGE_NICS:-}" ]; then unset NCCL_IB_MERGE_NICS; fi;
+        if [ -z "$${NCCL_IB_SUBNET_AWARE_ROUTING:-}" ]; then unset NCCL_IB_SUBNET_AWARE_ROUTING; fi;
+        if [ -z "$${NCCL_IB_SUBNET_PREFIX_LEN:-}" ]; then unset NCCL_IB_SUBNET_PREFIX_LEN; fi;
         if [ -z "$${NCCL_NET_GDR_LEVEL:-}" ]; then unset NCCL_NET_GDR_LEVEL; fi;
         if [ -z "$${NCCL_NET_GDR_READ:-}" ]; then unset NCCL_NET_GDR_READ; fi;
         if [ -z "$${NCCL_DMABUF_ENABLE:-}" ]; then unset NCCL_DMABUF_ENABLE; fi;
@@ -325,6 +334,10 @@ services:
           export VLLM_PLUGINS="$${VLLM_PLUGINS:-gb10_hybrid_nvfp4}";
           VLLM_QUANTIZATION_ARGS="--quantization modelopt_gb10_hybrid";
         fi;
+        if [ "${TP_SIZE:-2}" = "3" ]; then
+          if [ ! -f /opt/dsv4-tp3/apply_tp3_patch.py ]; then echo "FATAL: TP_SIZE=3 but /opt/dsv4-tp3/apply_tp3_patch.py is missing" >&2; exit 1; fi;
+          python3 /opt/dsv4-tp3/apply_tp3_patch.py || exit 1;
+        fi;
         case "$${DRAFT_SAMPLE_METHOD:-probabilistic}" in
           probabilistic|greedy) DRAFT_SAMPLE_METHOD="$${DRAFT_SAMPLE_METHOD:-probabilistic}" ;;
           *) echo "DRAFT_SAMPLE_METHOD must be one of: probabilistic, greedy (got: $${DRAFT_SAMPLE_METHOD})" >&2; exit 2 ;;
@@ -348,7 +361,7 @@ services:
         --trust-remote-code
         "$${API_KEY_ARGS[@]}"
         $${VLLM_QUANTIZATION_ARGS}
-        --tensor-parallel-size 2
+        --tensor-parallel-size ${TP_SIZE:-2}
         --pipeline-parallel-size 1
         --kv-cache-dtype nvfp4_ds_mla
         --block-size 256
@@ -374,7 +387,7 @@ services:
         --default-chat-template-kwargs "$${DEFAULT_CHAT_TEMPLATE_KWARGS}"
         --generation-config vllm
         --enable-flashinfer-autotune
-        --nnodes 2
+        --nnodes ${NNODES:-2}
         --node-rank ${NODE_RANK}
         --master-addr ${MASTER_ADDR}
         --master-port ${MASTER_PORT:-25000}

--- a/docs/TP3.md
+++ b/docs/TP3.md
@@ -1,0 +1,88 @@
+# Optional: 3× DGX Spark (TP=3)
+
+Default serve is still **two nodes, TP=2**:
+
+```bash
+./start-deepseek-v4-flash-dspark.sh
+```
+
+Three Sparks use a separate launcher so a `TP_SIZE=3` line in `.env.dspark`
+cannot silently change the 2-node path:
+
+```bash
+# in .env.dspark, in addition to the usual WORKER_HOST / fabric knobs:
+WORKER2_HOST=10.0.0.3
+WORKER2_VLLM_HOST_IP=10.0.0.3
+# optional port/HCA overrides (default to WORKER_*):
+# WORKER2_NCCL_IB_HCA=
+# WORKER2_NCCL_SOCKET_IFNAME=
+# WORKER2_HF_CACHE=
+# WORKER2_DIR=
+
+./prepare-dspark-model-cache.sh --yes   # also copies weights to WORKER2 when NFS=0
+./start-tp3.sh                         # or: ./start-tp3.sh --max-num-seqs 16
+scripts/validate_tp3.sh 127.0.0.1:8888
+```
+
+On a **QSFP ring**, spark3 is not on the spark1↔spark2 NFS subnet. Worker 1
+mounts `NFS_SERVER_IP` (often `10.0.22.1`). Worker 2 must use the head address
+on the spark1↔spark3 link (`WORKER2_NFS_SERVER_IP`, e.g. `10.0.23.1`) and that
+`/24` must be in the live exporter's clients (start adds it when it can).
+Pin `WORKER2_NCCL_*` to spark3's facing port toward spark1, not a copy of
+`WORKER_NCCL_*`. Start then moves **Gloo / NCCL socket / TP TCP** onto
+`TP3_BOOTSTRAP_IFNAME` (default `enP7s7` / 192.168.1.0/24). Do not use `lo`:
+Gloo binds `127.0.0.1` and the mesh fails. `NCCL_IB_HCA` is then set to
+**both** CX ports (`rocep1s0f0,rocep1s0f1`) so spark1 can reach spark2 on
+`10.0.22.0/24` and spark3 on `10.0.23.0/24` (a single facing HCA times out
+in QP RTR). Override with `TP3_NCCL_IB_HCA` if the roce names differ.
+Start also sets `NCCL_IB_MERGE_NICS=0`, `NCCL_IB_SUBNET_AWARE_ROUTING=1`, and
+`NCCL_IB_SUBNET_PREFIX_LEN=24` so NCCL pairs GIDs per `/24` (default `/16`
+would treat `10.0.22` and `10.0.23` as one subnet).
+
+Stop is the same script; if `WORKER2_HOST` is set it tears down rank 2 as well:
+
+```bash
+./stop-deepseek-v4-flash-dspark.sh
+```
+
+## Why a patch is required
+
+V4-Flash has **8 attention output groups**. TP must divide that count. 2 does;
+3 does not. Stock vLLM either refuses to start (`64 % 3 != 0`) or **silently**
+keeps `8 // 3 == 2` local groups and drops the rest.
+
+The fix (from [localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark](https://github.com/localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark))
+pads **groups 8→9**, keeps **heads-per-group = 8**, and zero-fills / `-inf`-fills
+the pad lanes. The entrypoint runs `patches/tp3/apply_tp3_patch.py` inside the
+container only when `TP_SIZE=3`.
+
+Do not pad heads inside a group: that changes the o_proj BMM `r=4096` contract
+and DeepGEMM rejects it.
+
+## Recreate after patch edits
+
+The patcher writes into the container layer. `docker compose` restart reuses
+that layer; a stale marker then fails closed (`STALE`). After changing
+`patches/tp3/`:
+
+```bash
+./stop-deepseek-v4-flash-dspark.sh
+./start-tp3.sh
+```
+
+`./stop` already `docker rm -f` the vLLM containers.
+
+## Concurrency
+
+The 2-node recipe stays at `MAX_NUM_SEQS` (default `6`). TP=3 slots:
+
+```bash
+./start-tp3.sh --max-num-seqs 16
+# or in .env.dspark (ignored by ./start-deepseek-v4-flash-dspark.sh):
+# TP3_MAX_NUM_SEQS=16
+```
+
+CLI wins over `TP3_MAX_NUM_SEQS`. CUDA-graph capture size is
+`MAX_NUM_SEQS * (MTP_NUM_TOKENS + 1)`. If capture OOMs, lower
+`GPU_MEMORY_UTILIZATION_TEXT` toward `0.78` rather than cutting
+`MAX_MODEL_LEN` first. Needs a recreate (`./stop-… && ./start-tp3.sh`).

--- a/files/nfs-share.sh
+++ b/files/nfs-share.sh
@@ -133,6 +133,68 @@ nfs_worker_has_model() {
   ssh_worker "docker run --rm -v '${NFS_VOLUME}:/hf:ro' alpine:latest test -d '/hf/${rel}'" >/dev/null 2>&1
 }
 
+# Head CX7 IPv4s on the onboard dual-port (enp1s*), not the 10.0.0.x lo alias
+# and not docker bridges. A 3-node QSFP ring puts each peer on a different /24.
+nfs_head_cx_ipv4s() {
+  ip -4 -o addr show | awk '$2 ~ /^enp1s/ { split($4, a, "/"); print a[1] }'
+}
+
+nfs_pick_server_ip_for_host() {
+  local host="$1"
+  local pinned="${2:-}"
+  local ip
+  if [ -n "$pinned" ]; then
+    printf '%s' "$pinned"
+    return 0
+  fi
+  for ip in $(nfs_head_cx_ipv4s); do
+    if ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" \
+      "ping -c1 -W1 $(printf '%q' "$ip") >/dev/null 2>&1"; then
+      printf '%s' "$ip"
+      return 0
+    fi
+  done
+  return 1
+}
+
+nfs_subnet24() {
+  local ip="$1"
+  printf '%s.0/24' "${ip%.*}"
+}
+
+# Additive: allow a new /24 on an already-running exporter (vllm-fn-nfs or
+# dspark-nfs). Does not recreate the container (Qwen may be using the share).
+nfs_grant_subnet() {
+  local subnet="$1"
+  local c opts line
+  opts="${NFS_OPTS:-ro,sync,no_subtree_check,no_root_squash,insecure,fsid=0}"
+  for c in vllm-fn-nfs "${NFS_CONTAINER:-dspark-nfs}"; do
+    [ -n "$(docker ps -q --filter "name=^/${c}$")" ] || continue
+    line="/export ${subnet}(${opts})"
+    docker exec "$c" sh -c "
+      set -e
+      if grep -Fq '${subnet}(' /etc/exports 2>/dev/null; then
+        echo 'exports already allow ${subnet}'
+        exit 0
+      fi
+      echo '${line}' >> /etc/exports
+      exportfs -rav
+    " || nfs_info "WARN: could not add ${subnet} to ${c} exports"
+  done
+}
+
+nfs_ensure_host_volume() {
+  local host="$1"
+  local server_ip="$2"
+  ssh "$host" "docker volume rm '$NFS_VOLUME' >/dev/null 2>&1 || true"
+  ssh "$host" "docker volume create --driver local \
+    --opt type=nfs \
+    --opt o=addr=${server_ip},nfsvers=4.2,ro,nconnect=8,rsize=1048576,wsize=1048576,hard,timeo=600 \
+    --opt device=:/ \
+    '$NFS_VOLUME' >/dev/null"
+  nfs_ok "Worker volume $NFS_VOLUME on ${host} → nfs://${server_ip}/"
+}
+
 nfs_stop_owned_server() {
   # Only the DSpark-owned container. Never docker rm vllm-fn-nfs — Qwen may
   # still be using that export.

--- a/logs-deepseek-v4-flash-dspark.sh
+++ b/logs-deepseek-v4-flash-dspark.sh
@@ -19,6 +19,8 @@ fi
 
 cd "$SCRIPT_DIR"
 WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
+WORKER2_HOST="${WORKER2_HOST:-}"
+WORKER2_DIR="${WORKER2_SCRIPT_DIR:-${WORKER2_DIR:-$WORKER_DIR}}"
 
 show_logs() {
   local project="$1"
@@ -28,6 +30,11 @@ show_logs() {
   echo "== worker logs: $project =="
   ssh "$WORKER_HOST" "cd '$WORKER_DIR' && COMPOSE_DISABLE_ENV_FILE=1 docker compose -p '$project' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail='$TAIL' vllm-dspark" || true
   echo
+  if [ -n "${WORKER2_HOST:-}" ]; then
+    echo "== worker2 logs: $project =="
+    ssh "$WORKER2_HOST" "cd '${WORKER2_DIR:-$WORKER_DIR}' && COMPOSE_DISABLE_ENV_FILE=1 docker compose -p '$project' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail='$TAIL' vllm-dspark" || true
+    echo
+  fi
 }
 
 show_logs "$PROJECT_NAME"

--- a/patches/dsv4_tp_pad.py
+++ b/patches/dsv4_tp_pad.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 TP padding for non-divisible tensor-parallel sizes (TP=3 on 3 Sparks).
+
+WHY THIS EXISTS
+---------------
+DeepSeek-V4-Flash has num_attention_heads=64 and o_groups=8. Neither divides by 3,
+so vLLM refuses to start at TP=3 (`attention.py:183`) -- and, worse, silently
+mis-shards the group axis (`attention.py:191`, `8 // 3 == 2`, no assert).
+
+This module supplies the padding so a 3-node tensor-parallel deployment is legal
+AND numerically identical to TP=1.
+
+THE GROUP SEMANTICS (measured, not assumed)
+-------------------------------------------
+V4's o_proj is a per-group BMM:
+
+    z = einsum("bhr,hdr->bhd", o, wo_a)     # h=group, r=hpg*head_dim, d=o_lora_rank
+    out = wo_b(z.flatten(1))
+
+Two candidate resolutions were tested against the REAL fp8 checkpoint weights
+(`layers.3.attn.wo_a.weight`, [8192, 4096]):
+
+  R2  pad groups 8 -> 24 (24 % 3 == 0), heads -> 72, hpg = 3.
+      *** REJECTED -- arithmetically impossible. ***
+      With G=24, each group slab needs width hpg*head_dim = 3*512 = 1536, but the
+      checkpoint's slabs are 4096 wide. You cannot pad to a NARROWER tensor.
+      Independently: a real 8-head group cannot split 3 ways (8/3 = 2.67).
+
+  R1  replicate groups (n_local_groups = n_groups = 8), shard heads WITHIN each
+      group. Pad heads-per-group 8 -> 9, so total heads = 8 * 9 = 72, and each
+      rank takes 3 heads per group.
+      *** CORRECT -- reproduces TP=1 at rel 2.3e-06 (fp8 e4m3 quantization noise). ***
+
+The critical consequence of R1: wo_a's out-features stay G*o_lora_rank (they are
+NOT divided by tp_size), so wo_b's input dim is unchanged and the all-reduce sums
+exact per-rank partials. The padded 9th head in each group is zero and therefore
+contributes exactly nothing.
+
+Note the head count 72 also satisfies the naive rule `heads % (tp * o_groups) == 0`,
+but for a DIFFERENT structural reason (9 heads per replicated group, not 24 padded
+groups). Same number, different mechanism -- do not conflate them.
+
+WHAT NOT TO DO
+--------------
+* Do NOT reuse GLM's `glm_wrapper_pad_backend_ok()`. It resolves against
+  FLASHINFER_MLA_SPARSE_SM120, a backend DSv4 explicitly REJECTS
+  (`nvidia/model.py:769-777`). Setting the correct backend env var would silently
+  flip the pad value.
+* Do NOT route `attn_sink` through GLM's `copy_tp_shard_with_pad()`. That helper
+  calls `dest.zero_()` first; a zeroed sink lane means exp(0)=1, which adds a
+  phantom unit to the softmax denominator and ATTENUATES REAL HEADS. Sink pad
+  lanes must stay -inf. See `pad_fill_value()` below.
+
+Enabled by env VLLM_DSV4_TP_PAD (default "1").
+
+Redmine: 
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+__all__ = [
+    "dsv4_tp_pad_enabled",
+    "pad_heads_for_groups",
+    "local_heads_per_group",
+    "pad_fill_value",
+    "describe_geometry",
+    "copy_head_shard_within_groups",
+]
+
+
+def dsv4_tp_pad_enabled() -> bool:
+    return os.environ.get("VLLM_DSV4_TP_PAD", "1") not in ("", "0", "false", "False")
+
+
+# FlashInfer DSv4 SM120 decode dispatch head counts. The backend zero-pads a
+# smaller local head count up to the next entry around the kernel call, so any
+# local <= 128 is runnable. (nvidia/flashinfer_sparse.py:592-603)
+#
+# NOTE: this is vLLM's CLAIM about the kernel, not the kernel itself. A decode
+# smoke test at the chosen local head count is the only way to confirm it.
+_DISPATCH_LOCAL_HEADS = (8, 16, 32, 64, 128)
+_MAX_LOCAL_HEADS = 128
+
+
+def pad_heads_for_groups(num_heads: int, tp_size: int, o_groups: int) -> int:
+    """Smallest head count >= num_heads that is TP-legal under R1 group semantics.
+
+    R1 keeps all `o_groups` groups on every rank and shards heads within each
+    group, so the binding constraint is on heads-per-group:
+
+        heads_per_group % tp_size == 0
+
+    i.e. num_heads must be a multiple of `tp_size * o_groups`.
+
+    For V4-Flash at TP=3: 64 -> 72 (8 groups x 9 heads, 3 heads/group/rank).
+
+    Raises if the resulting local head count exceeds what the decode kernel can
+    dispatch -- better a loud failure here than a silent mis-dispatch later.
+    """
+    if tp_size <= 1:
+        return num_heads
+    if o_groups <= 0:
+        raise ValueError(f"o_groups must be positive, got {o_groups}")
+
+    step = tp_size * o_groups
+    padded = ((num_heads + step - 1) // step) * step
+
+    local = padded // tp_size
+    if local > _MAX_LOCAL_HEADS:
+        raise ValueError(
+            f"padded local head count {local} exceeds the max dispatchable "
+            f"{_MAX_LOCAL_HEADS} (heads={num_heads} -> {padded}, tp={tp_size}, "
+            f"o_groups={o_groups})"
+        )
+    return padded
+
+
+def local_heads_per_group(padded_heads: int, tp_size: int, o_groups: int) -> int:
+    """Heads per group held by ONE rank under R1.
+
+    V4-Flash at TP=3: 72 / (3 * 8) = 3.
+
+    This is the value that must satisfy the hard invariant at
+    `fused_inv_rope_fp8_quant.py:183`:  num_heads == n_groups * heads_per_group
+    where num_heads there is the rank-local head count.
+    """
+    step = tp_size * o_groups
+    if padded_heads % step != 0:
+        raise ValueError(
+            f"padded_heads={padded_heads} is not a multiple of "
+            f"tp_size*o_groups={step}; R1 sharding would be non-integral"
+        )
+    return padded_heads // step
+
+
+def pad_fill_value(param_name: str) -> float:
+    """The value a padded lane of `param_name` must be filled with.
+
+    *** THE WHOLE POINT OF THIS FUNCTION IS THAT IT IS NOT ALWAYS ZERO. ***
+
+    attn_sink is an extra logit appended to the softmax denominator:
+        denom = sum_j exp(s_j) + exp(sink)
+
+      sink = -inf  =>  exp(-inf) = 0  =>  denominator unchanged, sink DISABLED.
+                       This is the identity element and the correct pad value.
+      sink = 0     =>  exp(0) = 1     =>  adds 1.0 to the denominator, shrinking
+                       every attention weight for that head. Silently wrong --
+                       plausible output, wrong attention temperature.
+
+    Every other padded tensor (wq_b rows, wo_a slices, wo_b rows) takes 0.0,
+    which annihilates exactly through the fp8 einsum and the all-reduce.
+
+    wo_b's pad rows do not strictly need zeroing (a zero `z` slice annihilates
+    them), but they MUST NOT be left as uninitialized `torch.empty` memory:
+    0 * NaN = NaN would poison every rank through the all-reduce.
+    """
+    if param_name.endswith("attn_sink") or ".attn_sink" in param_name:
+        return -float("inf")
+    return 0.0
+
+
+def describe_geometry(num_heads: int, tp_size: int, o_groups: int) -> str:
+    """One-line INFO log so a wrong shard is visible at startup, not at eval time."""
+    padded = pad_heads_for_groups(num_heads, tp_size, o_groups)
+    local = padded // tp_size
+    hpg = local_heads_per_group(padded, tp_size, o_groups)
+    return (
+        f"DSv4 TP pad: heads {num_heads}->{padded} (tp={tp_size}), "
+        f"local_heads={local}, o_groups={o_groups} (REPLICATED, not divided), "
+        f"heads_per_group_per_rank={hpg}, real_heads={num_heads}"
+    )
+
+
+def copy_head_shard_within_groups(
+    dest: torch.Tensor,
+    src: torch.Tensor,
+    tp_rank: int,
+    tp_size: int,
+    o_groups: int,
+    real_heads: int,
+    head_dim: int,
+    fill: float = 0.0,
+) -> None:
+    """Load a rank's head-shard under R1 group-replicated sharding.
+
+    Unlike a flat column shard, R1 takes a contiguous slice of heads FROM EACH
+    GROUP, not a contiguous slice of the whole head axis. Rank k holds heads
+    [k*hpg, (k+1)*hpg) within every one of the `o_groups` groups.
+
+    src is the full checkpoint tensor whose leading axis is real_heads*head_dim.
+    dest is this rank's parameter, sized o_groups*hpg*head_dim.
+
+    Padded lanes (group slots >= real heads-per-group) get `fill`.
+    """
+    dest.fill_(fill)
+
+    real_hpg = real_heads // o_groups                # 8
+    hpg_local = dest.shape[0] // (o_groups * head_dim)
+    start = tp_rank * hpg_local
+
+    for g in range(o_groups):
+        for j in range(hpg_local):
+            h_in_group = start + j
+            if h_in_group >= real_hpg:
+                continue  # padded head: leave at `fill`
+            src_head = g * real_hpg + h_in_group
+            dst_off = (g * hpg_local + j) * head_dim
+            src_off = src_head * head_dim
+            dest[dst_off : dst_off + head_dim].copy_(
+                src[src_off : src_off + head_dim]
+            )

--- a/patches/tp3/apply_tp3_patch.py
+++ b/patches/tp3/apply_tp3_patch.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Apply the DeepSeek-V4 TP=3 padding patch to an installed vLLM tree.
+
+Idempotent: each edit is guarded by a marker, so re-running is a no-op.
+Every edit is a NO-OP at TP=1 and TP=2 -- pad_heads_for_groups(64,2,8) == 64 --
+so applying this to a 2-node deployment changes nothing.
+
+Vendored from https://github.com/localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark (MIT).
+
+Usage:
+    python3 apply_tp3_patch.py [--vllm-root /usr/local/lib/python3.12/dist-packages/vllm]
+                               [--check]     # report status, change nothing
+                               [--revert]    # restore from .tp3bak
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import shutil
+import sys
+
+MARK = "# --- DSV4_TP3_PAD ---"
+
+PAD_MODULE = '''# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 TP padding (). Injected by apply_tp3_patch.py.
+
+R2 group semantics: pad the GROUP COUNT to a multiple of tp_size and keep
+heads_per_group CONSTANT. Groups 8 -> 9 at TP=3 => heads 64 -> 72, 3 groups and
+24 heads per rank, still 8 heads per group.
+
+*** WHY NOT R1 (replicate groups, shard heads within them) -- it was tried and
+it is STRUCTURALLY WRONG. o_proj is a per-group BMM:
+
+    fp8_einsum("bhr,hdr->bhd", o_fp8, wo_a.weight, z)
+
+`r` is a HARD CONTRACT: r == heads_per_group * head_dim, and the checkpoint
+fixes it at 4096 (= 8 heads/group * 512). Verified on the live weights:
+layers.3.attn.wo_a.weight = [8192, 4096].
+
+Stock vLLM shards the GROUPS and holds heads_per_group at 8, so r is invariant
+at 4096 for TP = 1, 2, 4, 8 -- every divisor of n_groups. R1 changes
+heads_per_group to 3 => r = 1536, and the kernel rejects it:
+
+    einsum.hpp:164: m == m_ and n == n_ and k == k_
+
+Padding wo_a to 4608 moves it FURTHER from both the activation (1536) and the
+checkpoint (4096). The only padded head count restoring hpg=8 under R1 is 192,
+3x the model. ⇒ Preserving heads_per_group is not a preference, it is the
+kernel's contract. R2 preserves it; R1 cannot.
+
+⛔ The padded 9th group is PURE PAD: its wo_a/wo_b slabs must be ZERO and its 8
+heads must carry attn_sink = -inf (exp(0)=1 would add a phantom softmax
+denominator term and attenuate the real heads).
+
+NO-OP at TP=1 and TP=2 by construction: 8 % 1 == 8 % 2 == 0, so no padding.
+"""
+import os
+
+
+def dsv4_tp_pad_enabled():
+    return os.environ.get("VLLM_DSV4_TP_PAD", "1") not in ("", "0", "false", "False")
+
+
+_MAX_LOCAL_HEADS = 128
+
+
+def pad_groups_for_tp(o_groups, tp_size):
+    """Smallest group count >= o_groups divisible by tp_size.
+
+    This is the whole technique: TP must divide n_groups, so pad n_groups.
+    8 -> 9 at TP=3. A no-op whenever tp already divides o_groups (TP=1,2,4,8).
+    """
+    if tp_size <= 1 or not o_groups or o_groups <= 0:
+        return o_groups
+    return ((o_groups + tp_size - 1) // tp_size) * tp_size
+
+
+def pad_heads_for_groups(num_heads, tp_size, o_groups):
+    """Head count implied by the padded group count, at CONSTANT heads/group.
+
+    heads_per_group is read from the REAL geometry (num_heads // o_groups) and
+    preserved exactly -- that is the kernel contract. 64 heads / 8 groups = 8
+    hpg; padded to 9 groups => 72 heads.
+    """
+    if tp_size <= 1:
+        return num_heads
+    if not o_groups or o_groups <= 0:
+        # No group structure -> plain TP divisibility.
+        return ((num_heads + tp_size - 1) // tp_size) * tp_size
+    if num_heads % o_groups != 0:
+        raise ValueError(
+            f"DSV4 TP pad: num_heads={num_heads} not divisible by "
+            f"o_groups={o_groups}; cannot infer heads_per_group"
+        )
+    hpg = num_heads // o_groups
+    padded = pad_groups_for_tp(o_groups, tp_size) * hpg
+    local = padded // tp_size
+    if local > _MAX_LOCAL_HEADS:
+        raise ValueError(
+            f"DSV4 TP pad: local heads {local} exceeds max dispatchable "
+            f"{_MAX_LOCAL_HEADS} (heads={num_heads} tp={tp_size} groups={o_groups})"
+        )
+    return padded
+
+
+def local_heads_per_group(padded_heads, tp_size, o_groups):
+    """Heads per group per rank -- INVARIANT under R2, and it must be.
+
+    Returns the same hpg the checkpoint was built with, so
+    r = hpg * head_dim matches wo_a's real input dim.
+    """
+    padded_groups = pad_groups_for_tp(o_groups, tp_size)
+    if padded_groups % tp_size != 0:
+        raise ValueError(
+            f"DSV4 TP pad: padded_groups={padded_groups} not divisible by "
+            f"tp={tp_size}"
+        )
+    if padded_heads % padded_groups != 0:
+        raise ValueError(
+            f"DSV4 TP pad: padded_heads={padded_heads} not a multiple of "
+            f"padded_groups={padded_groups}"
+        )
+    return padded_heads // padded_groups
+
+
+def real_groups(o_groups):
+    """Number of groups backed by real checkpoint data (the pad tail is above)."""
+    return o_groups
+'''
+
+# (file, anchor, replacement, description)
+EDITS = [
+    (
+        "models/deepseek_v4/attention.py",
+        """        self.n_heads = config.num_attention_heads
+        assert self.n_heads % tp_size == 0
+        self.n_local_heads = self.n_heads // tp_size""",
+        """        {MARK} head pad: 64 -> 72 at TP=3 (no-op at TP<=2)
+        from vllm.models.deepseek_v4.dsv4_tp_pad import (
+            dsv4_tp_pad_enabled, pad_heads_for_groups,
+        )
+        self.n_heads_real = config.num_attention_heads
+        if dsv4_tp_pad_enabled():
+            self.n_heads = pad_heads_for_groups(
+                config.num_attention_heads, tp_size,
+                getattr(config, "o_groups", 0),
+            )
+        else:
+            self.n_heads = config.num_attention_heads
+        assert self.n_heads % tp_size == 0
+        self.n_local_heads = self.n_heads // tp_size""",
+        "attention.py: head pad + drop hard assert",
+    ),
+    (
+        "models/deepseek_v4/attention.py",
+        """        self.n_groups = config.o_groups
+        self.n_local_groups = self.n_groups // tp_size""",
+        """        {MARK} R2: PAD the group count so tp divides it; keep heads/group.
+        # Stock code did `n_groups // tp_size` -> 8//3 == 2 SILENTLY (no assert),
+        # dropping six of eight HCA groups and producing fluent garbage.
+        #
+        # ⛔ Do NOT replicate groups and shard heads within them (the old "R1").
+        # o_proj is a per-group BMM whose `r` dim is a HARD CONTRACT:
+        #     r == heads_per_group * head_dim == 8 * 512 == 4096
+        # fixed by the checkpoint (wo_a = [8192, 4096]). R1 makes hpg 3 => r=1536
+        # and the kernel rejects it (einsum.hpp:164 m==m_ and n==n_ and k==k_).
+        # Padding wo_a to 4608 only moves it further away. ⇒ heads_per_group must
+        # be PRESERVED, which is exactly what padding the GROUP count does.
+        self.n_groups_real = config.o_groups
+        from vllm.models.deepseek_v4.dsv4_tp_pad import (
+            dsv4_tp_pad_enabled, local_heads_per_group, pad_groups_for_tp,
+        )
+        if dsv4_tp_pad_enabled():
+            self.n_groups = pad_groups_for_tp(config.o_groups, tp_size)
+        else:
+            self.n_groups = config.o_groups
+        self.n_local_groups = self.n_groups // tp_size
+        self.heads_per_group_local = local_heads_per_group(
+            self.n_heads, tp_size, self.n_groups_real
+        )
+        # The invariant that matters: hpg is UNCHANGED from the real geometry,
+        # so `r` still matches the checkpoint. If this ever trips, the BMM will
+        # fail in the kernel with a shape assert rather than silently.
+        assert self.heads_per_group_local == (
+            self.n_heads_real // self.n_groups_real
+        ), (
+            f"DSV4 R2 contract broken: hpg={self.heads_per_group_local} != "
+            f"real hpg={self.n_heads_real // self.n_groups_real} -- the o_proj "
+            f"BMM `r` dim would no longer match the checkpoint"
+        )
+        assert self.n_local_heads == self.n_local_groups * self.heads_per_group_local, (
+            f"DSV4 R2 invariant broken: n_local_heads={self.n_local_heads} != "
+            f"n_local_groups={self.n_local_groups} * hpg={self.heads_per_group_local}"
+        )""",
+        "attention.py: R2 group padding + BMM contract assert",
+    ),
+    (
+        # The config layer validates head divisibility LONG before any model
+        # class is constructed -- SpeculativeConfig hits it first. Patching only
+        # the model code is not enough: vLLM dies in arg parsing with
+        # "Total number of attention heads (64) must be divisible by tensor
+        # parallel size (3)". This is the site that actually blocks the boot.
+        "config/model.py",
+        """        total_num_attention_heads = self.model_arch_config.total_num_attention_heads
+        tensor_parallel_size = parallel_config.tensor_parallel_size
+        if total_num_attention_heads % tensor_parallel_size != 0:
+            raise ValueError(
+                f"Total number of attention heads ({total_num_attention_heads})"
+                " must be divisible by tensor parallel size "
+                f"({tensor_parallel_size})."
+            )""",
+        """        {MARK} allow a padded head count for DSv4 (heads 64->72 at TP=3).
+        total_num_attention_heads = self.model_arch_config.total_num_attention_heads
+        tensor_parallel_size = parallel_config.tensor_parallel_size
+        if total_num_attention_heads % tensor_parallel_size != 0:
+            _padded_ok = False
+            try:
+                from vllm.models.deepseek_v4.dsv4_tp_pad import (
+                    dsv4_tp_pad_enabled, pad_heads_for_groups,
+                )
+                _og = getattr(self.hf_config, "o_groups", 0)
+                if dsv4_tp_pad_enabled() and _og:
+                    _p = pad_heads_for_groups(
+                        total_num_attention_heads, tensor_parallel_size, _og
+                    )
+                    _padded_ok = (_p % tensor_parallel_size == 0)
+                    if _padded_ok:
+                        import logging
+                        logging.getLogger(__name__).info(
+                            "DSv4 TP pad: heads %d -> %d for TP=%d (o_groups=%d)",
+                            total_num_attention_heads, _p,
+                            tensor_parallel_size, _og,
+                        )
+            except Exception:
+                _padded_ok = False
+            if not _padded_ok:
+                raise ValueError(
+                    f"Total number of attention heads "
+                    f"({total_num_attention_heads})"
+                    " must be divisible by tensor parallel size "
+                    f"({tensor_parallel_size})."
+                )""",
+        "config/model.py: allow padded head count (THE boot blocker)",
+    ),
+    (
+        # The MERGED-column loader (fused gate/up). A third loader, distinct from
+        # load_column_parallel_weight -- patching that one does NOT cover this path:
+        #   RuntimeError: start (12) + length (6) exceeds dimension size (16)
+        # It narrows the CHECKPOINT by tp_rank*shard_size, which overruns on the
+        # last rank once the destination is padded. Same clamped-copy remedy.
+        "model_executor/parameter.py",
+        """        param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
+        loaded_weight = loaded_weight.narrow(
+            self.output_dim, self.tp_rank * shard_size, shard_size
+        )
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def load_qkv_weight(self, loaded_weight: torch.Tensor, **kwargs):""",
+        """        param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
+        {MARK} pad-aware merged-column load: clamp to what really exists.
+        _real = loaded_weight.shape[self.output_dim]
+        _start = self.tp_rank * shard_size
+        _avail = max(0, min(_real - _start, shard_size))
+        if _avail != shard_size:
+            param_data.zero_()
+            if _avail > 0:
+                param_data.narrow(self.output_dim, 0, _avail).copy_(
+                    loaded_weight.narrow(self.output_dim, _start, _avail)
+                )
+            return
+        loaded_weight = loaded_weight.narrow(
+            self.output_dim, self.tp_rank * shard_size, shard_size
+        )
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def load_qkv_weight(self, loaded_weight: torch.Tensor, **kwargs):""",
+        "parameter.py: pad-aware load_merged_column_weight",
+    ),
+    (
+        # Row-parallel mirror of the column loader: shards the INPUT dim instead.
+        # Same clamped-copy + zero-fill, same self-disabling property.
+        "model_executor/parameter.py",
+        """    def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
+        shard_size = self.data.shape[self.input_dim]
+        loaded_weight = loaded_weight.narrow(
+            self.input_dim, self.tp_rank * shard_size, shard_size
+        )
+
+        if len(loaded_weight.shape) == 0:
+            loaded_weight = loaded_weight.reshape(1)
+
+        assert self.data.shape == loaded_weight.shape
+        self.data.copy_(loaded_weight)""",
+        """    def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
+        {MARK} pad-aware: copy the real intersection, zero-fill any padded tail.
+        # Handles both a short SHARDED dim and any widened NON-sharded dim.
+        shard_size = self.data.shape[self.input_dim]
+        _real = loaded_weight.shape[self.input_dim]
+        # ⚠️ See the column loader: a REPLICATED param still carries the real
+        # tp_rank; offsetting by it zeroes the whole tensor on ranks 1..N-1.
+        _replicated = (shard_size == _real)
+        _start = 0 if _replicated else self.tp_rank * shard_size
+        _avail = max(0, min(_real - _start, shard_size))
+        _id_short = (_avail != shard_size or _start >= _real)
+        _other_pad = any(
+            self.data.shape[_d] != loaded_weight.shape[_d]
+            for _d in range(loaded_weight.dim())
+            if _d != self.input_dim
+        )
+        if _id_short or _other_pad:
+            self.data.zero_()
+            if _avail > 0:
+                _src = loaded_weight.narrow(self.input_dim, _start, _avail)
+                _dst = self.data.narrow(self.input_dim, 0, _avail)
+                for _d in range(_src.dim()):
+                    if _d == self.input_dim:
+                        continue
+                    _n = min(_src.shape[_d], _dst.shape[_d])
+                    _src = _src.narrow(_d, 0, _n)
+                    _dst = _dst.narrow(_d, 0, _n)
+                _dst.copy_(_src)
+            return
+        loaded_weight = loaded_weight.narrow(
+            self.input_dim, self.tp_rank * shard_size, shard_size
+        )
+
+        if len(loaded_weight.shape) == 0:
+            loaded_weight = loaded_weight.reshape(1)
+
+        assert self.data.shape == loaded_weight.shape
+        self.data.copy_(loaded_weight)""",
+        "parameter.py: pad-aware load_row_parallel_weight",
+    ),
+    (
+        # THE PAD LOADERS. Every site above changes SHAPES; this is what makes a
+        # padded parameter loadable at all.
+        #
+        # Stock: shard_size = padded_local; narrow(dim, tp_rank*shard_size, shard_size)
+        # assumes tp_rank*shard_size + shard_size <= checkpoint size. Under padding it
+        # does not (e.g. wq_b padded local 12288 rows x 3 ranks = 36864 > 32768 real),
+        # so the bare `assert self.data.shape == loaded_weight.shape` fires.
+        #
+        # Fix: copy only the intersection with what really exists, zero the rest.
+        #   dest.zero_(); dest[:n].copy_(src[start:start+n])   where n may be 0
+        # A zero pad lane is exactly inert: zero weights -> zero activation -> zero
+        # contribution through the all-reduce.
+        #
+        # ⚠️ attn_sink is NOT loaded through here (it is a bare nn.Parameter with its
+        # own loaders, sites 8-10) -- which is what keeps its pad lanes at -inf. If a
+        # future change routes it through this path, the zero_() below would silently
+        # enable phantom sinks.
+        #
+        # Self-disabling: when nothing is padded the intersection is the whole tensor
+        # and this is byte-identical to stock behaviour.
+        "model_executor/parameter.py",
+        """    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        shard_size = self.data.shape[self.output_dim]
+        loaded_weight = loaded_weight.narrow(
+            self.output_dim, self.tp_rank * shard_size, shard_size
+        )
+        assert self.data.shape == loaded_weight.shape
+        self.data.copy_(loaded_weight)""",
+        """    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        {MARK} pad-aware: copy the real intersection, zero-fill any padded tail.
+        # Padding widens TWO kinds of dim, so both must be handled:
+        #   - the SHARDED dim (output_dim) -- e.g. wq_b, where tp_rank*shard may
+        #     run past the end of the real checkpoint tensor;
+        #   - a NON-sharded dim -- e.g. wo_a's input, which widens 4096->4608 when
+        #     heads pad 64->72 and which disable_tp leaves unsharded entirely.
+        # A dim-by-dim clamped copy covers both without special-casing either.
+        shard_size = self.data.shape[self.output_dim]
+        _real = loaded_weight.shape[self.output_dim]
+        # ⚠️ A REPLICATED param (disable_tp=True, e.g. wo_a under R1) still carries
+        # the real tp_rank. Offsetting by it would push ranks 1..N-1 past the end of
+        # the checkpoint and zero the WHOLE tensor -- silently, on 2 of 3 ranks.
+        # If the param is not actually sharded on this dim, every rank loads it whole.
+        _replicated = (shard_size == _real)
+        _start = 0 if _replicated else self.tp_rank * shard_size
+        _avail = max(0, min(_real - _start, shard_size))
+        _od_short = (_avail != shard_size or _start >= _real)
+        _other_pad = any(
+            self.data.shape[_d] != loaded_weight.shape[_d]
+            for _d in range(loaded_weight.dim())
+            if _d != self.output_dim
+        )
+        if _od_short or _other_pad:
+            self.data.zero_()
+            if _avail > 0:
+                _src = loaded_weight.narrow(self.output_dim, _start, _avail)
+                _dst = self.data.narrow(self.output_dim, 0, _avail)
+                # Clamp every remaining dim to the smaller of the two.
+                for _d in range(_src.dim()):
+                    if _d == self.output_dim:
+                        continue
+                    _n = min(_src.shape[_d], _dst.shape[_d])
+                    _src = _src.narrow(_d, 0, _n)
+                    _dst = _dst.narrow(_d, 0, _n)
+                _dst.copy_(_src)
+            return
+        loaded_weight = loaded_weight.narrow(
+            self.output_dim, self.tp_rank * shard_size, shard_size
+        )
+        assert self.data.shape == loaded_weight.shape
+        self.data.copy_(loaded_weight)""",
+        "parameter.py: pad-aware load_column_parallel_weight",
+    ),
+    (
+        # moe_intermediate_size=2048 does not divide 3:
+        #   fused_moe/config.py:1314  assert self.intermediate_size % tp_size == 0
+        #
+        # This image has NO pad support (no intermediate_size_real, no pad_moe_*) --
+        # that was the MiaAI image, not this one. But it DOES carry
+        # `intermediate_size_per_partition_unpadded`, which downstream quant/backend
+        # code reads to recover the true size. So pad up to lcm(tp, 64) and record
+        # the real per-partition size there:
+        #   lcm(3,64) = 192 -> 2048 pads to 2112; 2112/3 = 704, and 704 % 64 == 0
+        #   so NVFP4's 64-alignment on the per-rank K axis still holds.
+        #
+        # The pad columns must be ZERO for correctness. Expert weight loaders
+        # narrow() to param.shape, so the padded tail is whatever the parameter was
+        # allocated with -- verify it is zero-initialised, or a garbage tail leaks
+        # into the SwiGLU product. THIS IS THE UNVERIFIED PART: see validate_tp3.sh.
+        "model_executor/layers/fused_moe/config.py",
+        """        tp_size = self.moe_parallel_config.tp_size
+        assert self.intermediate_size % tp_size == 0
+        self.intermediate_size_per_partition = self.intermediate_size // tp_size""",
+        """        tp_size = self.moe_parallel_config.tp_size
+        {MARK} pad intermediate to lcm(tp, 64) when it does not divide tp.
+        if tp_size > 1 and self.intermediate_size % tp_size != 0:
+            import math as _math
+            _lcm = _math.lcm(tp_size, 64)
+            _padded = ((self.intermediate_size + _lcm - 1) // _lcm) * _lcm
+            if self.intermediate_size_per_partition_unpadded is None:
+                self.intermediate_size_per_partition_unpadded = (
+                    self.intermediate_size // tp_size
+                )
+            self.intermediate_size = _padded
+        assert self.intermediate_size % tp_size == 0
+        self.intermediate_size_per_partition = self.intermediate_size // tp_size""",
+        "fused_moe/config.py: pad MoE intermediate to lcm(tp,64)",
+    ),
+    (
+        # n_routed_experts=256 does not divide 3, but with EP OFF this assert
+        # guards values that are DEAD on the FusedMoE path:
+        #   - fused_moe/layer.py:250 gates the real expert-count check on `use_ep`
+        #   - experts_start_idx / n_local_physical_experts are consumed only by
+        #     MegaMoE (model.py:255-257), which is SM100-gated and not our path
+        #   - experts are TP-sharded on the INTERMEDIATE dim (2048), handled elsewhere
+        #
+        # DO NOT follow the assert's own advice: num_redundant_experts=2 (-> 258)
+        # hits a DIFFERENT assert at fused_moe/layer.py:257, "Redundant experts are
+        # only supported with EPLB." The error message's remedy is not the diagnosis.
+        #
+        # So: scope it to the paths that actually consume the values.
+        "models/deepseek_v4/nvidia/model.py",
+        """        assert self.n_physical_experts % self.tp_size == 0, (
+            f"n_physical_experts={self.n_physical_experts} must be divisible by "
+            f"tp_size={self.tp_size}. Adjust num_redundant_experts."
+        )""",
+        """        {MARK} scope to MegaMoE / EP -- dead values on the FusedMoE path.
+        _experts_shard_by_count = bool(
+            getattr(self, "use_mega_moe", False)
+            or getattr(parallel_config, "enable_expert_parallel", False)
+        )
+        if _experts_shard_by_count:
+            assert self.n_physical_experts % self.tp_size == 0, (
+                f"n_physical_experts={self.n_physical_experts} must be divisible "
+                f"by tp_size={self.tp_size}. Adjust num_redundant_experts."
+            )""",
+        "model.py: scope the 256-expert assert to MegaMoE/EP",
+    ),
+    (
+        # R1 REQUIRES wo_a/wo_b to stay UNSHARDED on the group axis. Setting
+        # n_local_groups = n_groups (the R1 edit) is not enough on its own: the
+        # LAYERS still shard. ColumnParallelLinear divides out-features by tp, and
+        # n_groups*o_lora_rank = 8*1024 = 8192 is not divisible by 3:
+        #   linear.py:441  self.output_size_per_partition = divide(output_size, tp)
+        #   AssertionError: 8192 is not divisible by 3
+        # wo_b is the mirror case (RowParallelLinear divides its INPUT dim, same 8192).
+        #
+        # disable_tp=True on both makes them replicated, exactly as V4 already does
+        # for fused_wqa_wkv. That is what makes the all-reduce sum exact per-rank
+        # partials -- the property the R1 test measured at rel 2.3e-06.
+        "models/deepseek_v4/attention.py",
+        """        self.wo_a = ColumnParallelLinear(
+            self.n_heads * self.head_dim // self.n_groups,
+            self.n_groups * self.o_lora_rank,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.wo_a",
+        )
+        self.wo_a.is_bmm = True
+        self.wo_a.bmm_batch_size = self.n_local_groups
+        self.wo_b = RowParallelLinear(
+            self.n_groups * self.o_lora_rank,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.wo_b",
+        )""",
+        """        {MARK} R2: wo_a/wo_b shard NORMALLY on the padded group axis.
+        # n_groups is already PADDED (8->9 at TP=3), so n_groups*o_lora_rank =
+        # 9216 divides 3 cleanly -> 3072 per rank. No disable_tp needed; that was
+        # an R1 workaround for 8192 % 3 != 0.
+        #
+        # ⭐ The input dim uses heads_per_group * head_dim, NOT n_heads*head_dim//
+        # n_groups. They coincide only when nothing is padded. This is the o_proj
+        # BMM `r` contract -- it MUST stay 8*512 == 4096 to match the checkpoint.
+        self.wo_a = ColumnParallelLinear(
+            self.heads_per_group_local * self.head_dim,
+            self.n_groups * self.o_lora_rank,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.wo_a",
+        )
+        self.wo_a.is_bmm = True
+        self.wo_a.bmm_batch_size = self.n_local_groups
+        self.wo_b = RowParallelLinear(
+            self.n_groups * self.o_lora_rank,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.wo_b",
+        )""",
+        "attention.py: wo_a/wo_b shard on the padded group axis (R2)",
+    ),
+    (
+        # vocab_size=129280 is not divisible by 3. This image's padding_size
+        # defaults to a plain 64, so pad_vocab_size(129280, 64) == 129280 and the
+        # embedding shard dies with "129280 is not divisible by 3" AFTER all three
+        # ranks have already joined the NCCL group -- which reads as a distributed
+        # problem rather than a padding one.
+        #
+        # lcm(64, tp) keeps the existing 64-alignment AND makes it divide tp:
+        #   lcm(64,3) = 192 -> pad_vocab_size(129280, 192) = 129408; 129408/3 = 43136.
+        "model_executor/layers/vocab_parallel_embedding.py",
+        """        self.tp_size = get_tensor_model_parallel_world_size()
+        self.num_embeddings = num_embeddings
+        self.padding_size = padding_size""",
+        """        self.tp_size = get_tensor_model_parallel_world_size()
+        self.num_embeddings = num_embeddings
+        {MARK} pad vocab to lcm(padding_size, tp) so it divides TP (no-op when tp | padding_size)
+        import math as _math
+        self.padding_size = _math.lcm(padding_size, self.tp_size)""",
+        "vocab_parallel_embedding.py: pad vocab to lcm(padding_size, tp)",
+    ),
+    (
+        "models/deepseek_v4/nvidia/model.py",
+        """        n_head = self.config.num_attention_heads
+        n_local_head = n_head // tp_size
+        head_rank_start = n_local_head * tp_rank
+        head_rank_end = n_local_head * (tp_rank + 1)""",
+        """        {MARK} attn_sink window from the PADDED head count, clamped to real.
+        # Stock read raw num_attention_heads -> 64//3 == 21 -> windows
+        # [0:21][21:42][42:63]: head 63 never loads on ANY rank, silently.
+        from vllm.models.deepseek_v4.dsv4_tp_pad import pad_heads_for_groups
+        n_head = self.config.num_attention_heads
+        _n_head_padded = pad_heads_for_groups(
+            n_head, tp_size, getattr(self.config, "o_groups", 0)
+        )
+        n_local_head = _n_head_padded // tp_size
+        head_rank_start = n_local_head * tp_rank
+        head_rank_end = min(head_rank_start + n_local_head, n_head)""",
+        "model.py: attn_sink loader window",
+    ),
+]
+
+# The two other attn_sink loaders use the same idiom with a different receiver.
+SINK_VARIANTS = [
+    ("models/deepseek_v4/nvidia/mtp.py", "mtp.py: attn_sink loader window"),
+    ("models/deepseek_v4/nvidia/dspark.py", "dspark.py: attn_sink loader window"),
+]
+# Two idioms occur in the wild: `head_start/head_end` (dspark.py) and
+# `head_rank_start/head_rank_end` preceded by an `n_head = ...` line (mtp.py).
+SINK_ANCHORS = [
+    ("""        n_local_head = {recv}.num_attention_heads // tp_size
+        head_start = n_local_head * tp_rank
+        head_end = n_local_head * (tp_rank + 1)""", "head_start", "head_end"),
+    ("""        n_head = {recv}.num_attention_heads
+        n_local_head = n_head // tp_size
+        head_rank_start = n_local_head * tp_rank
+        head_rank_end = n_local_head * (tp_rank + 1)""",
+     "head_rank_start", "head_rank_end"),
+]
+
+
+def patch_file(path: pathlib.Path, anchor: str, repl: str, desc: str,
+               check: bool, version: str | None = None) -> str:
+    """Apply one edit. Idempotent and multi-occurrence safe.
+
+    Two traps this guards against, both found the hard way:
+      1. A whole-file MARK check is wrong when one file carries several edits --
+         it reports 'already patched' for edits that never applied. The guard
+         must be per-edit, so we tag each replacement with its own marker.
+      2. The same anchor text can occur in MORE THAN ONE CLASS (attention.py's
+         anchor appears in both DeepseekV4Attention and the MTP attention
+         subclass). Replacing only the first occurrence silently leaves the
+         second unpatched; replacing all of them is what we actually want.
+      3. the tag was derived from `desc` ALONE, so a change to a
+         patch BODY kept the same tag. A container whose writable layer still
+         held the OLD patch therefore reported 'already patched' and was skipped
+         forever -- the fixed loader never landed, and the only symptom was a
+         rank-2 shape assert. `docker compose` restarts (not recreates) a
+         container, so that stale layer survived every stop/start cycle.
+         The tag now carries a hash of the replacement body, so a changed body
+         yields a DIFFERENT tag: a stale patch no longer looks current, and the
+         mismatch is reported instead of silently skipped.
+    """
+    if not path.exists():
+        return f"SKIP  {desc} (file not found: {path})"
+    text = path.read_text()
+    # The version identifies WHICH revision of this edit is installed. Callers
+    # whose `repl` is composed at call time (the attn_sink variants pick one of
+    # several receiver expressions) MUST pass an explicit, stable `version` --
+    # hashing their generated body would yield a different tag per run and make
+    # an already-correct file look STALE.
+    body_hash = version or hashlib.sha256(repl.encode()).hexdigest()[:12]
+    tag = f"{MARK} [{desc}] v={body_hash}"
+    if tag in text:
+        return f"OK    {desc} (already patched)"
+    # Same edit, DIFFERENT body => a stale patch is baked into this file.
+    # Never silently skip it: the file cannot be re-anchored (the stock text is
+    # gone), so this needs a pristine file -- i.e. `docker rm -f` the container.
+    stale = f"{MARK} [{desc}]"
+    if stale in text:
+        return (f"STALE {desc} -- an OLDER version of this patch is present. "
+                f"The anchor is consumed, so this CANNOT be re-applied in place. "
+                f"Recreate the container (`docker rm -f`) to get a pristine file.")
+    n = text.count(anchor)
+    if n == 0:
+        return f"MISS  {desc} -- anchor not found, NEEDS MANUAL REVIEW"
+    if check:
+        return f"TODO  {desc} ({n} site{'s' if n > 1 else ''} found)"
+    bak = path.with_suffix(path.suffix + ".tp3bak")
+    if not bak.exists():
+        shutil.copy2(path, bak)
+    path.write_text(text.replace(anchor, repl.replace("{MARK}", tag)))
+    return f"PATCH {desc} ({n} site{'s' if n > 1 else ''})"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vllm-root",
+                    default="/usr/local/lib/python3.12/dist-packages/vllm")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--revert", action="store_true")
+    args = ap.parse_args()
+
+    root = pathlib.Path(args.vllm_root)
+    if not root.is_dir():
+        print(f"ERROR: vllm root not found: {root}", file=sys.stderr)
+        return 2
+
+    if args.revert:
+        n = 0
+        for bak in root.rglob("*.tp3bak"):
+            orig = bak.with_suffix("")
+            shutil.copy2(bak, orig)
+            bak.unlink()
+            print(f"REVERT {orig.relative_to(root)}")
+            n += 1
+        mod = root / "models/deepseek_v4/dsv4_tp_pad.py"
+        if mod.exists():
+            mod.unlink()
+            print("REVERT dsv4_tp_pad.py removed")
+        print(f"\n{n} file(s) reverted.")
+        return 0
+
+    # 1. drop the pad module next to the model code
+    mod = root / "models/deepseek_v4/dsv4_tp_pad.py"
+    if args.check:
+        print(f"{'OK   ' if mod.exists() else 'TODO '} dsv4_tp_pad.py module")
+    else:
+        mod.write_text(PAD_MODULE)
+        print("WRITE dsv4_tp_pad.py module")
+
+    results = [patch_file(root / f, a, r, d, args.check) for f, a, r, d in EDITS]
+
+    for rel, desc in SINK_VARIANTS:
+        p = root / rel
+        done = False
+        for tmpl, s_name, e_name in SINK_ANCHORS:
+            for recv in ("self.config", "config", "self.model_config.hf_config"):
+                anchor = tmpl.format(recv=recv)
+                repl = (
+                    "        {MARK} attn_sink window from PADDED head count.\n"
+                    "        from vllm.models.deepseek_v4.dsv4_tp_pad import "
+                    "pad_heads_for_groups\n"
+                    f"        n_head = {recv}.num_attention_heads\n"
+                    f"        _padded = pad_heads_for_groups(n_head, tp_size, "
+                    f"getattr({recv}, 'o_groups', 0))\n"
+                    "        n_local_head = _padded // tp_size\n"
+                    f"        {s_name} = n_local_head * tp_rank\n"
+                    f"        {e_name} = min({s_name} + n_local_head, n_head)"
+                )
+                # Stable version: this edit's body varies by receiver, so bump
+                # this string by hand when the attn_sink logic itself changes.
+                out = patch_file(p, anchor, repl, desc, args.check,
+                                 version="sink1")
+                if not out.startswith("MISS"):
+                    results.append(out)
+                    done = True
+                    break
+            if done:
+                break
+        if not done:
+            results.append(f"MISS  {desc} -- anchor not found, NEEDS MANUAL REVIEW")
+
+    for r in results:
+        print(r)
+
+    misses = [r for r in results if r.startswith("MISS")]
+    if misses:
+        print(f"\n{len(misses)} anchor(s) not found. Do NOT boot TP=3 until resolved -- "
+              "an unpatched attn_sink loader fails SILENTLY.", file=sys.stderr)
+        return 1
+    # a STALE edit is a HARD failure, never a warning. It means an
+    # older patch body is baked into the file (a reused container writable layer),
+    # so the running code is NOT the code in this repo. Exiting 0 here is what let
+    # a buggy loader boot three times while every log line read "OK".
+    stales = [r for r in results if r.startswith("STALE")]
+    if stales:
+        print(f"\n{len(stales)} edit(s) present at an OLDER version. The container is "
+              "reusing a writable layer that already holds a previous patch.\n"
+              "Fix: `docker rm -f <container>` on EVERY node, then start again -- a "
+              "compose restart REUSES the layer and will not clear this.",
+              file=sys.stderr)
+        return 1
+    print("\nAll edits applied." if not args.check else "\nCheck complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prepare-dspark-model-cache.sh
+++ b/prepare-dspark-model-cache.sh
@@ -353,5 +353,18 @@ if [ "${PREPARE_WORKER:-1}" = "1" ]; then
     scp "$SCRIPT_DIR/prepare-dspark-model-cache.sh" "${WORKER_HOST}:${WORKER_DIR}/prepare-dspark-model-cache.sh"
     scp "$ENV_FILE" "${WORKER_HOST}:${WORKER_DIR}/.env.dspark"
     ssh "$WORKER_HOST" "cd '$WORKER_DIR' && chmod +x ./prepare-dspark-model-cache.sh && env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS ENV_FILE='.env.dspark' THIS_NODE_HF_CACHE='$WORKER_HF_CACHE' PREPARE_WORKER=0 ABLITERATED='$ABLITERATED' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_REVISION_ABLITERATED='${DSPARK_REVISION_ABLITERATED:-}' ${WORKER_HF_TOKEN_ENV} ./prepare-dspark-model-cache.sh --yes"
+    if [ -n "${WORKER2_HOST:-}" ]; then
+      WORKER2_DIR="${WORKER2_SCRIPT_DIR:-${WORKER2_DIR:-$WORKER_DIR}}"
+      WORKER2_HF_CACHE="${WORKER2_HF_CACHE:-$WORKER_HF_CACHE}"
+      echo "prepare: also downloading onto worker2 $WORKER2_HOST → $WORKER2_HF_CACHE"
+      ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER2_HOST" "docker image inspect '$DSPARK_VLLM_IMAGE' >/dev/null" || {
+        echo "Missing worker2 Docker image $DSPARK_VLLM_IMAGE." >&2
+        exit 1
+      }
+      ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER2_HOST" "mkdir -p '$WORKER2_DIR' '$WORKER2_HF_CACHE'"
+      scp "$SCRIPT_DIR/prepare-dspark-model-cache.sh" "${WORKER2_HOST}:${WORKER2_DIR}/prepare-dspark-model-cache.sh"
+      scp "$ENV_FILE" "${WORKER2_HOST}:${WORKER2_DIR}/.env.dspark"
+      ssh "$WORKER2_HOST" "cd '$WORKER2_DIR' && chmod +x ./prepare-dspark-model-cache.sh && env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS ENV_FILE='.env.dspark' THIS_NODE_HF_CACHE='$WORKER2_HF_CACHE' PREPARE_WORKER=0 ABLITERATED='$ABLITERATED' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_REVISION_ABLITERATED='${DSPARK_REVISION_ABLITERATED:-}' ${WORKER_HF_TOKEN_ENV} ./prepare-dspark-model-cache.sh --yes"
+    fi
   fi
 fi

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -13,6 +13,7 @@ bad() { printf '  FAIL %s\n' "$*" >&2; fail=1; }
 echo "== shell syntax =="
 for f in \
   start-deepseek-v4-flash-dspark.sh \
+  start-tp3.sh \
   stop-deepseek-v4-flash-dspark.sh \
   validate-dspark-config.sh \
   prepare-dspark-model-cache.sh \
@@ -28,6 +29,7 @@ for f in \
   scripts/test-nccl-ib-hca-gid-resolve.sh \
   scripts/boot-shape-warmup.sh \
   scripts/test-boot-shape-warmup.sh \
+  scripts/validate_tp3.sh \
   lmcache/run-lmcache-server.sh \
   scripts/test-lmcache-compose-gate.sh \
   patches/*.sh
@@ -304,9 +306,9 @@ if grep -Fq 'hotfix-vllm-issue138-responses-history.py}:/opt/hotfix-vllm-issue13
   && grep -Fq '# Issue #138 Responses history compatibility pre-flight (begin).' start-deepseek-v4-flash-dspark.sh \
   && grep -Fq 'issue138 Responses history compatibility: 0 (stock)' start-deepseek-v4-flash-dspark.sh \
   && grep -Fq 'issue138 Responses history compatibility: 1 (apply)' start-deepseek-v4-flash-dspark.sh \
-  && [ "$issue138_worker_count" -eq 2 ] \
+  && [ "$issue138_worker_count" -eq 4 ] \
   && grep -Fq 'scp "$DSPARK_ISSUE138_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-vllm-issue138-responses-history.py"' start-deepseek-v4-flash-dspark.sh; then
-  ok "issue138 hotfix is default-off, exact-1 fail-closed, preflighted, reported, and propagated to both ranks"
+  ok "issue138 hotfix is default-off, exact-1 fail-closed, preflighted, reported, and propagated to worker1 and worker2"
 else
   bad "issue138 Responses history hotfix wiring is incomplete"
 fi
@@ -375,6 +377,40 @@ if grep -Fq 'bash /opt/dspark-patches/hotfix-vllm-redact-api-key-log.sh || exit 
   ok "compose redaction gate is fail-closed and worker sync retains the patch"
 else
   bad "redact-api-key-log must apply + verify outside the optional loop and remain in worker sync"
+fi
+
+# Optional TP=3: pad only at TP_SIZE=3; default start still forces two nodes.
+if [ -f start-tp3.sh ] && grep -Fq 'export DSPARK_TP3=1' start-tp3.sh \
+  && grep -Fq 'exec "$SCRIPT_DIR/start-deepseek-v4-flash-dspark.sh"' start-tp3.sh \
+  && grep -Fq -- '--max-num-seqs' start-tp3.sh; then
+  ok "start-tp3.sh is an opt-in exec wrapper with --max-num-seqs"
+else
+  bad "start-tp3.sh must exec the 2-node start with DSPARK_TP3=1 and --max-num-seqs"
+fi
+
+if grep -Fq 'DSPARK_TP3="${DSPARK_TP3:-0}"' start-deepseek-v4-flash-dspark.sh \
+  && grep -Fq 'TP_SIZE=2' start-deepseek-v4-flash-dspark.sh \
+  && grep -Fq 'NNODES=2' start-deepseek-v4-flash-dspark.sh \
+  && grep -Fq ': "${WORKER2_HOST:?WORKER2_HOST must be set' start-deepseek-v4-flash-dspark.sh; then
+  ok "2-node start forces TP=2/NNODES=2; TP=3 requires WORKER2_HOST"
+else
+  bad "start-deepseek-v4-flash-dspark.sh must force TP=2 unless DSPARK_TP3=1"
+fi
+
+if grep -Fq 'if [ "${TP_SIZE:-2}" = "3" ]; then' docker-compose.dspark.yml \
+  && grep -Fq 'python3 /opt/dsv4-tp3/apply_tp3_patch.py' docker-compose.dspark.yml \
+  && grep -Fq -- '--tensor-parallel-size ${TP_SIZE:-2}' docker-compose.dspark.yml \
+  && grep -Fq -- '--nnodes ${NNODES:-2}' docker-compose.dspark.yml \
+  && grep -Fq '/opt/dsv4-tp3:ro' docker-compose.dspark.yml; then
+  ok "compose interpolates TP_SIZE/NNODES and gates the TP=3 pad"
+else
+  bad "compose must interpolate TP_SIZE/NNODES and apply the pad only at TP_SIZE=3"
+fi
+
+if [ -f patches/tp3/apply_tp3_patch.py ] && [ -f patches/dsv4_tp_pad.py ] && [ -f scripts/validate_tp3.sh ]; then
+  ok "TP=3 pad + validate_tp3.sh present"
+else
+  bad "missing patches/tp3/apply_tp3_patch.py, patches/dsv4_tp_pad.py, or scripts/validate_tp3.sh"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/test-nccl-fabric-passthrough.sh
+++ b/scripts/test-nccl-fabric-passthrough.sh
@@ -26,7 +26,7 @@ COMPOSE="$ROOT/docker-compose.dspark.yml"
 QUIET=0
 [ "${1:-}" = "-q" ] && QUIET=1
 
-KNOBS=(NCCL_IB_MERGE_NICS NCCL_NET_GDR_LEVEL NCCL_NET_GDR_READ NCCL_DMABUF_ENABLE NCCL_IB_GID_INDEX)
+KNOBS=(NCCL_IB_MERGE_NICS NCCL_IB_SUBNET_AWARE_ROUTING NCCL_IB_SUBNET_PREFIX_LEN NCCL_NET_GDR_LEVEL NCCL_NET_GDR_READ NCCL_DMABUF_ENABLE NCCL_IB_GID_INDEX)
 
 pass=0
 fail=0
@@ -36,8 +36,8 @@ bad() { fail=$((fail + 1)); printf '  FAIL %s\n' "$*" >&2; }
 
 # Extract the shipped normalization block (entrypoint text uses $$ for $).
 fragment="$(sed -n '/if \[ -z "\$\${NCCL_IB_MERGE_NICS/,/unset NCCL_IB_GID_INDEX; fi;$/p' "$COMPOSE" | sed 's/\$\$/$/g')"
-if [ "$(printf '%s\n' "$fragment" | grep -c 'unset NCCL_')" -ne 5 ]; then
-  echo "FAIL could not extract the 5-knob unset normalization from $COMPOSE" >&2
+if [ "$(printf '%s\n' "$fragment" | grep -c 'unset NCCL_')" -ne 7 ]; then
+  echo "FAIL could not extract the 7-knob unset normalization from $COMPOSE" >&2
   exit 1
 fi
 
@@ -54,7 +54,7 @@ trap 'rm -rf "$tmp"' EXIT
 # Direction 1: empty is normalized to absent. Defined-but-empty is exactly what
 # compose injects when .env leaves the knob unconfigured; it must end up unset,
 # never forwarded as an empty setting.
-out="$(env NCCL_IB_MERGE_NICS='' NCCL_NET_GDR_LEVEL='' NCCL_NET_GDR_READ='' NCCL_DMABUF_ENABLE='' NCCL_IB_GID_INDEX='' bash "$tmp/fragment.sh")"
+out="$(env NCCL_IB_MERGE_NICS='' NCCL_IB_SUBNET_AWARE_ROUTING='' NCCL_IB_SUBNET_PREFIX_LEN='' NCCL_NET_GDR_LEVEL='' NCCL_NET_GDR_READ='' NCCL_DMABUF_ENABLE='' NCCL_IB_GID_INDEX='' bash "$tmp/fragment.sh")"
 want="$(printf '%s absent\n' "${KNOBS[@]}")"
 if [ "$out" = "$want" ]; then
   ok "empty is normalized to absent (defined-empty from compose becomes truly unset)"
@@ -63,8 +63,8 @@ else
 fi
 
 # Direction 2: configured non-empty values pass through byte-identical.
-out="$(env NCCL_IB_MERGE_NICS='0' NCCL_NET_GDR_LEVEL='SYS' NCCL_NET_GDR_READ='1' NCCL_DMABUF_ENABLE='0' NCCL_IB_GID_INDEX='3' bash "$tmp/fragment.sh")"
-want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS=0' 'NCCL_NET_GDR_LEVEL=SYS' 'NCCL_NET_GDR_READ=1' 'NCCL_DMABUF_ENABLE=0' 'NCCL_IB_GID_INDEX=3')"
+out="$(env NCCL_IB_MERGE_NICS='0' NCCL_IB_SUBNET_AWARE_ROUTING='1' NCCL_IB_SUBNET_PREFIX_LEN='24' NCCL_NET_GDR_LEVEL='SYS' NCCL_NET_GDR_READ='1' NCCL_DMABUF_ENABLE='0' NCCL_IB_GID_INDEX='3' bash "$tmp/fragment.sh")"
+want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS=0' 'NCCL_IB_SUBNET_AWARE_ROUTING=1' 'NCCL_IB_SUBNET_PREFIX_LEN=24' 'NCCL_NET_GDR_LEVEL=SYS' 'NCCL_NET_GDR_READ=1' 'NCCL_DMABUF_ENABLE=0' 'NCCL_IB_GID_INDEX=3')"
 if [ "$out" = "$want" ]; then
   ok "configured non-empty values pass through unchanged"
 else
@@ -74,17 +74,17 @@ fi
 # Contract boundary: only *empty* is normalized. A value that is non-empty but
 # unusual (whitespace, punctuation, mixed case) is still a configured value and
 # must reach NCCL byte-identical rather than being trimmed or dropped.
-out="$(env NCCL_IB_MERGE_NICS=' ' NCCL_NET_GDR_LEVEL='PHB ' NCCL_NET_GDR_READ='0' NCCL_DMABUF_ENABLE='Yes' NCCL_IB_GID_INDEX=' ' bash "$tmp/fragment.sh")"
-want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS= ' 'NCCL_NET_GDR_LEVEL=PHB ' 'NCCL_NET_GDR_READ=0' 'NCCL_DMABUF_ENABLE=Yes' 'NCCL_IB_GID_INDEX= ')"
+out="$(env NCCL_IB_MERGE_NICS=' ' NCCL_IB_SUBNET_AWARE_ROUTING='1' NCCL_IB_SUBNET_PREFIX_LEN='24' NCCL_NET_GDR_LEVEL='PHB ' NCCL_NET_GDR_READ='0' NCCL_DMABUF_ENABLE='Yes' NCCL_IB_GID_INDEX=' ' bash "$tmp/fragment.sh")"
+want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS= ' 'NCCL_IB_SUBNET_AWARE_ROUTING=1' 'NCCL_IB_SUBNET_PREFIX_LEN=24' 'NCCL_NET_GDR_LEVEL=PHB ' 'NCCL_NET_GDR_READ=0' 'NCCL_DMABUF_ENABLE=Yes' 'NCCL_IB_GID_INDEX= ')"
 if [ "$out" = "$want" ]; then
   ok "non-empty boundary values (whitespace/case preserved) pass through unchanged"
 else
   bad "non-empty boundary values altered: $out"
 fi
 
-# Mixed: one configured, four unconfigured.
-out="$(env NCCL_IB_MERGE_NICS='' NCCL_NET_GDR_LEVEL='LOC' NCCL_NET_GDR_READ='' NCCL_DMABUF_ENABLE='' NCCL_IB_GID_INDEX='' bash "$tmp/fragment.sh")"
-want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS absent' 'NCCL_NET_GDR_LEVEL=LOC' 'NCCL_NET_GDR_READ absent' 'NCCL_DMABUF_ENABLE absent' 'NCCL_IB_GID_INDEX absent')"
+# Mixed: one configured, six unconfigured.
+out="$(env NCCL_IB_MERGE_NICS='' NCCL_IB_SUBNET_AWARE_ROUTING='' NCCL_IB_SUBNET_PREFIX_LEN='' NCCL_NET_GDR_LEVEL='LOC' NCCL_NET_GDR_READ='' NCCL_DMABUF_ENABLE='' NCCL_IB_GID_INDEX='' bash "$tmp/fragment.sh")"
+want="$(printf '%s\n' 'NCCL_IB_MERGE_NICS absent' 'NCCL_IB_SUBNET_AWARE_ROUTING absent' 'NCCL_IB_SUBNET_PREFIX_LEN absent' 'NCCL_NET_GDR_LEVEL=LOC' 'NCCL_NET_GDR_READ absent' 'NCCL_DMABUF_ENABLE absent' 'NCCL_IB_GID_INDEX absent')"
 if [ "$out" = "$want" ]; then
   ok "mixed configuration: set stays set, unset stays absent"
 else
@@ -99,7 +99,7 @@ for k in "${KNOBS[@]}"; do
   grep -Fq "$k: \"\${$k:-}\"" "$COMPOSE" || wiring_missing="$wiring_missing $k"
 done
 if [ -z "$wiring_missing" ]; then
-  ok "compose declares all five knobs in the environment map"
+  ok "compose declares all seven knobs in the environment map"
 else
   bad "compose environment map missing:$wiring_missing"
 fi

--- a/scripts/test-python-hotfix-failclosed.py
+++ b/scripts/test-python-hotfix-failclosed.py
@@ -303,11 +303,15 @@ class PythonHotfixFailClosedTest(unittest.TestCase):
             "DSPARK_ISSUE138_HOTFIX='./patches/"
             "hotfix-vllm-issue138-responses-history.py'"
         )
-        self.assertEqual(source.count(worker_env), 2)
+        self.assertEqual(source.count(worker_env), 4)
         self.assertIn(
             'scp "$DSPARK_ISSUE138_HOTFIX" "${WORKER_HOST}:'
             '${REMOTE_WORKER_DIR}/patches/'
             'hotfix-vllm-issue138-responses-history.py"',
+            source,
+        )
+        self.assertIn(
+            "NODE_RANK=2 HEADLESS=1 $WORKER2_HF_COMPOSE_ENV",
             source,
         )
 

--- a/scripts/validate_tp3.sh
+++ b/scripts/validate_tp3.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Validate a TP=3 DeepSeek-V4-Flash deployment.
+#
+# "It started" is NOT evidence of correctness. A wrong o_groups shard produces
+# fluent, plausible text with no error anywhere -- that is the entire hazard
+# this patch exists to avoid. So this checks reasoning that a subtly-broken
+# attention would fail, not just that tokens come out.
+#
+# Usage: validate_tp3.sh [host:port]        (default 127.0.0.1:8888)
+#
+set -uo pipefail
+
+EP="${1:-127.0.0.1:8888}"
+BASE="http://$EP"
+pass=0; fail=0
+
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail+1)); }
+info() { printf '  ---- %s\n' "$1"; }
+
+echo "=== 1. server up + model identity ==="
+models="$(curl -s -m 20 "$BASE/v1/models" 2>/dev/null)"
+if [[ -z "$models" ]]; then
+  bad "no response from $BASE/v1/models"
+  echo; echo "Server is not answering. Nothing else can be validated."; exit 1
+fi
+mid="$(printf '%s' "$models" | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null)"
+[[ -n "$mid" ]] && ok "serving: $mid" || bad "could not parse model id"
+
+ask() {  # $1=prompt  $2=max_tokens
+  curl -s -m 180 "$BASE/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d "$(python3 -c '
+import json,sys
+print(json.dumps({"model":sys.argv[1],"messages":[{"role":"user","content":sys.argv[2]}],
+                  "max_tokens":int(sys.argv[3]),"temperature":0,
+                  "chat_template_kwargs":{"thinking":False}}))' "$mid" "$1" "${2:-64}")" \
+  | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    m=d["choices"][0]["message"]
+    t=(m.get("content") or m.get("reasoning_content") or m.get("reasoning") or "")
+    print(t.strip())
+except Exception as e:
+    print(f"__ERROR__ {e}")' 2>/dev/null
+}
+
+echo
+echo "=== 2. deterministic factual recall ==="
+# Degenerate attention usually survives token-level fluency but loses precise
+# recall first. These have exactly one right answer.
+for probe in "What is the capital of Japan?|Tokyo" \
+             "What is 17 multiplied by 23? Reply with only the number.|391" \
+             "Complete exactly: The quick brown fox jumps over the lazy|dog"; do
+  q="${probe%%|*}"; want="${probe##*|}"
+  a="$(ask "$q" 32)"
+  if [[ "$a" == __ERROR__* ]]; then bad "request failed: $q ($a)"
+  elif grep -qi -- "$want" <<<"$a"; then ok "$q -> $(head -c 60 <<<"$a")"
+  else bad "$q -> expected '$want', got: $(head -c 90 <<<"$a")"; fi
+done
+
+echo
+echo "=== 3. multi-step reasoning (fails first under a bad shard) ==="
+a="$(ask 'A shelf holds 3 red books and 5 blue books. I remove 2 blue books, then add 4 red books. How many red and how many blue remain? Answer in the form: red=N blue=N' 96)"
+if [[ "$a" == __ERROR__* ]]; then bad "reasoning request failed ($a)"
+elif grep -qE 'red=7' <<<"$a" && grep -qE 'blue=3' <<<"$a"; then ok "arithmetic reasoning: $(head -c 70 <<<"$a")"
+else bad "expected red=7 blue=3, got: $(head -c 120 <<<"$a")"; fi
+
+echo
+echo "=== 4. long-range coherence (attention over distance) ==="
+needle="The passphrase is CRIMSON-MERIDIAN-42."
+filler="$(python3 -c 'print(" ".join(["The weather report for that day was unremarkable."]*120))')"
+a="$(ask "$needle $filler What exactly is the passphrase? Reply with only the passphrase." 32)"
+if [[ "$a" == __ERROR__* ]]; then bad "needle test failed ($a)"
+elif grep -qi 'CRIMSON-MERIDIAN-42' <<<"$a"; then ok "recalled the needle across ~1.5k tokens"
+else bad "lost the needle -> $(head -c 90 <<<"$a")"; fi
+
+echo
+echo "=== 5. degeneration check (repetition / gibberish) ==="
+a="$(ask 'Write two sentences about the ocean.' 80)"
+if [[ "$a" == __ERROR__* ]]; then bad "generation failed ($a)"
+else
+  words=$(wc -w <<<"$a"); uniq=$(tr ' ' '\n' <<<"$a" | sort -u | wc -l)
+  ratio=$(python3 -c "print(round($uniq/max($words,1),2))")
+  info "words=$words unique=$uniq ratio=$ratio"
+  # Degenerate output loops: unique/total collapses well below ~0.5.
+  python3 -c "import sys; sys.exit(0 if $ratio >= 0.5 else 1)" \
+    && ok "no degeneration (unique-word ratio $ratio)" \
+    || bad "possible degeneration, ratio $ratio: $(head -c 100 <<<"$a")"
+fi
+
+echo
+echo "==============================================="
+printf '  %d passed, %d failed\n' "$pass" "$fail"
+if (( fail )); then
+  echo "  ⚠️  DO NOT TRUST THIS DEPLOYMENT until these are explained."
+  echo "     A wrong o_groups shard is silent -- fluent output is not proof."
+  exit 1
+fi
+echo "  All checks passed."

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -22,6 +22,7 @@ Options:
   --port PORT  vLLM API listen port (default: VLLM_PORT or 8888)
   -h, --help   Show this help message
 
+Two-node TP=2 is the default. Three nodes: ./start-tp3.sh (see docs/TP3.md).
 Command-line options override values from $ENV_FILE.
 EOF
 }
@@ -111,6 +112,17 @@ COMPOSE_ENV_FILE="$_dspark_env_clean"
 # the profile stays in one place.
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION_TEXT:-0.835}"
 export GPU_MEMORY_UTILIZATION
+
+# TP=3 concurrent slots: CLI (./start-tp3.sh --max-num-seqs) beats
+# TP3_MAX_NUM_SEQS in .env.dspark; both leave the 2-node MAX_NUM_SEQS alone.
+if [ "${DSPARK_TP3:-0}" = "1" ]; then
+  if [ -n "${_START_TP3_MAX_NUM_SEQS:-}" ]; then
+    MAX_NUM_SEQS="$_START_TP3_MAX_NUM_SEQS"
+  elif [ -n "${TP3_MAX_NUM_SEQS:-}" ]; then
+    MAX_NUM_SEQS="$TP3_MAX_NUM_SEQS"
+  fi
+  export MAX_NUM_SEQS
+fi
 
 # Checkpoint flag: official Vision-Exp vs Keys abliterated weights.
 #   ABLITERATED=0 → DSPARK_MODEL_OFFICIAL
@@ -291,6 +303,18 @@ export DSPARK_ISSUE136_XGRAMMAR_HOTFIX DSPARK_ENABLE_ISSUE136_XGRAMMAR_HOTFIX
 : "${NCCL_SOCKET_IFNAME:?NCCL_SOCKET_IFNAME must be set in $ENV_FILE}"
 : "${DSPARK_VLLM_IMAGE:?DSPARK_VLLM_IMAGE must be set in $ENV_FILE}"
 
+# ./start-tp3.sh sets DSPARK_TP3=1. Ignore TP_SIZE/NNODES from .env on the
+# two-node path so a copied 3-node snippet cannot boot nnodes=3 with one worker.
+DSPARK_TP3="${DSPARK_TP3:-0}"
+if [ "$DSPARK_TP3" = "1" ]; then
+  TP_SIZE=3
+  NNODES=3
+else
+  TP_SIZE=2
+  NNODES=2
+fi
+export TP_SIZE NNODES DSPARK_TP3
+
 VLLM_HOST_IP="${VLLM_HOST_IP:-$MASTER_ADDR}"
 WORKER_VLLM_HOST_IP="${WORKER_VLLM_HOST_IP:-$WORKER_HOST}"
 WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
@@ -309,6 +333,29 @@ WORKER_NCCL_IB_HCA="${WORKER_NCCL_IB_HCA:-$NCCL_IB_HCA}"
 WORKER_NCCL_SOCKET_IFNAME="${WORKER_NCCL_SOCKET_IFNAME:-$NCCL_SOCKET_IFNAME}"
 WORKER_TP_SOCKET_IFNAME="${WORKER_TP_SOCKET_IFNAME:-${TP_SOCKET_IFNAME:-$WORKER_NCCL_SOCKET_IFNAME}}"
 WORKER_GLOO_SOCKET_IFNAME="${WORKER_GLOO_SOCKET_IFNAME:-${GLOO_SOCKET_IFNAME:-$WORKER_NCCL_SOCKET_IFNAME}}"
+WORKER2_HOST="${WORKER2_HOST:-}"
+WORKER2_VLLM_HOST_IP="${WORKER2_VLLM_HOST_IP:-$WORKER2_HOST}"
+WORKER2_DIR="${WORKER2_SCRIPT_DIR:-${WORKER2_DIR:-$WORKER_DIR}}"
+WORKER2_HF_CACHE="${WORKER2_HF_CACHE:-${WORKER_HF_CACHE:-}}"
+WORKER2_NCCL_IB_HCA="${WORKER2_NCCL_IB_HCA:-$WORKER_NCCL_IB_HCA}"
+WORKER2_NCCL_SOCKET_IFNAME="${WORKER2_NCCL_SOCKET_IFNAME:-$WORKER_NCCL_SOCKET_IFNAME}"
+WORKER2_TP_SOCKET_IFNAME="${WORKER2_TP_SOCKET_IFNAME:-${WORKER_TP_SOCKET_IFNAME}}"
+WORKER2_GLOO_SOCKET_IFNAME="${WORKER2_GLOO_SOCKET_IFNAME:-${WORKER_GLOO_SOCKET_IFNAME}}"
+WORKER2_NCCL_IB_GID_MATCH_IP="${WORKER2_NCCL_IB_GID_MATCH_IP:-}"
+ENV_WORKER2_NCCL_IB_GID_INDEX="${WORKER2_NCCL_IB_GID_INDEX:-}"
+WORKER2_NCCL_IB_GID_INDEX="${ENV_WORKER2_NCCL_IB_GID_INDEX}"
+if [ "$DSPARK_TP3" = "1" ]; then
+  : "${WORKER2_HOST:?WORKER2_HOST must be set in $ENV_FILE for ./start-tp3.sh}"
+  if [ ! -f "$SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" ]; then
+    echo "Missing TP=3 patcher: $SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" >&2
+    exit 1
+  fi
+  REMOTE_WORKER2_DIR="$(printf '%q' "$WORKER2_DIR")"
+  REMOTE_COMPOSE2="cd $REMOTE_WORKER2_DIR && env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS COMPOSE_DISABLE_ENV_FILE=1"
+  REMOTE_COMPOSE_FILE2="$REMOTE_WORKER2_DIR/docker-compose.dspark.yml"
+  REMOTE_ENV_FILE2="$REMOTE_WORKER2_DIR/.env.dspark"
+  REMOTE_VLLM_GB10_PATCH_DIR2="$REMOTE_WORKER2_DIR/vllm_patch_gb10"
+fi
 # RoCEv2 GID index differs per node/HCA and drifts after reboot/link events.
 # Default (NCCL_IB_GID_AUTO=1): validate every selected HCA/port from sysfs,
 # then leave NCCL_IB_GID_INDEX unset on both ranks — a pin is one global value
@@ -351,6 +398,8 @@ host_without_user() {
 
 WORKER_COMPOSE_FILES="-f docker-compose.dspark.yml"
 WORKER_HF_COMPOSE_ENV="HF_CACHE='$WORKER_HF_CACHE'"
+WORKER2_COMPOSE_FILES="-f docker-compose.dspark.yml"
+WORKER2_HF_COMPOSE_ENV="HF_CACHE='$WORKER2_HF_CACHE'"
 if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
   IFACE="${NFS_IFACE:-$NCCL_SOCKET_IFNAME}"
   HF_CACHE_DIR="${HF_CACHE:-$HOME/.cache/huggingface}"
@@ -361,6 +410,11 @@ if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
   WORKER_COMPOSE_FILES="-f docker-compose.dspark.yml -f docker-compose.dspark-nfs.override.yml"
   WORKER_HF_COMPOSE_ENV="HF_CACHE='$NFS_VOLUME' DSPARK_JIT_CACHE='$WORKER_HF_CACHE'"
   REMOTE_NFS_OVERRIDE_FILE="$REMOTE_WORKER_DIR/docker-compose.dspark-nfs.override.yml"
+  if [ "$DSPARK_TP3" = "1" ]; then
+    WORKER2_COMPOSE_FILES="-f docker-compose.dspark.yml -f docker-compose.dspark-nfs.override.yml"
+    WORKER2_HF_COMPOSE_ENV="HF_CACHE='$NFS_VOLUME' DSPARK_JIT_CACHE='$WORKER2_HF_CACHE'"
+    REMOTE_NFS_OVERRIDE_FILE2="$REMOTE_WORKER2_DIR/docker-compose.dspark-nfs.override.yml"
+  fi
 fi
 
 ipv4_to_gid_suffix() {
@@ -676,7 +730,18 @@ resolve_nccl_gid_indexes() {
       echo "NCCL_IB_GID_AUTO=0 requires NCCL_IB_GID_INDEX and preferably WORKER_NCCL_IB_GID_INDEX in $ENV_FILE." >&2
       exit 1
     fi
-    echo "Using pinned NCCL GID indexes (auto off): head=$NCCL_IB_GID_INDEX worker=$WORKER_NCCL_IB_GID_INDEX"
+    if [ "${DSPARK_TP3:-0}" = "1" ]; then
+      WORKER2_NCCL_IB_GID_INDEX="${ENV_WORKER2_NCCL_IB_GID_INDEX:-$WORKER_NCCL_IB_GID_INDEX}"
+      if [ -z "$WORKER2_NCCL_IB_GID_INDEX" ]; then
+        echo "NCCL_IB_GID_AUTO=0 requires WORKER2_NCCL_IB_GID_INDEX (or WORKER_NCCL_IB_GID_INDEX) in $ENV_FILE." >&2
+        exit 1
+      fi
+    fi
+    if [ "${DSPARK_TP3:-0}" = "1" ]; then
+      echo "Using pinned NCCL GID indexes (auto off): head=$NCCL_IB_GID_INDEX worker=$WORKER_NCCL_IB_GID_INDEX worker2=$WORKER2_NCCL_IB_GID_INDEX"
+    else
+      echo "Using pinned NCCL GID indexes (auto off): head=$NCCL_IB_GID_INDEX worker=$WORKER_NCCL_IB_GID_INDEX"
+    fi
     return 0
   fi
 
@@ -711,6 +776,25 @@ resolve_nccl_gid_indexes() {
   NCCL_IB_GID_INDEX=""
   WORKER_NCCL_IB_GID_INDEX=""
   echo "RoCEv2 GIDs validated on both ranks; NCCL_IB_GID_INDEX left unset so NCCL selects the RoCEv2/IPv4 GID per HCA."
+
+  if [ "${DSPARK_TP3:-0}" = "1" ]; then
+    local worker2_match
+    worker2_match="$(pick_gid_match_ip "$WORKER2_HOST" "$WORKER2_NCCL_SOCKET_IFNAME" "$WORKER2_NCCL_IB_GID_MATCH_IP" "$WORKER2_VLLM_HOST_IP" "$WORKER2_HOST")" || {
+      echo "FATAL: could not determine worker2 RoCE IPv4 for GID match (if=$WORKER2_NCCL_SOCKET_IFNAME)." >&2
+      exit 1
+    }
+    echo "Validating RoCEv2 GIDs for worker2 (if=$WORKER2_NCCL_SOCKET_IFNAME ip=$worker2_match selector=$WORKER2_NCCL_IB_HCA)..."
+    resolve_rocev2_gid_index "$WORKER2_HOST" "$WORKER2_NCCL_IB_HCA" "$worker2_match" || {
+      echo "FATAL: could not validate worker2 RoCEv2 GIDs (WORKER2_NCCL_IB_HCA=$WORKER2_NCCL_IB_HCA, match $worker2_match)." >&2
+      echo "Check on worker2: ibstat ; show_gids" >&2
+      exit 1
+    }
+    if [ -n "${ENV_WORKER2_NCCL_IB_GID_INDEX:-}" ]; then
+      echo "Note: ignoring WORKER2_NCCL_IB_GID_INDEX=$ENV_WORKER2_NCCL_IB_GID_INDEX from $ENV_FILE (NCCL_IB_GID_AUTO=1 leaves GID selection to NCCL per HCA)."
+    fi
+    WORKER2_NCCL_IB_GID_INDEX=""
+    echo "RoCEv2 GIDs validated on worker2; NCCL_IB_GID_INDEX left unset."
+  fi
 }
 
 remote_nccl_env() {
@@ -720,12 +804,15 @@ remote_nccl_env() {
   # compose interpolation, and the shared entrypoint normalization makes the
   # defined-empty variable truly absent in the container (NCCL would parse a
   # defined-empty value as GID index 0).
-  printf "NCCL_IB_HCA='%s' NCCL_SOCKET_IFNAME='%s' TP_SOCKET_IFNAME='%s' GLOO_SOCKET_IFNAME='%s' NCCL_IB_GID_INDEX='%s' VLLM_HOST='%s' VLLM_PORT='%s'" \
+  printf "NCCL_IB_HCA='%s' NCCL_SOCKET_IFNAME='%s' TP_SOCKET_IFNAME='%s' GLOO_SOCKET_IFNAME='%s' NCCL_IB_GID_INDEX='%s' NCCL_IB_MERGE_NICS='%s' NCCL_IB_SUBNET_AWARE_ROUTING='%s' NCCL_IB_SUBNET_PREFIX_LEN='%s' VLLM_HOST='%s' VLLM_PORT='%s'" \
     "$WORKER_NCCL_IB_HCA" \
     "$WORKER_NCCL_SOCKET_IFNAME" \
     "$WORKER_TP_SOCKET_IFNAME" \
     "$WORKER_GLOO_SOCKET_IFNAME" \
     "$WORKER_NCCL_IB_GID_INDEX" \
+    "${NCCL_IB_MERGE_NICS:-}" \
+    "${NCCL_IB_SUBNET_AWARE_ROUTING:-}" \
+    "${NCCL_IB_SUBNET_PREFIX_LEN:-}" \
     "$VLLM_HOST" \
     "$VLLM_PORT"
 }
@@ -737,7 +824,12 @@ compose_base() {
     MASTER_PORT="$MASTER_PORT" \
     NCCL_IB_HCA="$NCCL_IB_HCA" \
     NCCL_SOCKET_IFNAME="$NCCL_SOCKET_IFNAME" \
+    TP_SOCKET_IFNAME="${TP_SOCKET_IFNAME:-$NCCL_SOCKET_IFNAME}" \
+    GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-$NCCL_SOCKET_IFNAME}" \
     NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-}" \
+    NCCL_IB_MERGE_NICS="${NCCL_IB_MERGE_NICS:-}" \
+    NCCL_IB_SUBNET_AWARE_ROUTING="${NCCL_IB_SUBNET_AWARE_ROUTING:-}" \
+    NCCL_IB_SUBNET_PREFIX_LEN="${NCCL_IB_SUBNET_PREFIX_LEN:-}" \
     VLLM_HOST="$VLLM_HOST" \
     VLLM_PORT="$VLLM_PORT" \
     VLLM_HOST_IP="$VLLM_HOST_IP" \
@@ -747,15 +839,36 @@ compose_base() {
     ENABLE_VLLM_GB10_PATCH="$ENABLE_VLLM_GB10_PATCH" \
     VLLM_GB10_PATCH_DIR="$VLLM_GB10_PATCH_DIR" \
     GB10_HYBRID_NVFP4_M_THRESHOLD="${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}" \
+    TP_SIZE="$TP_SIZE" \
+    NNODES="$NNODES" \
+    TP3_PATCH_DIR="${TP3_PATCH_DIR:-$SCRIPT_DIR/patches/tp3}" \
     NODE_RANK="$1" \
     HEADLESS="$2" \
     docker compose -p "$PROJECT_NAME" --env-file "$COMPOSE_ENV_FILE" -f "$COMPOSE_FILE" "${@:3}"
 }
 
+remote_nccl_env2() {
+  printf "NCCL_IB_HCA='%s' NCCL_SOCKET_IFNAME='%s' TP_SOCKET_IFNAME='%s' GLOO_SOCKET_IFNAME='%s' NCCL_IB_GID_INDEX='%s' NCCL_IB_MERGE_NICS='%s' NCCL_IB_SUBNET_AWARE_ROUTING='%s' NCCL_IB_SUBNET_PREFIX_LEN='%s' VLLM_HOST='%s' VLLM_PORT='%s'" \
+    "$WORKER2_NCCL_IB_HCA" \
+    "$WORKER2_NCCL_SOCKET_IFNAME" \
+    "$WORKER2_TP_SOCKET_IFNAME" \
+    "$WORKER2_GLOO_SOCKET_IFNAME" \
+    "$WORKER2_NCCL_IB_GID_INDEX" \
+    "${NCCL_IB_MERGE_NICS:-}" \
+    "${NCCL_IB_SUBNET_AWARE_ROUTING:-}" \
+    "${NCCL_IB_SUBNET_PREFIX_LEN:-}" \
+    "$VLLM_HOST" \
+    "$VLLM_PORT"
+}
+
 remote_compose() {
   # The head may use an absolute local mount override; the worker always uses
   # the canonical synced relative path.
-  ssh "$WORKER_HOST" "$REMOTE_COMPOSE DSPARK_ENABLE_ISSUE136_XGRAMMAR_HOTFIX=$REMOTE_ISSUE136_ENABLE DSPARK_ISSUE136_XGRAMMAR_HOTFIX='./patches/hotfix-vllm-issue136-xgrammar-termination.py' $(remote_nccl_env) $*"
+  ssh "$WORKER_HOST" "$REMOTE_COMPOSE DSPARK_ENABLE_ISSUE136_XGRAMMAR_HOTFIX=$REMOTE_ISSUE136_ENABLE DSPARK_ISSUE136_XGRAMMAR_HOTFIX='./patches/hotfix-vllm-issue136-xgrammar-termination.py' TP_SIZE='$TP_SIZE' NNODES='$NNODES' TP3_PATCH_DIR='./patches/tp3' $(remote_nccl_env) $*"
+}
+
+remote_compose2() {
+  ssh "$WORKER2_HOST" "$REMOTE_COMPOSE2 DSPARK_ENABLE_ISSUE136_XGRAMMAR_HOTFIX=$REMOTE_ISSUE136_ENABLE DSPARK_ISSUE136_XGRAMMAR_HOTFIX='./patches/hotfix-vllm-issue136-xgrammar-termination.py' TP_SIZE='$TP_SIZE' NNODES='$NNODES' TP3_PATCH_DIR='./patches/tp3' $(remote_nccl_env2) $*"
 }
 
 log_since() {
@@ -767,6 +880,9 @@ print_startup_logs() {
 
   compose_base 0 "" logs --since "$since" vllm-dspark || true
   remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --since '$since' vllm-dspark" || true
+  if [ "$DSPARK_TP3" = "1" ]; then
+    remote_compose2 "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --since '$since' vllm-dspark" || true
+  fi
 }
 
 wait_with_startup_logs() {
@@ -780,6 +896,9 @@ wait_with_startup_logs() {
 print_initial_startup_logs() {
   compose_base 0 "" logs --tail=100 vllm-dspark || true
   remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail=100 vllm-dspark" || true
+  if [ "$DSPARK_TP3" = "1" ]; then
+    remote_compose2 "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail=100 vllm-dspark" || true
+  fi
 }
 
 print_failure_logs() {
@@ -789,6 +908,10 @@ print_failure_logs() {
   compose_base 0 "" logs --since "$since" vllm-dspark >&2 || true
   echo "Recent worker logs:" >&2
   remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --since '$since' vllm-dspark" >&2 || true
+  if [ "$DSPARK_TP3" = "1" ]; then
+    echo "Recent worker2 logs:" >&2
+    remote_compose2 "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --since '$since' vllm-dspark" >&2 || true
+  fi
 }
 
 on_error() {
@@ -811,7 +934,11 @@ print_resolved_profile() {
   echo "  model: ${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}"
   echo "  served model: ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
   echo "  max model len: ${MAX_MODEL_LEN:-1000000}"
-  echo "  max num seqs: ${MAX_NUM_SEQS:-6}"
+  if [ "${DSPARK_TP3:-0}" = "1" ]; then
+    echo "  max num seqs: ${MAX_NUM_SEQS:-6} (TP=3; CUDA-graph capture $(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-6} + 1) )))"
+  else
+    echo "  max num seqs: ${MAX_NUM_SEQS:-6}"
+  fi
   echo "  max batched tokens: ${MAX_NUM_BATCHED_TOKENS:-8192}"
   echo "  gpu memory utilization: ${GPU_MEMORY_UTILIZATION:-0.835} (from GPU_MEMORY_UTILIZATION_TEXT=${GPU_MEMORY_UTILIZATION_TEXT:-0.835})"
   echo "  mtp speculative tokens: ${MTP_NUM_TOKENS:-6} (Vision-Exp: >=5 and divisible by 3)"
@@ -830,11 +957,21 @@ print_resolved_profile() {
   fi
   echo "  issue133 Triton specialization hotfix: will apply on start"
   echo "  issue141 sparse-MLA fixed-64 workaround: $DSPARK_ISSUE141_EFFECTIVE (0=stock / 1=apply)"
-  echo "  cudagraph capture size: $(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-6} + 1) ))"
+  echo "  DeepGEMM sm121 header alias: $DSPARK_DEEPGEMM_ALIAS_EFFECTIVE (0=stock / 1=apply)"
+  echo "  cudagraph capture size: $(( ( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-6} + 1) + 7 ) / 8 * 8 )) (rounded up to a multiple of 8 so spec-decode keeps the full-concurrency shape)"
   echo "  API bind: $VLLM_HOST:$VLLM_PORT"
   echo "  API probe: $API_URL"
   echo "  head fabric IP: $VLLM_HOST_IP"
   echo "  worker host/ip: $WORKER_HOST / $WORKER_VLLM_HOST_IP"
+  if [ "$DSPARK_TP3" = "1" ]; then
+    echo "  tensor parallel / nnodes: $TP_SIZE / $NNODES (start-tp3)"
+    echo "  worker2 host/ip: $WORKER2_HOST / $WORKER2_VLLM_HOST_IP"
+    echo "  worker2 NCCL HCA/if: $WORKER2_NCCL_IB_HCA / $WORKER2_NCCL_SOCKET_IFNAME"
+    echo "  worker2 NCCL_IB_GID_INDEX: ${WORKER2_NCCL_IB_GID_INDEX:-}"
+    echo "  worker2 dir: $WORKER2_DIR"
+  else
+    echo "  tensor parallel / nnodes: $TP_SIZE / $NNODES"
+  fi
   echo "  head NCCL HCA/if: $NCCL_IB_HCA / $NCCL_SOCKET_IFNAME"
   echo "  worker NCCL HCA/if: $WORKER_NCCL_IB_HCA / $WORKER_NCCL_SOCKET_IFNAME"
   echo "  NCCL_IB_GID_AUTO: $NCCL_IB_GID_AUTO"
@@ -885,6 +1022,10 @@ validate_compose() {
   compose_base 0 "" config --quiet
   echo "Validating worker compose config..."
   remote_compose "NODE_RANK=1 HEADLESS=1 $WORKER_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_ENABLE_ISSUE141_SPARSE_MLA_CHUNK='$DSPARK_ISSUE141_EFFECTIVE' DSPARK_ISSUE141_HOTFIX='./patches/hotfix-dsv4-issue141-sparse-mla-decode-chunk.py' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT='$DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT' DSPARK_ISSUE138_HOTFIX='./patches/hotfix-vllm-issue138-responses-history.py' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER_COMPOSE_FILES config --quiet"
+  if [ "$DSPARK_TP3" = "1" ]; then
+    echo "Validating worker2 compose config..."
+    remote_compose2 "NODE_RANK=2 HEADLESS=1 $WORKER2_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER2_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_ENABLE_ISSUE141_SPARSE_MLA_CHUNK='$DSPARK_ISSUE141_EFFECTIVE' DSPARK_ISSUE141_HOTFIX='./patches/hotfix-dsv4-issue141-sparse-mla-decode-chunk.py' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT='$DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT' DSPARK_ISSUE138_HOTFIX='./patches/hotfix-vllm-issue138-responses-history.py' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER2_COMPOSE_FILES config --quiet"
+  fi
 }
 
 need_cmd docker
@@ -925,6 +1066,18 @@ ssh "$WORKER_HOST" "docker image inspect '$DSPARK_VLLM_IMAGE' >/dev/null" || {
   exit 1
 }
 
+if [ "$DSPARK_TP3" = "1" ]; then
+  ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER2_HOST" "true" >/dev/null || {
+    echo "Cannot reach worker2 with passwordless SSH: $WORKER2_HOST" >&2
+    exit 1
+  }
+  ssh "$WORKER2_HOST" "docker image inspect '$DSPARK_VLLM_IMAGE' >/dev/null" || {
+    echo "Missing worker2 Docker image $DSPARK_VLLM_IMAGE." >&2
+    echo "Pull it on worker2 (e.g. docker pull $DSPARK_VLLM_IMAGE)." >&2
+    exit 1
+  }
+fi
+
 already_running_hint() {
   echo "This is not a failed start: dockerd likely restored ranks after a reboot (compose restart: unless-stopped). The cluster may already be serving. Run ./stop-deepseek-v4-flash-dspark.sh only if you want a cold start. Supervisors: treat exit 3 as already-up (systemd SuccessExitStatus=3)." >&2
 }
@@ -948,8 +1101,54 @@ else
   exit "$worker_rc"
 fi
 
+if [ "$DSPARK_TP3" = "1" ]; then
+  if ssh "$WORKER2_HOST" "if docker ps --format '{{.Names}}' | grep -qx '${PROJECT_NAME}-vllm-dspark-1'; then echo 'DSpark worker2 container already exists for project $PROJECT_NAME. Stop it first.' >&2; exit 1; fi"; then
+    :
+  else
+    worker_rc=$?
+    echo "Cannot start: worker2 check on $WORKER2_HOST failed (ssh exit $worker_rc)." >&2
+    exit "$worker_rc"
+  fi
+fi
+
+# Pairwise CX /24s are fine for RoCE but not for Gloo/NCCL TCP bootstrap.
+# Rank 2 will try the head's CX IP (e.g. 10.0.22.1) and time out. After GID
+# resolve (which must still match the RoCE iface), move bootstrap to the
+# 10.0.0.x loopback aliases already used as MASTER_ADDR / VLLM_HOST_IP.
+apply_tp3_bootstrap_ifaces() {
+  [ "$DSPARK_TP3" = "1" ] || return 0
+  # lo has 127.0.0.1 plus 10.0.0.x; Gloo binds 127.0.0.1 and the mesh dies.
+  # On this DGX Spark ring the RJ45 NIC is named enP7s7 on every node and
+  # shares 192.168.1.0/24 — the only L3 that reaches all three ranks.
+  local bif="${TP3_BOOTSTRAP_IFNAME:-enP7s7}"
+  echo "TP=3 bootstrap: Gloo/NCCL-socket/TP TCP on ${bif} (LAN all-to-all). NCCL_IB_HCA stays on ConnectX."
+  GLOO_SOCKET_IFNAME="$bif"
+  TP_SOCKET_IFNAME="$bif"
+  NCCL_SOCKET_IFNAME="$bif"
+  WORKER_GLOO_SOCKET_IFNAME="$bif"
+  WORKER_TP_SOCKET_IFNAME="$bif"
+  WORKER_NCCL_SOCKET_IFNAME="$bif"
+  WORKER2_GLOO_SOCKET_IFNAME="$bif"
+  WORKER2_TP_SOCKET_IFNAME="$bif"
+  WORKER2_NCCL_SOCKET_IFNAME="$bif"
+  # Pairwise CX /24s: a single HCA makes spark1 try 10.0.22.1 → 10.0.23.3 (RTR timeout).
+  local hcas="${TP3_NCCL_IB_HCA:-rocep1s0f0,rocep1s0f1}"
+  echo "TP=3 RoCE: NCCL_IB_HCA=${hcas} (both CX ports; GID index already resolved)."
+  NCCL_IB_HCA="$hcas"
+  WORKER_NCCL_IB_HCA="$hcas"
+  WORKER2_NCCL_IB_HCA="$hcas"
+  # Dual-port CX: each port is a different /24 to a different neighbor.
+  # MERGE_NICS=1 bonds them and QPs the wrong peer; default prefix /16 treats
+  # 10.0.22 and 10.0.23 as one subnet. Spark-ring recipe: MERGE=0 + subnet /24.
+  NCCL_IB_MERGE_NICS=0
+  NCCL_IB_SUBNET_AWARE_ROUTING=1
+  NCCL_IB_SUBNET_PREFIX_LEN=24
+  echo "TP=3 RoCE: NCCL_IB_MERGE_NICS=0 NCCL_IB_SUBNET_AWARE_ROUTING=1 NCCL_IB_SUBNET_PREFIX_LEN=24"
+}
+
 cd "$SCRIPT_DIR"
 resolve_nccl_gid_indexes
+apply_tp3_bootstrap_ifaces
 STARTUP_LOG_SINCE="$(log_since)"
 trap on_error ERR
 print_resolved_profile
@@ -1095,6 +1294,12 @@ if [ -f "$DSPARK_ISSUE136_XGRAMMAR_HOTFIX" ] && [ ! -L "$DSPARK_ISSUE136_XGRAMMA
   ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches'"
   scp "$DSPARK_ISSUE136_XGRAMMAR_HOTFIX" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/hotfix-vllm-issue136-xgrammar-termination.py"
 fi
+# Compose always bind-mounts patches/tp3. Create it on the worker even for
+# TP=2 so Docker does not invent a root-owned empty dir (or fail the mount).
+ssh "$WORKER_HOST" "mkdir -p '${REMOTE_WORKER_DIR}/patches/tp3'"
+if [ -f "$SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" ]; then
+  scp "$SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" "${WORKER_HOST}:${REMOTE_WORKER_DIR}/patches/tp3/apply_tp3_patch.py"
+fi
 if [ "$ENABLE_VLLM_GB10_PATCH" = "1" ]; then
   echo "Syncing GB10 vLLM patch to ${WORKER_HOST}:${WORKER_DIR}/vllm_patch_gb10"
   tar -C "$VLLM_GB10_PATCH_DIR" \
@@ -1102,6 +1307,75 @@ if [ "$ENABLE_VLLM_GB10_PATCH" = "1" ]; then
     --exclude='__pycache__' \
     --exclude='*.pyc' \
     -cf - . | ssh "$WORKER_HOST" "mkdir -p $REMOTE_VLLM_GB10_PATCH_DIR && tar -C $REMOTE_VLLM_GB10_PATCH_DIR --no-overwrite-dir -xf -"
+fi
+
+sync_tp3_patch_dir() {
+  local host="$1"
+  local dest_q="$2"
+  echo "Syncing patches/tp3 to ${host} (refuse boot if this fails)"
+  ssh "$host" "mkdir -p ${dest_q}/patches/tp3" || {
+    echo "FATAL: failed to mkdir patches/tp3 on ${host}" >&2
+    exit 1
+  }
+  scp "$SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" "${host}:${dest_q}/patches/tp3/apply_tp3_patch.py" || {
+    echo "FATAL: failed to sync apply_tp3_patch.py to ${host} -- refusing to boot TP=3." >&2
+    exit 1
+  }
+  if [ -f "$SCRIPT_DIR/patches/dsv4_tp_pad.py" ]; then
+    scp "$SCRIPT_DIR/patches/dsv4_tp_pad.py" "${host}:${dest_q}/patches/dsv4_tp_pad.py" || {
+      echo "FATAL: failed to sync dsv4_tp_pad.py to ${host}" >&2
+      exit 1
+    }
+  fi
+}
+
+push_compose_env_file() {
+  local host="$1"
+  local remote_env_q="$2"
+  ssh "$host" "
+    set -euo pipefail
+    _env_final=$remote_env_q
+    _env_tmp=\"\${_env_final}.tmp.\$\$\"
+    _cleanup_remote_env() { [ -z \"\$_env_tmp\" ] || rm -f -- \"\$_env_tmp\"; }
+    trap _cleanup_remote_env EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    umask 077
+    cat > \"\$_env_tmp\"
+    chmod 600 \"\$_env_tmp\"
+    mv -f -- \"\$_env_tmp\" \"\$_env_final\"
+    _env_tmp=
+    trap - EXIT HUP INT TERM
+  " < "$COMPOSE_ENV_FILE"
+}
+
+if [ "$DSPARK_TP3" = "1" ]; then
+  sync_tp3_patch_dir "$WORKER_HOST" "$REMOTE_WORKER_DIR"
+  echo "Syncing DSpark deployment files to ${WORKER2_HOST}:${WORKER2_DIR}"
+  ssh "$WORKER2_HOST" "mkdir -p $REMOTE_WORKER2_DIR $REMOTE_WORKER2_DIR/recipe/vllm/v1/spec_decode $REMOTE_WORKER2_DIR/patches"
+  scp "$COMPOSE_FILE" "${WORKER2_HOST}:${REMOTE_COMPOSE_FILE2}"
+  if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
+    [ -f "$NFS_OVERRIDE_FILE" ] || { echo "Missing NFS compose override: $NFS_OVERRIDE_FILE" >&2; exit 1; }
+    scp "$NFS_OVERRIDE_FILE" "${WORKER2_HOST}:${REMOTE_NFS_OVERRIDE_FILE2}"
+  fi
+  push_compose_env_file "$WORKER2_HOST" "$REMOTE_ENV_FILE2"
+  scp "$DSPARK_PROPOSER_FILE" "${WORKER2_HOST}:${REMOTE_WORKER2_DIR}/recipe/vllm/v1/spec_decode/dspark_proposer.py"
+  tar -C "$SCRIPT_DIR" \
+    --exclude='patches/__pycache__' \
+    --exclude='patches/*/__pycache__' \
+    -cf - patches | ssh "$WORKER2_HOST" "tar -C $REMOTE_WORKER2_DIR --no-overwrite-dir -xf -" || {
+    echo "FATAL: failed to sync patches/ to ${WORKER2_HOST} -- refusing to boot TP=3." >&2
+    exit 1
+  }
+  if [ "$ENABLE_VLLM_GB10_PATCH" = "1" ]; then
+    tar -C "$VLLM_GB10_PATCH_DIR" \
+      --exclude='*.egg-info' \
+      --exclude='__pycache__' \
+      --exclude='*.pyc' \
+      -cf - . | ssh "$WORKER2_HOST" "mkdir -p $REMOTE_VLLM_GB10_PATCH_DIR2 && tar -C $REMOTE_VLLM_GB10_PATCH_DIR2 --no-overwrite-dir -xf -"
+  fi
+  sync_tp3_patch_dir "$WORKER2_HOST" "$REMOTE_WORKER2_DIR"
 fi
 
 if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
@@ -1123,6 +1397,37 @@ if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
     echo "Download weights on the head first: ./prepare-dspark-model-cache.sh --yes" >&2
     exit 1
   fi
+  if [ "$DSPARK_TP3" = "1" ]; then
+    if [ -z "$WORKER2_HF_CACHE" ] || [ "$WORKER2_HF_CACHE" = "${HF_CACHE:-}" ]; then
+      WORKER2_HF_CACHE="$(ssh "$WORKER2_HOST" 'printf %s "$HOME/.cache/huggingface"')"
+      [ -n "$WORKER2_HF_CACHE" ] || { echo "Could not resolve worker2 HOME for JIT cache overlays." >&2; exit 1; }
+      WORKER2_HF_COMPOSE_ENV="HF_CACHE='$NFS_VOLUME' DSPARK_JIT_CACHE='$WORKER2_HF_CACHE'"
+      echo "Worker2 JIT cache defaulted to $WORKER2_HF_CACHE"
+    fi
+    ssh "$WORKER2_HOST" "mkdir -p $(for d in $(nfs_jit_subdirs); do printf '%s/%s ' "$WORKER2_HF_CACHE" "$d"; done)"
+    # 3-node ring: worker2 is on a different CX /24 than worker1. Do not reuse
+    # NFS_SERVER_IP from NCCL_SOCKET_IFNAME (spark1↔spark2). Pick a head CX
+    # IPv4 worker2 can ping, or WORKER2_NFS_SERVER_IP.
+    WORKER2_NFS_SERVER_IP="$(nfs_pick_server_ip_for_host "$WORKER2_HOST" "${WORKER2_NFS_SERVER_IP:-}")" || {
+      echo "FATAL: no head ConnectX IPv4 is pingable from worker2 ${WORKER2_HOST}." >&2
+      echo "Set WORKER2_NFS_SERVER_IP to the spark1 address on the spark1↔spark3 link (not 10.0.22.1)." >&2
+      exit 1
+    }
+    if [ "$WORKER2_NFS_SERVER_IP" = "$NFS_SERVER_IP" ]; then
+      echo "Worker2 NFS via same head IP as worker1: $WORKER2_NFS_SERVER_IP"
+    else
+      echo "Worker2 NFS via ring peer link: $WORKER2_NFS_SERVER_IP (worker1 uses $NFS_SERVER_IP)"
+    fi
+    nfs_grant_subnet "$(nfs_subnet24 "$WORKER2_NFS_SERVER_IP")"
+    nfs_ensure_host_volume "$WORKER2_HOST" "$WORKER2_NFS_SERVER_IP"
+    if timeout 45 ssh "$WORKER2_HOST" "docker run --rm -v '${NFS_VOLUME}:/hf:ro' alpine:latest test -d '/hf/${_nfs_model_rel}'" >/dev/null 2>&1; then
+      echo "Worker2 sees $_nfs_model_rel over NFS ($NFS_VOLUME @ $WORKER2_NFS_SERVER_IP)."
+    else
+      echo "WORKER2 cannot see $_nfs_model_rel over NFS at ${WORKER2_NFS_SERVER_IP}." >&2
+      echo "Export must allow $(nfs_subnet24 "$WORKER2_NFS_SERVER_IP") (live vllm-fn-nfs clients are often only worker1's /24)." >&2
+      exit 1
+    fi
+  fi
 fi
 validate_compose
 
@@ -1136,12 +1441,21 @@ fi
 if [ "${DSPARK_ENABLE_ISSUE136_XGRAMMAR_HOTFIX:-0}" = "1" ]; then
   echo "Checking Issue #136 XGrammar compatibility on the worker before either rank starts..."
   remote_compose "NODE_RANK=1 HEADLESS=1 $WORKER_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER_COMPOSE_FILES run --rm --no-deps --entrypoint python3 vllm-dspark /opt/hotfix-vllm-issue136-xgrammar-termination.py --check"
+  if [ "$DSPARK_TP3" = "1" ]; then
+    echo "Checking Issue #136 XGrammar compatibility on worker2 before ranks start..."
+    remote_compose2 "NODE_RANK=2 HEADLESS=1 $WORKER2_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER2_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER2_COMPOSE_FILES run --rm --no-deps --entrypoint python3 vllm-dspark /opt/hotfix-vllm-issue136-xgrammar-termination.py --check"
+  fi
   echo "Checking Issue #136 XGrammar compatibility on the head before either rank starts..."
   compose_base 0 "" run --rm --no-deps --entrypoint python3 vllm-dspark /opt/hotfix-vllm-issue136-xgrammar-termination.py --check
 fi
 
 echo "Starting DSpark worker on ${WORKER_HOST}..."
 remote_compose "NODE_RANK=1 HEADLESS=1 $WORKER_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_ENABLE_ISSUE141_SPARSE_MLA_CHUNK='$DSPARK_ISSUE141_EFFECTIVE' DSPARK_ISSUE141_HOTFIX='./patches/hotfix-dsv4-issue141-sparse-mla-decode-chunk.py' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT='$DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT' DSPARK_ISSUE138_HOTFIX='./patches/hotfix-vllm-issue138-responses-history.py' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER_COMPOSE_FILES up -d"
+
+if [ "$DSPARK_TP3" = "1" ]; then
+  echo "Starting DSpark worker2 on ${WORKER2_HOST}..."
+  remote_compose2 "NODE_RANK=2 HEADLESS=1 $WORKER2_HF_COMPOSE_ENV VLLM_HOST_IP='$WORKER2_VLLM_HOST_IP' GPU_MEMORY_UTILIZATION='$GPU_MEMORY_UTILIZATION' DSPARK_MODEL='$DSPARK_MODEL' DSPARK_REVISION='${DSPARK_REVISION:-}' DSPARK_ENABLE_ISSUE141_SPARSE_MLA_CHUNK='$DSPARK_ISSUE141_EFFECTIVE' DSPARK_ISSUE141_HOTFIX='./patches/hotfix-dsv4-issue141-sparse-mla-decode-chunk.py' ENABLE_VLLM_GB10_PATCH='$ENABLE_VLLM_GB10_PATCH' VLLM_GB10_PATCH_DIR='./vllm_patch_gb10' GB10_HYBRID_NVFP4_M_THRESHOLD='${GB10_HYBRID_NVFP4_M_THRESHOLD:-128}' DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT='$DSPARK_ENABLE_ISSUE138_RESPONSES_HISTORY_COMPAT' DSPARK_ISSUE138_HOTFIX='./patches/hotfix-vllm-issue138-responses-history.py' docker compose -p '$PROJECT_NAME' --env-file .env.dspark $WORKER2_COMPOSE_FILES up -d"
+fi
 
 echo "Starting DSpark head..."
 compose_base 0 "" up -d
@@ -1167,6 +1481,9 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
     echo "DeepSeek V4 Flash DSpark is running: $API_URL"
     compose_base 0 "" ps
     remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml ps"
+    if [ "$DSPARK_TP3" = "1" ]; then
+      remote_compose2 "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml ps"
+    fi
     if [ "${DSPARK_ENABLE_ISSUE31_GPU_HOTFIX:-0}" = "1" ]; then
       echo "Running minimal OpenAI-compatible thinking-budget chat request..."
       curl -fsS --max-time 60 "${AUTH_HEADER_ARGS[@]}" "$CHAT_URL" \
@@ -1224,4 +1541,8 @@ echo "Timed out waiting for DSpark API. Recent head logs:" >&2
 compose_base 0 "" logs --tail=120 vllm-dspark >&2 || true
 echo "Recent worker logs:" >&2
 remote_compose "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail=120 vllm-dspark" >&2 || true
+if [ "$DSPARK_TP3" = "1" ]; then
+  echo "Recent worker2 logs:" >&2
+  remote_compose2 "docker compose -p '$PROJECT_NAME' --env-file .env.dspark -f docker-compose.dspark.yml logs --tail=120 vllm-dspark" >&2 || true
+fi
 exit 1

--- a/start-tp3.sh
+++ b/start-tp3.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Optional 3-node TP=3 launcher. The default
+# ./start-deepseek-v4-flash-dspark.sh path stays TP=2 (one worker).
+#
+# Pads attention groups 8→9 so 3 divides the shard. Patch:
+#   patches/tp3/apply_tp3_patch.py
+# from https://github.com/localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--max-num-seqs N] [--host HOST] [--port PORT]
+
+Start DeepSeek-V4-Flash DSpark on three DGX Sparks (tensor parallel 3).
+Requires WORKER_HOST and WORKER2_HOST in .env.dspark.
+
+Options:
+  --max-num-seqs N   Concurrent slots (vLLM --max-num-seqs). CUDA-graph
+                     capture size is N * (MTP_NUM_TOKENS + 1).
+                     Default: TP3_MAX_NUM_SEQS in .env.dspark, else MAX_NUM_SEQS
+                     (the 2-node value, usually 6). The 2-node start ignores
+                     TP3_MAX_NUM_SEQS.
+  --host HOST        Passed through to start-deepseek-v4-flash-dspark.sh
+  --port PORT        Passed through to start-deepseek-v4-flash-dspark.sh
+
+This does not replace ./start-deepseek-v4-flash-dspark.sh (TP=2).
+
+After boot, prove the shard (not just that HTTP is up):
+  scripts/validate_tp3.sh 127.0.0.1:8888
+
+Patch or seqs changes need a recreate, not a container restart:
+  ./stop-deepseek-v4-flash-dspark.sh && ./start-tp3.sh
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --max-num-seqs)
+      [ "$#" -ge 2 ] && [ -n "$2" ] || { echo "--max-num-seqs requires a value." >&2; exit 2; }
+      export _START_TP3_MAX_NUM_SEQS="$2"
+      shift 2
+      ;;
+    --max-num-seqs=*)
+      export _START_TP3_MAX_NUM_SEQS="${1#*=}"
+      [ -n "${_START_TP3_MAX_NUM_SEQS}" ] || { echo "--max-num-seqs requires a value." >&2; exit 2; }
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ ! -f "$SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" ]; then
+  echo "Missing $SCRIPT_DIR/patches/tp3/apply_tp3_patch.py" >&2
+  exit 1
+fi
+
+export DSPARK_TP3=1
+export TP_SIZE=3
+export NNODES=3
+exec "$SCRIPT_DIR/start-deepseek-v4-flash-dspark.sh" "$@"

--- a/status-deepseek-v4-flash-dspark.sh
+++ b/status-deepseek-v4-flash-dspark.sh
@@ -68,6 +68,8 @@ API_URL="${API_URL:-http://${_dspark_host}:${VLLM_PORT:-8888}/v1/models}"
 
 cd "$SCRIPT_DIR"
 WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
+WORKER2_HOST="${WORKER2_HOST:-}"
+WORKER2_DIR="${WORKER2_SCRIPT_DIR:-${WORKER2_DIR:-$WORKER_DIR}}"
 
 show_compose() {
   local project="$1"
@@ -77,6 +79,11 @@ show_compose() {
   echo "== worker compose: $project =="
   ssh "$WORKER_HOST" "cd '$WORKER_DIR' && COMPOSE_DISABLE_ENV_FILE=1 docker compose -p '$project' --env-file .env.dspark -f docker-compose.dspark.yml ps" || true
   echo
+  if [ -n "${WORKER2_HOST:-}" ]; then
+    echo "== worker2 compose: $project =="
+    ssh "$WORKER2_HOST" "cd '${WORKER2_DIR:-$WORKER_DIR}' && COMPOSE_DISABLE_ENV_FILE=1 docker compose -p '$project' --env-file .env.dspark -f docker-compose.dspark.yml ps" || true
+    echo
+  fi
 }
 
 show_compose "$PROJECT_NAME"
@@ -90,9 +97,17 @@ echo
 echo "== worker matching containers =="
 ssh "$WORKER_HOST" "docker ps -a --format '{{.Names}} {{.Status}} {{.Image}}' | grep -E 'deepseek|dspark|vllm' || true" || true
 echo
+if [ -n "${WORKER2_HOST:-}" ]; then
+  echo "== worker2 matching containers =="
+  ssh "$WORKER2_HOST" "docker ps -a --format '{{.Names}} {{.Status}} {{.Image}}' | grep -E 'deepseek|dspark|vllm' || true" || true
+  echo
+fi
 echo "== images =="
 docker image inspect "$DSPARK_VLLM_IMAGE" --format "head $DSPARK_VLLM_IMAGE {{.Id}}" || true
 ssh "$WORKER_HOST" "docker image inspect '$DSPARK_VLLM_IMAGE' --format 'worker $DSPARK_VLLM_IMAGE {{.Id}}'" || true
+if [ -n "${WORKER2_HOST:-}" ]; then
+  ssh "$WORKER2_HOST" "docker image inspect '$DSPARK_VLLM_IMAGE' --format 'worker2 $DSPARK_VLLM_IMAGE {{.Id}}'" || true
+fi
 echo
 echo "== port/API =="
 if command -v ss >/dev/null 2>&1; then

--- a/stop-deepseek-v4-flash-dspark.sh
+++ b/stop-deepseek-v4-flash-dspark.sh
@@ -37,6 +37,10 @@ fi
 cd "$SCRIPT_DIR"
 
 WORKER_DIR="${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}"
+WORKER2_HOST="${WORKER2_HOST:-}"
+WORKER2_DIR="${WORKER2_SCRIPT_DIR:-${WORKER2_DIR:-$WORKER_DIR}}"
+WORKER2_HF_CACHE="${WORKER2_HF_CACHE:-${WORKER_HF_CACHE:-${HF_CACHE:-}}}"
+WORKER2_VLLM_HOST_IP="${WORKER2_VLLM_HOST_IP:-}"
 WORKER_HF_CACHE="${WORKER_HF_CACHE:-${HF_CACHE:-}}"
 WORKER_VLLM_HOST_IP="${WORKER_VLLM_HOST_IP:-}"
 DSPARK_WORKER_HF_NFS="${DSPARK_WORKER_HF_NFS:-0}"
@@ -44,9 +48,13 @@ NFS_VOLUME="${NFS_VOLUME:-dspark-hf}"
 NFS_CONTAINER="${NFS_CONTAINER:-dspark-nfs}"
 WORKER_COMPOSE_FILES="-f docker-compose.dspark.yml"
 WORKER_HF_COMPOSE_ENV="HF_CACHE='$WORKER_HF_CACHE'"
+WORKER2_COMPOSE_FILES="-f docker-compose.dspark.yml"
+WORKER2_HF_COMPOSE_ENV="HF_CACHE='$WORKER2_HF_CACHE'"
 if [ "$DSPARK_WORKER_HF_NFS" = "1" ]; then
   WORKER_COMPOSE_FILES="-f docker-compose.dspark.yml -f docker-compose.dspark-nfs.override.yml"
   WORKER_HF_COMPOSE_ENV="HF_CACHE='$NFS_VOLUME' DSPARK_JIT_CACHE='$WORKER_HF_CACHE'"
+  WORKER2_COMPOSE_FILES="-f docker-compose.dspark.yml -f docker-compose.dspark-nfs.override.yml"
+  WORKER2_HF_COMPOSE_ENV="HF_CACHE='$NFS_VOLUME' DSPARK_JIT_CACHE='$WORKER2_HF_CACHE'"
 fi
 
 # A stop that cannot reach the worker must not report success: a powered-down
@@ -70,6 +78,14 @@ else
   WORKER_REACHABLE=0
   echo "WARN: cannot reach worker ${WORKER_HOST}; its ranks will NOT be stopped." >&2
 fi
+WORKER2_REACHABLE=0
+if [ -n "$WORKER2_HOST" ]; then
+  if ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER2_HOST" "true" >/dev/null 2>&1; then
+    WORKER2_REACHABLE=1
+  else
+    echo "WARN: cannot reach worker2 ${WORKER2_HOST}; its ranks will NOT be stopped." >&2
+  fi
+fi
 
 local_project_has_resources() {
   local project="$1"
@@ -83,7 +99,7 @@ local_project_has_resources() {
 # Force-remove leftover containers by compose project label + known names.
 force_rm_project_containers() {
   local project="$1"
-  local where="$2" # local | remote
+  local where="$2" # local | remote | remote2
   local cmd
   cmd=$(cat <<EOF
 ids=\$(docker ps -aq --filter "label=com.docker.compose.project=$project" 2>/dev/null || true)
@@ -98,6 +114,10 @@ EOF
 )
   if [ "$where" = "local" ]; then
     bash -c "$cmd" || true
+  elif [ "$where" = "remote2" ]; then
+    if [ -n "$WORKER2_HOST" ] && [ "${WORKER2_REACHABLE:-0}" = "1" ]; then
+      ssh "$WORKER2_HOST" "$cmd" || stop_warn "force-remove on ${WORKER2_HOST} failed"
+    fi
   elif [ "${WORKER_REACHABLE:-1}" = "1" ]; then
     ssh "$WORKER_HOST" "$cmd" || stop_warn "force-remove on ${WORKER_HOST} failed"
   fi
@@ -137,30 +157,42 @@ stop_main_head() {
 
 stop_main_worker() {
   local project="$1"
-  if [ "${WORKER_REACHABLE:-1}" != "1" ]; then
-    stop_warn "worker ${WORKER_HOST} unreachable: main DSpark worker rank not stopped"
+  local host="${2:-$WORKER_HOST}"
+  local wdir="${3:-$WORKER_DIR}"
+  local hf_env="${4:-$WORKER_HF_COMPOSE_ENV}"
+  local vllm_ip="${5:-$WORKER_VLLM_HOST_IP}"
+  local rank="${6:-1}"
+  local compose_files="${7:-$WORKER_COMPOSE_FILES}"
+  local reachable=1
+  if [ "$host" = "$WORKER_HOST" ]; then
+    reachable="${WORKER_REACHABLE:-1}"
+  elif [ "$host" = "$WORKER2_HOST" ]; then
+    reachable="${WORKER2_REACHABLE:-1}"
+  fi
+  if [ "$reachable" != "1" ]; then
+    stop_warn "worker ${host} unreachable: DSpark rank not stopped"
     return 0
   fi
-  ssh "$WORKER_HOST" "
-    cd '$WORKER_DIR' || exit 1
+  ssh "$host" "
+    cd '$wdir' || exit 1
     if {
       docker ps -aq --filter 'label=com.docker.compose.project=$project'
       docker network ls -q --filter 'label=com.docker.compose.project=$project'
       docker volume ls -q --filter 'label=com.docker.compose.project=$project'
       docker ps -aq --filter 'name=${project}-vllm-dspark'
     } | grep -q .; then
-      echo 'Stopping DSpark on worker $WORKER_HOST (project $project)...'
+      echo 'Stopping DSpark on worker $host (project $project)...'
       docker ps -aq --filter 'name=${project}-vllm-dspark' | xargs -r docker rm -f >/dev/null 2>&1 || true
       env -u MASTER_ADDR -u MASTER_PORT -u NODE_RANK -u HEADLESS \
-        COMPOSE_DISABLE_ENV_FILE=1 $WORKER_HF_COMPOSE_ENV \
-        VLLM_HOST_IP='$WORKER_VLLM_HOST_IP' NODE_RANK=1 HEADLESS=1 \
+        COMPOSE_DISABLE_ENV_FILE=1 $hf_env \
+        VLLM_HOST_IP='$vllm_ip' NODE_RANK=$rank HEADLESS=1 \
         docker compose -p '$project' --env-file .env.dspark \
-          $WORKER_COMPOSE_FILES down --remove-orphans -t 1 2>&1 \
+          $compose_files down --remove-orphans -t 1 2>&1 \
           | grep -v 'No resource found to remove for project' || true
     else
-      echo 'No DSpark worker resources for project $project on $WORKER_HOST; skipping.'
+      echo 'No DSpark worker resources for project $project on $host; skipping.'
     fi
-  " || stop_warn "main DSpark worker stop failed on ${WORKER_HOST}"
+  " || stop_warn "main DSpark worker stop failed on ${host}"
 }
 
 stop_project() {
@@ -172,10 +204,14 @@ stop_project() {
 
   stop_main_head "$project"
   stop_main_worker "$project"
+  if [ -n "$WORKER2_HOST" ]; then
+    stop_main_worker "$project" "$WORKER2_HOST" "$WORKER2_DIR" "$WORKER2_HF_COMPOSE_ENV" "$WORKER2_VLLM_HOST_IP" 2 "$WORKER2_COMPOSE_FILES"
+  fi
 
   # Sweep anything left under this compose project on both nodes.
   force_rm_project_containers "$project" local
   force_rm_project_containers "$project" remote
+  force_rm_project_containers "$project" remote2
 }
 
 stop_project "$PROJECT_NAME"
@@ -193,6 +229,15 @@ if [ "$STOP_NFS" = "1" ]; then
       || stop_warn "worker volume rm failed on ${WORKER_HOST}"
   else
     stop_warn "worker ${WORKER_HOST} unreachable: NFS volume $NFS_VOLUME not removed"
+  fi
+  if [ -n "$WORKER2_HOST" ]; then
+    if [ "${WORKER2_REACHABLE:-0}" = "1" ]; then
+      echo "Removing worker2 NFS volume ($NFS_VOLUME)..."
+      ssh "$WORKER2_HOST" "docker volume rm $NFS_VOLUME 2>/dev/null && echo '  Worker2 volume: removed.' || echo '  Worker2 volume: not present.'" \
+        || stop_warn "worker2 volume rm failed on ${WORKER2_HOST}"
+    else
+      stop_warn "worker2 ${WORKER2_HOST} unreachable: NFS volume $NFS_VOLUME not removed"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Adds opt-in `./start-tp3.sh` for three DGX Sparks (TP=3 / nnodes=3). Default `./start-deepseek-v4-flash-dspark.sh` still **forces TP=2 / nnodes=2**, so a `TP_SIZE=3` line in `.env.dspark` cannot change the two-node path.
- Vendors the attention-group pad (8→9, heads 64→72, pad sinks `-inf`) from [localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark](https://github.com/localaiguyy/DeepSeek-V4-Flash-DSpark-3x-DGX-Spark) (MIT). Compose runs `apply_tp3_patch.py` **only when `TP_SIZE=3`**.
- Third rank (`WORKER2_HOST`): NFS via `WORKER2_NFS_SERVER_IP` (spark3 cannot reach the spark1↔spark2 CX `/24`), Gloo/NCCL/TP sockets on `TP3_BOOTSTRAP_IFNAME` (default `enP7s7`, not `lo`), both CX HCAs plus `NCCL_IB_SUBNET_AWARE_ROUTING=1` / `NCCL_IB_SUBNET_PREFIX_LEN=24` so QP RTR pairs GIDs per `/24`. `--max-num-seqs` / `TP3_MAX_NUM_SEQS` apply only on this path.
- If `WORKER2_HOST` is set, **stop / status / logs / prepare** still talk to spark3 even on a 2-node start. Compose always bind-mounts `patches/tp3` (no-op at TP=2). Recreate after overlay or seqs changes (`./stop` then `./start-tp3.sh`).

## Test plan
- [x] `bash scripts/ci-validate.sh` on this branch
- [ ] `./start-deepseek-v4-flash-dspark.sh` still boots `--tensor-parallel-size 2 --nnodes 2` (compose interpolates `TP_SIZE`/`NNODES` as 2)
- [ ] Live 3-node: `./start-tp3.sh` then `scripts/validate_tp3.sh 127.0.0.1:8888` (use `chat_template_kwargs.thinking=false` if a tiny max-tokens call returns `content=None`)
- [ ] Pad log: heads 64 → 72; spark3 NFS is the spark1↔spark3 CX IP, not `10.0.22.1`


Made with [Cursor](https://cursor.com)