### PR TITLE
perf(vision-exp): classify routing kind once per forward instead of once per MoE gate

### DIFF
--- a/patches/vision_exp/apply.py
+++ b/patches/vision_exp/apply.py
@@ -14,9 +14,11 @@ from torch import nn
 from .image_processor import (
     IMAGE,
     IMAGE_TOKEN_ID,
+    current_routing_kind,
     is_unregistered_router_bias,
     is_vision_exp_weight_name,
-    token_routing_kind,
+    routing_kind_from_mm,
+    set_pending_routing_kind,
     vision_args_from_config,
 )
 from .processor import IMAGE_PLACEHOLDER, register_vision_exp_processor
@@ -152,6 +154,7 @@ def fused_topk_bias_split_vl(
     input_tokens: Any,
     hash_indices_table: Any,
     routed_scaling_factor: float,
+    kind: Any = None,
 ) -> tuple[Any, Any]:
     """Route image placeholder rows with bias_vl and no hash table (issue #175)."""
     from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
@@ -173,7 +176,8 @@ def fused_topk_bias_split_vl(
         )
 
     vl = _bias_data(e_score_correction_bias_vl)
-    kind = token_routing_kind(input_tokens)
+    if kind is None:
+        kind = current_routing_kind(input_tokens)
     if vl is None or kind == "text":
         return _call(
             hidden_states,
@@ -263,7 +267,14 @@ def _wrap_router_compute_routing(router: Any, gate: Any) -> None:
             capturing = bool(torch.cuda.is_current_stream_capturing())
         except Exception:
             capturing = False
-        if vl is None or capturing or token_routing_kind(input_ids) == "text":
+        # Order matters: capture must never resolve a kind (no host sync,
+        # no .item()) -- decode graphs only ever replay text tokens.
+        if vl is None or capturing:
+            return orig(
+                hidden_states, router_logits, indices_type, input_ids=input_ids
+            )
+        kind = current_routing_kind(input_ids)
+        if kind == "text":
             return orig(
                 hidden_states, router_logits, indices_type, input_ids=input_ids
             )
@@ -279,6 +290,7 @@ def _wrap_router_compute_routing(router: Any, gate: Any) -> None:
             input_tokens=input_ids,
             hash_indices_table=getattr(router, "_hash_indices_table", None),
             routed_scaling_factor=getattr(router, "routed_scaling_factor", 1.0),
+            kind=kind,
         )
         return _append_fused_shared_experts(router, topk_weights, topk_ids)
 
@@ -313,6 +325,70 @@ def embed_multimodal(self, **kwargs: object):
             )
         )
     return out
+
+
+def _num_tokens(input_ids: Any) -> int:
+    """Row count of a token tensor. ``numel`` is metadata: no host sync."""
+    if hasattr(input_ids, "numel"):
+        return int(input_ids.numel())
+    try:
+        return len(input_ids)
+    except TypeError:
+        return 0
+
+
+def make_embed_input_ids(orig_lm_embed):
+    """Wrap the stock ``embed_input_ids`` and classify the batch once (#175).
+
+    This runs once per forward, ahead of every MoE layer, and already knows
+    whether the step carries multimodal embeddings -- so a text-only step is
+    classified with zero device->host syncs.
+    """
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: Any = None,
+        *,
+        is_multimodal: Any = None,
+    ):
+        # Default for every early return below: no mm embeddings == text.
+        set_pending_routing_kind("text")
+        text_embeds = orig_lm_embed(self, input_ids)
+        if multimodal_embeddings is None:
+            return text_embeds
+        try:
+            empty = len(multimodal_embeddings) == 0
+        except TypeError:
+            empty = False
+        if empty:
+            return text_embeds
+        from vllm.model_executor.models.interfaces import _require_is_multimodal
+        from vllm.model_executor.models.utils import _merge_multimodal_embeddings
+
+        is_mm = _require_is_multimodal(is_multimodal)
+        n_placeholders = (
+            int(is_mm.sum().item()) if hasattr(is_mm, "sum") else int(is_mm)
+        )
+        n_embeds = _mm_embed_rows(multimodal_embeddings)
+        if n_placeholders != n_embeds:
+            raise ValueError(
+                "Vision-Exp placeholder/embedding mismatch: "
+                f"{n_embeds} multimodal tokens vs {n_placeholders} placeholders. "
+                "Image block length depends on start_pos%4; a content-only encoder "
+                "cache hit can reuse the wrong compress_pad (issue #172)."
+            )
+        # Reuses the sum above: the image path stays at one sync per forward.
+        set_pending_routing_kind(
+            routing_kind_from_mm(n_placeholders, _num_tokens(input_ids))
+        )
+        return _merge_multimodal_embeddings(
+            inputs_embeds=text_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_mm,
+        )
+
+    return embed_input_ids
 
 
 @classmethod
@@ -437,42 +513,7 @@ def apply_vision_exp(
 
     orig_lm_embed = DeepseekV4ForCausalLM.embed_input_ids
 
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: Any = None,
-        *,
-        is_multimodal: Any = None,
-    ):
-        text_embeds = orig_lm_embed(self, input_ids)
-        if multimodal_embeddings is None:
-            return text_embeds
-        try:
-            empty = len(multimodal_embeddings) == 0
-        except TypeError:
-            empty = False
-        if empty:
-            return text_embeds
-        from vllm.model_executor.models.interfaces import _require_is_multimodal
-        from vllm.model_executor.models.utils import _merge_multimodal_embeddings
-
-        is_mm = _require_is_multimodal(is_multimodal)
-        n_placeholders = int(is_mm.sum().item()) if hasattr(is_mm, "sum") else int(is_mm)
-        n_embeds = _mm_embed_rows(multimodal_embeddings)
-        if n_placeholders != n_embeds:
-            raise ValueError(
-                "Vision-Exp placeholder/embedding mismatch: "
-                f"{n_embeds} multimodal tokens vs {n_placeholders} placeholders. "
-                "Image block length depends on start_pos%4; a content-only encoder "
-                "cache hit can reuse the wrong compress_pad (issue #172)."
-            )
-        return _merge_multimodal_embeddings(
-            inputs_embeds=text_embeds,
-            multimodal_embeddings=multimodal_embeddings,
-            is_multimodal=is_mm,
-        )
-
-    DeepseekV4ForCausalLM.embed_input_ids = embed_input_ids
+    DeepseekV4ForCausalLM.embed_input_ids = make_embed_input_ids(orig_lm_embed)
 
     if SupportsMultiModal not in DeepseekV4ForCausalLM.__mro__:
         DeepseekV4ForCausalLM.__bases__ = (

--- a/patches/vision_exp/apply.py
+++ b/patches/vision_exp/apply.py
@@ -337,6 +337,13 @@ def tag_routing_owner(root: nn.Module, owner_id: int) -> int:
     ``ffn`` gates are wrapped too) and runs them under its own
     ``ForwardContext``. Tagging by object graph -- not by module name -- keeps
     each model's gates bound to its own ``embed_input_ids``.
+
+    The unit tagged is the MoE layer that owns ``e_score_correction_bias_vl``,
+    not the wrapped router: ``_init_mega_moe_experts`` builds
+    ``DeepseekV4MegaMoEExperts``, which has no ``.router``, and that config
+    routes through ``moe_forward`` / ``_split_ftb`` off the MoE module itself.
+    Counting wrapped routers instead would return 0 there and trip the
+    fail-closed check in ``lm_init``.
     """
     tagged = 0
     for mod in root.modules():

--- a/patches/vision_exp/apply.py
+++ b/patches/vision_exp/apply.py
@@ -155,6 +155,7 @@ def fused_topk_bias_split_vl(
     hash_indices_table: Any,
     routed_scaling_factor: float,
     kind: Any = None,
+    owner_id: Any = None,
 ) -> tuple[Any, Any]:
     """Route image placeholder rows with bias_vl and no hash table (issue #175)."""
     from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
@@ -177,7 +178,7 @@ def fused_topk_bias_split_vl(
 
     vl = _bias_data(e_score_correction_bias_vl)
     if kind is None:
-        kind = current_routing_kind(input_tokens)
+        kind = current_routing_kind(input_tokens, owner_id=owner_id)
     if vl is None or kind == "text":
         return _call(
             hidden_states,
@@ -273,7 +274,9 @@ def _wrap_router_compute_routing(router: Any, gate: Any) -> None:
             return orig(
                 hidden_states, router_logits, indices_type, input_ids=input_ids
             )
-        kind = current_routing_kind(input_ids)
+        kind = current_routing_kind(
+            input_ids, owner_id=getattr(router, "_dspark_routing_owner", None)
+        )
         if kind == "text":
             return orig(
                 hidden_states, router_logits, indices_type, input_ids=input_ids
@@ -327,14 +330,41 @@ def embed_multimodal(self, **kwargs: object):
     return out
 
 
+def tag_routing_owner(root: nn.Module, owner_id: int) -> int:
+    """Mark the MoE layers that may consume ``owner_id``'s published kind.
+
+    The DSpark drafter builds its own ``DeepseekV4DecoderLayer`` stack (so its
+    ``ffn`` gates are wrapped too) and runs them under its own
+    ``ForwardContext``. Tagging by object graph -- not by module name -- keeps
+    each model's gates bound to its own ``embed_input_ids``.
+    """
+    tagged = 0
+    for mod in root.modules():
+        gate = getattr(mod, "gate", None)
+        if gate is None or getattr(gate, "e_score_correction_bias_vl", None) is None:
+            continue
+        mod._dspark_routing_owner = owner_id
+        router = getattr(getattr(mod, "experts", None), "router", None)
+        if router is not None:
+            router._dspark_routing_owner = owner_id
+        tagged += 1
+    return tagged
+
+
 def _num_tokens(input_ids: Any) -> int:
-    """Row count of a token tensor. ``numel`` is metadata: no host sync."""
+    """Row count of a token tensor. ``numel`` is metadata: no host sync.
+
+    Never guesses: a 0 here would make any non-empty placeholder count look
+    like a full-image batch.
+    """
     if hasattr(input_ids, "numel"):
         return int(input_ids.numel())
     try:
         return len(input_ids)
-    except TypeError:
-        return 0
+    except TypeError as exc:
+        raise TypeError(
+            f"Vision-Exp cannot size input_ids of type {type(input_ids).__name__}"
+        ) from exc
 
 
 def make_embed_input_ids(orig_lm_embed):
@@ -353,7 +383,7 @@ def make_embed_input_ids(orig_lm_embed):
         is_multimodal: Any = None,
     ):
         # Default for every early return below: no mm embeddings == text.
-        set_pending_routing_kind("text")
+        set_pending_routing_kind("text", id(self))
         text_embeds = orig_lm_embed(self, input_ids)
         if multimodal_embeddings is None:
             return text_embeds
@@ -380,7 +410,7 @@ def make_embed_input_ids(orig_lm_embed):
             )
         # Reuses the sum above: the image path stays at one sync per forward.
         set_pending_routing_kind(
-            routing_kind_from_mm(n_placeholders, _num_tokens(input_ids))
+            routing_kind_from_mm(n_placeholders, _num_tokens(input_ids)), id(self)
         )
         return _merge_multimodal_embeddings(
             inputs_embeds=text_embeds,
@@ -489,7 +519,9 @@ def apply_vision_exp(
                     "issue #175 mega-MoE wrap expects fused_topk_bias keyword args"
                 )
             return fused_topk_bias_split_vl(
-                e_score_correction_bias_vl=vl, **kwargs
+                e_score_correction_bias_vl=vl,
+                owner_id=getattr(self, "_dspark_routing_owner", None),
+                **kwargs,
             )
 
         nvidia_mod.fused_topk_bias = _split_ftb
@@ -505,6 +537,14 @@ def apply_vision_exp(
     def lm_init(self, *, vllm_config, prefix: str = ""):
         orig_lm_init(self, vllm_config=vllm_config, prefix=prefix)
         self.hf_to_vllm_mapper = _extend_weights_mapper(self.hf_to_vllm_mapper)
+        tagged = tag_routing_owner(self, id(self))
+        if getattr(vllm_config.model_config.hf_config, "vision_n_layers", 0) > 0:
+            if tagged == 0:
+                raise RuntimeError(
+                    "Vision-Exp found no bias_vl MoE gate to bind to this model; "
+                    "the per-forward routing kind would never be consumed and "
+                    "every gate would host-sync again (issue #175)"
+                )
 
     DeepseekV4ForCausalLM.__init__ = lm_init
     DeepseekV4ForCausalLM.hf_to_vllm_mapper = _extend_weights_mapper(

--- a/patches/vision_exp/apply.py
+++ b/patches/vision_exp/apply.py
@@ -18,7 +18,6 @@ from .image_processor import (
     is_unregistered_router_bias,
     is_vision_exp_weight_name,
     routing_kind_from_mm,
-    set_pending_routing_kind,
     vision_args_from_config,
 )
 from .processor import IMAGE_PLACEHOLDER, register_vision_exp_processor
@@ -155,7 +154,7 @@ def fused_topk_bias_split_vl(
     hash_indices_table: Any,
     routed_scaling_factor: float,
     kind: Any = None,
-    owner_id: Any = None,
+    kind_cell: Any = None,
 ) -> tuple[Any, Any]:
     """Route image placeholder rows with bias_vl and no hash table (issue #175)."""
     from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
@@ -178,7 +177,7 @@ def fused_topk_bias_split_vl(
 
     vl = _bias_data(e_score_correction_bias_vl)
     if kind is None:
-        kind = current_routing_kind(input_tokens, owner_id=owner_id)
+        kind = current_routing_kind(input_tokens, kind_cell=kind_cell)
     if vl is None or kind == "text":
         return _call(
             hidden_states,
@@ -275,7 +274,7 @@ def _wrap_router_compute_routing(router: Any, gate: Any) -> None:
                 hidden_states, router_logits, indices_type, input_ids=input_ids
             )
         kind = current_routing_kind(
-            input_ids, owner_id=getattr(router, "_dspark_routing_owner", None)
+            input_ids, kind_cell=getattr(router, "_dspark_routing_kind_cell", None)
         )
         if kind == "text":
             return orig(
@@ -330,32 +329,19 @@ def embed_multimodal(self, **kwargs: object):
     return out
 
 
-def tag_routing_owner(root: nn.Module, owner_id: int) -> int:
-    """Mark the MoE layers that may consume ``owner_id``'s published kind.
-
-    The DSpark drafter builds its own ``DeepseekV4DecoderLayer`` stack (so its
-    ``ffn`` gates are wrapped too) and runs them under its own
-    ``ForwardContext``. Tagging by object graph -- not by module name -- keeps
-    each model's gates bound to its own ``embed_input_ids``.
-
-    The unit tagged is the MoE layer that owns ``e_score_correction_bias_vl``,
-    not the wrapped router: ``_init_mega_moe_experts`` builds
-    ``DeepseekV4MegaMoEExperts``, which has no ``.router``, and that config
-    routes through ``moe_forward`` / ``_split_ftb`` off the MoE module itself.
-    Counting wrapped routers instead would return 0 there and trip the
-    fail-closed check in ``lm_init``.
-    """
-    tagged = 0
+def attach_routing_kind_cell(root: nn.Module, kind_cell: list[Any]) -> int:
+    """Share one model-local publication cell with its Vision-Exp MoE gates."""
+    attached = 0
     for mod in root.modules():
         gate = getattr(mod, "gate", None)
         if gate is None or getattr(gate, "e_score_correction_bias_vl", None) is None:
             continue
-        mod._dspark_routing_owner = owner_id
+        mod._dspark_routing_kind_cell = kind_cell
         router = getattr(getattr(mod, "experts", None), "router", None)
         if router is not None:
-            router._dspark_routing_owner = owner_id
-        tagged += 1
-    return tagged
+            router._dspark_routing_kind_cell = kind_cell
+        attached += 1
+    return attached
 
 
 def _num_tokens(input_ids: Any) -> int:
@@ -390,7 +376,7 @@ def make_embed_input_ids(orig_lm_embed):
         is_multimodal: Any = None,
     ):
         # Default for every early return below: no mm embeddings == text.
-        set_pending_routing_kind("text", id(self))
+        self._dspark_routing_kind_cell[0] = "text"
         text_embeds = orig_lm_embed(self, input_ids)
         if multimodal_embeddings is None:
             return text_embeds
@@ -416,8 +402,8 @@ def make_embed_input_ids(orig_lm_embed):
                 "cache hit can reuse the wrong compress_pad (issue #172)."
             )
         # Reuses the sum above: the image path stays at one sync per forward.
-        set_pending_routing_kind(
-            routing_kind_from_mm(n_placeholders, _num_tokens(input_ids)), id(self)
+        self._dspark_routing_kind_cell[0] = routing_kind_from_mm(
+            n_placeholders, _num_tokens(input_ids)
         )
         return _merge_multimodal_embeddings(
             inputs_embeds=text_embeds,
@@ -527,7 +513,7 @@ def apply_vision_exp(
                 )
             return fused_topk_bias_split_vl(
                 e_score_correction_bias_vl=vl,
-                owner_id=getattr(self, "_dspark_routing_owner", None),
+                kind_cell=getattr(self, "_dspark_routing_kind_cell", None),
                 **kwargs,
             )
 
@@ -544,9 +530,10 @@ def apply_vision_exp(
     def lm_init(self, *, vllm_config, prefix: str = ""):
         orig_lm_init(self, vllm_config=vllm_config, prefix=prefix)
         self.hf_to_vllm_mapper = _extend_weights_mapper(self.hf_to_vllm_mapper)
-        tagged = tag_routing_owner(self, id(self))
+        self._dspark_routing_kind_cell = [None]
+        attached = attach_routing_kind_cell(self, self._dspark_routing_kind_cell)
         if getattr(vllm_config.model_config.hf_config, "vision_n_layers", 0) > 0:
-            if tagged == 0:
+            if attached == 0:
                 raise RuntimeError(
                     "Vision-Exp found no bias_vl MoE gate to bind to this model; "
                     "the per-forward routing kind would never be consumed and "

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import io
+import logging
 import math
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -109,16 +110,15 @@ _ROUTING_KIND_CTX_ATTR = "_dspark_vision_exp_routing_kind"
 _PENDING_ROUTING_KIND = None
 _PENDING_SEQ = 0
 _FORWARD_CONTEXT_HOOKS = None
-_WARNED = set()
+_LOGGED_ONCE = set()
+_LOGGER = logging.getLogger(__name__)
 
 
-def _warn_once(msg: str, *args: Any) -> None:
-    if msg in _WARNED:
+def _log_once(level: int, msg: str, *args: Any) -> None:
+    if msg in _LOGGED_ONCE:
         return
-    _WARNED.add(msg)
-    import logging
-
-    logging.getLogger(__name__).warning(msg, *args)
+    _LOGGED_ONCE.add(msg)
+    _LOGGER.log(level, msg, *args)
 
 
 def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
@@ -162,15 +162,36 @@ def _take_pending_routing_kind(owner_id: Any):
         return None
     kind, pending_owner, seq = pending
     if pending_owner != owner_id:
-        # Not ours: leave it for its real owner and scan instead. Loud, because
-        # a scan here is 43 host syncs per forward coming back.
-        _warn_once(
-            "vision_exp: routing kind seq=%s published by owner %s reached "
-            "owner %s; falling back to a per-layer token scan (issue #175)",
-            seq,
-            pending_owner,
-            owner_id,
-        )
+        # Not ours: leave it for its real owner and scan instead.
+        if owner_id is None:
+            # Expected, and it happens on ordinary steps: an untagged gate does
+            # not belong to a model that publishes kinds. The DSpark drafter
+            # builds its own DeepseekV4DecoderLayer stack and opens its own
+            # ForwardContext, and a target step that replayed a full CUDA graph
+            # ran no Python in its gates, so its value is still sitting here.
+            # The drafter scanning for itself is correct pre-#175 behaviour and
+            # the target model is unaffected -- this is not a fault.
+            _log_once(
+                logging.DEBUG,
+                "vision_exp: routing kind seq=%s (owner %s) was read by an "
+                "untagged gate; expected spec-decode drafter path, that gate "
+                "scans for itself and the target model is unaffected",
+                seq,
+                pending_owner,
+            )
+        else:
+            # A tagged gate belongs to a model that does publish kinds, so two
+            # of them crossed. Unexpected, and it costs 43 host syncs per
+            # forward -- say so.
+            _log_once(
+                logging.WARNING,
+                "vision_exp: routing kind seq=%s published by owner %s reached "
+                "tagged owner %s; unexpected, falling back to a per-layer token "
+                "scan (issue #175)",
+                seq,
+                pending_owner,
+                owner_id,
+            )
         return None
     _PENDING_ROUTING_KIND = None
     return kind

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import base64
 import io
-import logging
 import math
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -92,33 +91,12 @@ def token_routing_kind(input_tokens: Any, image_token_id: int = IMAGE_TOKEN_ID) 
     return "mixed"
 
 
-# --- per-forward routing kind (issue #175 host-sync removal) -----------------
-# ``token_routing_kind`` ends in ``.sum().item()``: a device->host sync. It used
-# to run once per MoE gate per forward (43 syncs, and prefill is never captured
-# into a CUDA graph, so plain text prompts paid them too). The runner now
-# classifies the batch once in ``embed_input_ids`` -- which runs before any MoE
-# layer -- and publishes the answer through ``_PENDING_ROUTING_KIND``. The first
-# MoE gate of the step moves it onto vLLM's per-step ``ForwardContext``; every
-# later gate then reads it for free.
-#
-# ``set_forward_context`` builds a fresh ``ForwardContext`` per step, so the
-# attribute cannot leak into the next step. An ``id(input_ids)`` memo would:
-# the runner hands out slices of one preallocated buffer, so each step gets a
-# new view object whose id is silently recycled.
+# ``token_routing_kind`` ends in ``.sum().item()``. The runner classifies the
+# batch in ``embed_input_ids`` before the step's ``ForwardContext`` exists, then
+# the first eager MoE gate moves that model's one-slot value onto the fresh
+# context. Later gates read it without another host sync.
 _ROUTING_KIND_CTX_ATTR = "_dspark_vision_exp_routing_kind"
-# (kind, owner_id, seq) published by embed_input_ids, or None once consumed.
-_PENDING_ROUTING_KIND = None
-_PENDING_SEQ = 0
 _FORWARD_CONTEXT_HOOKS = None
-_LOGGED_ONCE = set()
-_LOGGER = logging.getLogger(__name__)
-
-
-def _log_once(level: int, msg: str, *args: Any) -> None:
-    if msg in _LOGGED_ONCE:
-        return
-    _LOGGED_ONCE.add(msg)
-    _LOGGER.log(level, msg, *args)
 
 
 def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
@@ -141,60 +119,6 @@ def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
     return "mixed"
 
 
-def set_pending_routing_kind(kind: Any, owner_id: Any = None) -> None:
-    """Publish the routing kind for the forward that is about to start.
-
-    ``owner_id`` is ``id()`` of the ``embed_input_ids`` receiver. Only MoE
-    gates tagged with the same owner may consume it: the DSpark drafter builds
-    its own ``DeepseekV4DecoderLayer``/``DeepseekV4MoE`` stack and opens its own
-    ``ForwardContext``, so an unstamped value could be eaten by another model.
-    """
-    global _PENDING_ROUTING_KIND, _PENDING_SEQ
-    _PENDING_SEQ += 1
-    _PENDING_ROUTING_KIND = None if kind is None else (kind, owner_id, _PENDING_SEQ)
-
-
-def _take_pending_routing_kind(owner_id: Any):
-    """One-shot, owner-checked read. None when there is nothing of ours."""
-    global _PENDING_ROUTING_KIND
-    pending = _PENDING_ROUTING_KIND
-    if pending is None:
-        return None
-    kind, pending_owner, seq = pending
-    if pending_owner != owner_id:
-        # Not ours: leave it for its real owner and scan instead.
-        if owner_id is None:
-            # Expected, and it happens on ordinary steps: an untagged gate does
-            # not belong to a model that publishes kinds. The DSpark drafter
-            # builds its own DeepseekV4DecoderLayer stack and opens its own
-            # ForwardContext, and a target step that replayed a full CUDA graph
-            # ran no Python in its gates, so its value is still sitting here.
-            # The drafter scanning for itself is correct pre-#175 behaviour and
-            # the target model is unaffected -- this is not a fault.
-            _log_once(
-                logging.DEBUG,
-                "vision_exp: routing kind seq=%s (owner %s) was read by an "
-                "untagged gate; expected spec-decode drafter path, that gate "
-                "scans for itself and the target model is unaffected",
-                seq,
-                pending_owner,
-            )
-        else:
-            # A tagged gate belongs to a model that does publish kinds, so two
-            # of them crossed. Unexpected, and it costs 43 host syncs per
-            # forward -- say so.
-            _log_once(
-                logging.WARNING,
-                "vision_exp: routing kind seq=%s published by owner %s reached "
-                "tagged owner %s; unexpected, falling back to a per-layer token "
-                "scan (issue #175)",
-                seq,
-                pending_owner,
-                owner_id,
-            )
-        return None
-    _PENDING_ROUTING_KIND = None
-    return kind
 
 
 def _forward_context_or_none():
@@ -222,26 +146,26 @@ def _forward_context_or_none():
 def current_routing_kind(
     input_tokens: Any,
     image_token_id: int = IMAGE_TOKEN_ID,
-    owner_id: Any = None,
+    kind_cell: Any = None,
 ) -> str:
-    """Routing kind of the running forward, computed at most once per step.
+    """Return one routing kind per eager forward.
 
-    Falls back to a fresh ``token_routing_kind`` scan whenever the per-step
-    carrier is missing (no forward context, a forward that never went through
-    ``embed_input_ids``, another model's pending value), so the semantics are
-    unchanged -- only the sync count differs.
+    ``kind_cell`` belongs to one language-model instance and is shared only
+    with that model's gates. A missing publication falls back to one token scan
+    memoized on the current ``ForwardContext``.
     """
     ctx = _forward_context_or_none()
     if ctx is None:
         return token_routing_kind(input_tokens, image_token_id)
     kind = getattr(ctx, _ROUTING_KIND_CTX_ATTR, None)
     if kind is None:
-        kind = _take_pending_routing_kind(owner_id)
+        if kind_cell is not None:
+            kind = kind_cell[0]
+            kind_cell[0] = None
         if kind is None:
             kind = token_routing_kind(input_tokens, image_token_id)
-        # Deliberately unguarded: if ForwardContext ever stops accepting
-        # attributes this must fail at warmup, not silently restore 43 syncs
-        # per forward. _dummy_run reaches this before the server is healthy.
+        # Fail during warmup if ForwardContext stops accepting attributes;
+        # silently restoring 43 scans per forward is not a safe fallback.
         setattr(ctx, _ROUTING_KIND_CTX_ATTR, kind)
     return kind
 

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -105,7 +105,20 @@ def token_routing_kind(input_tokens: Any, image_token_id: int = IMAGE_TOKEN_ID) 
 # the runner hands out slices of one preallocated buffer, so each step gets a
 # new view object whose id is silently recycled.
 _ROUTING_KIND_CTX_ATTR = "_dspark_vision_exp_routing_kind"
+# (kind, owner_id, seq) published by embed_input_ids, or None once consumed.
 _PENDING_ROUTING_KIND = None
+_PENDING_SEQ = 0
+_FORWARD_CONTEXT_HOOKS = None
+_WARNED = set()
+
+
+def _warn_once(msg: str, *args: Any) -> None:
+    if msg in _WARNED:
+        return
+    _WARNED.add(msg)
+    import logging
+
+    logging.getLogger(__name__).warning(msg, *args)
 
 
 def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
@@ -116,6 +129,11 @@ def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
     ``is_multimodal`` is the runner's authoritative "these rows get image
     embeddings" mask, i.e. exactly the rows that must route with ``bias_vl``.
     """
+    if n_tokens <= 0:
+        raise ValueError(
+            f"Vision-Exp routing kind needs a token count, got n_tokens={n_tokens!r} "
+            f"with n_placeholders={n_placeholders!r}"
+        )
     if n_placeholders <= 0:
         return "text"
     if n_placeholders >= n_tokens:
@@ -123,58 +141,87 @@ def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
     return "mixed"
 
 
-def set_pending_routing_kind(kind: Any) -> None:
-    """Publish the routing kind for the forward that is about to start."""
-    global _PENDING_ROUTING_KIND
-    _PENDING_ROUTING_KIND = kind
+def set_pending_routing_kind(kind: Any, owner_id: Any = None) -> None:
+    """Publish the routing kind for the forward that is about to start.
+
+    ``owner_id`` is ``id()`` of the ``embed_input_ids`` receiver. Only MoE
+    gates tagged with the same owner may consume it: the DSpark drafter builds
+    its own ``DeepseekV4DecoderLayer``/``DeepseekV4MoE`` stack and opens its own
+    ``ForwardContext``, so an unstamped value could be eaten by another model.
+    """
+    global _PENDING_ROUTING_KIND, _PENDING_SEQ
+    _PENDING_SEQ += 1
+    _PENDING_ROUTING_KIND = None if kind is None else (kind, owner_id, _PENDING_SEQ)
 
 
-def _take_pending_routing_kind():
-    """One-shot read, so a stale kind can never be reused by a later forward."""
+def _take_pending_routing_kind(owner_id: Any):
+    """One-shot, owner-checked read. None when there is nothing of ours."""
     global _PENDING_ROUTING_KIND
-    kind = _PENDING_ROUTING_KIND
+    pending = _PENDING_ROUTING_KIND
+    if pending is None:
+        return None
+    kind, pending_owner, seq = pending
+    if pending_owner != owner_id:
+        # Not ours: leave it for its real owner and scan instead. Loud, because
+        # a scan here is 43 host syncs per forward coming back.
+        _warn_once(
+            "vision_exp: routing kind seq=%s published by owner %s reached "
+            "owner %s; falling back to a per-layer token scan (issue #175)",
+            seq,
+            pending_owner,
+            owner_id,
+        )
+        return None
     _PENDING_ROUTING_KIND = None
     return kind
 
 
 def _forward_context_or_none():
-    """The current ``ForwardContext``, or None outside a vLLM forward."""
-    try:
-        from vllm.forward_context import (
-            get_forward_context,
-            is_forward_context_available,
+    """The current ``ForwardContext``, or None when no forward is running.
+
+    Resolved once and cached. A missing symbol is a hard failure, exactly like
+    this patch's dependency on ``_require_is_multimodal``: degrading quietly
+    would put 43 host syncs per forward back with nothing to show for it. The
+    import stays lazy so the CPU test suite can import this module without vLLM.
+    """
+    global _FORWARD_CONTEXT_HOOKS
+    if _FORWARD_CONTEXT_HOOKS is None:
+        from vllm import forward_context as _fc
+
+        _FORWARD_CONTEXT_HOOKS = (
+            _fc.is_forward_context_available,
+            _fc.get_forward_context,
         )
-    except Exception:
+    available, get_ctx = _FORWARD_CONTEXT_HOOKS
+    if not available():
         return None
-    try:
-        if not is_forward_context_available():
-            return None
-        return get_forward_context()
-    except Exception:
-        return None
+    return get_ctx()
 
 
 def current_routing_kind(
-    input_tokens: Any, image_token_id: int = IMAGE_TOKEN_ID
+    input_tokens: Any,
+    image_token_id: int = IMAGE_TOKEN_ID,
+    owner_id: Any = None,
 ) -> str:
     """Routing kind of the running forward, computed at most once per step.
 
     Falls back to a fresh ``token_routing_kind`` scan whenever the per-step
-    carrier is missing (no forward context, or a forward that never went
-    through ``embed_input_ids``), so the semantics are unchanged.
+    carrier is missing (no forward context, a forward that never went through
+    ``embed_input_ids``, another model's pending value), so the semantics are
+    unchanged -- only the sync count differs.
     """
     ctx = _forward_context_or_none()
     if ctx is None:
         return token_routing_kind(input_tokens, image_token_id)
     kind = getattr(ctx, _ROUTING_KIND_CTX_ATTR, None)
     if kind is None:
-        kind = _take_pending_routing_kind()
+        kind = _take_pending_routing_kind(owner_id)
         if kind is None:
             kind = token_routing_kind(input_tokens, image_token_id)
-        try:
-            setattr(ctx, _ROUTING_KIND_CTX_ATTR, kind)
-        except Exception:
-            pass
+        # Deliberately unguarded: if ForwardContext ever stops accepting
+        # attributes this must fail at warmup, not silently restore 43 syncs
+        # per forward. _dummy_run reaches this before the server is healthy.
+        setattr(ctx, _ROUTING_KIND_CTX_ATTR, kind)
     return kind
 
 

--- a/patches/vision_exp/image_processor.py
+++ b/patches/vision_exp/image_processor.py
@@ -91,6 +91,93 @@ def token_routing_kind(input_tokens: Any, image_token_id: int = IMAGE_TOKEN_ID) 
     return "mixed"
 
 
+# --- per-forward routing kind (issue #175 host-sync removal) -----------------
+# ``token_routing_kind`` ends in ``.sum().item()``: a device->host sync. It used
+# to run once per MoE gate per forward (43 syncs, and prefill is never captured
+# into a CUDA graph, so plain text prompts paid them too). The runner now
+# classifies the batch once in ``embed_input_ids`` -- which runs before any MoE
+# layer -- and publishes the answer through ``_PENDING_ROUTING_KIND``. The first
+# MoE gate of the step moves it onto vLLM's per-step ``ForwardContext``; every
+# later gate then reads it for free.
+#
+# ``set_forward_context`` builds a fresh ``ForwardContext`` per step, so the
+# attribute cannot leak into the next step. An ``id(input_ids)`` memo would:
+# the runner hands out slices of one preallocated buffer, so each step gets a
+# new view object whose id is silently recycled.
+_ROUTING_KIND_CTX_ATTR = "_dspark_vision_exp_routing_kind"
+_PENDING_ROUTING_KIND = None
+
+
+def routing_kind_from_mm(n_placeholders: int, n_tokens: int) -> str:
+    """Routing kind from the multimodal placeholder count. No host sync.
+
+    ``n_placeholders`` is ``is_multimodal.sum()``, which ``embed_input_ids``
+    already reads for the issue #172 length check, so this costs nothing extra.
+    ``is_multimodal`` is the runner's authoritative "these rows get image
+    embeddings" mask, i.e. exactly the rows that must route with ``bias_vl``.
+    """
+    if n_placeholders <= 0:
+        return "text"
+    if n_placeholders >= n_tokens:
+        return "image"
+    return "mixed"
+
+
+def set_pending_routing_kind(kind: Any) -> None:
+    """Publish the routing kind for the forward that is about to start."""
+    global _PENDING_ROUTING_KIND
+    _PENDING_ROUTING_KIND = kind
+
+
+def _take_pending_routing_kind():
+    """One-shot read, so a stale kind can never be reused by a later forward."""
+    global _PENDING_ROUTING_KIND
+    kind = _PENDING_ROUTING_KIND
+    _PENDING_ROUTING_KIND = None
+    return kind
+
+
+def _forward_context_or_none():
+    """The current ``ForwardContext``, or None outside a vLLM forward."""
+    try:
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+    except Exception:
+        return None
+    try:
+        if not is_forward_context_available():
+            return None
+        return get_forward_context()
+    except Exception:
+        return None
+
+
+def current_routing_kind(
+    input_tokens: Any, image_token_id: int = IMAGE_TOKEN_ID
+) -> str:
+    """Routing kind of the running forward, computed at most once per step.
+
+    Falls back to a fresh ``token_routing_kind`` scan whenever the per-step
+    carrier is missing (no forward context, or a forward that never went
+    through ``embed_input_ids``), so the semantics are unchanged.
+    """
+    ctx = _forward_context_or_none()
+    if ctx is None:
+        return token_routing_kind(input_tokens, image_token_id)
+    kind = getattr(ctx, _ROUTING_KIND_CTX_ATTR, None)
+    if kind is None:
+        kind = _take_pending_routing_kind()
+        if kind is None:
+            kind = token_routing_kind(input_tokens, image_token_id)
+        try:
+            setattr(ctx, _ROUTING_KIND_CTX_ATTR, kind)
+        except Exception:
+            pass
+    return kind
+
+
 def is_vision_exp_weight_name(name: str) -> bool:
     """Checkpoint keys for the ViT/Aligner/image tokens.
 

--- a/tests/test_issue175_routing_kind_once.py
+++ b/tests/test_issue175_routing_kind_once.py
@@ -3,7 +3,7 @@
 ``token_routing_kind`` ends in ``.sum().item()``. It used to run in every MoE
 gate (43 per forward, and prefill is never CUDA-graphed, so text prompts paid
 it too). The batch is now classified once in ``embed_input_ids`` and carried on
-vLLM's per-step ``ForwardContext``.
+vLLM's per-step ``ForwardContext``, bound to the model that published it.
 
 Run inside the container:
   python3 tests/test_issue175_routing_kind_once.py
@@ -15,6 +15,7 @@ import types
 from pathlib import Path
 
 import torch
+from torch import nn
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "patches"))
 
@@ -44,6 +45,7 @@ def syncs():
 def reset():
     _counter["n"] = 0
     ip.set_pending_routing_kind(None)
+    ip._WARNED.clear()
 
 
 FAILURES = []
@@ -56,34 +58,49 @@ def check(name, got, want):
         FAILURES.append(name)
 
 
+def raises(name, exc_type, fn):
+    try:
+        fn()
+    except exc_type as e:
+        print(f"  [PASS] {name}: raised {type(e).__name__}")
+        return
+    except Exception as e:  # noqa: BLE001
+        print(f"  [FAIL] {name}: raised {type(e).__name__}, want {exc_type.__name__}")
+        FAILURES.append(name)
+        return
+    print(f"  [FAIL] {name}: no exception, want {exc_type.__name__}")
+    FAILURES.append(name)
+
+
 def fake_ctx():
     return types.SimpleNamespace(tag="forward-context")
 
 
-def embed_fn():
-    """The real patched embed_input_ids over a stub base embedding."""
+class FakeLM:
+    """Stands in for DeepseekV4ForCausalLM as the embed_input_ids receiver."""
 
+
+def embed_fn():
     def orig(self, input_ids):
         return torch.zeros((int(input_ids.numel()), 4), dtype=torch.float32)
 
     return ap.make_embed_input_ids(orig)
 
 
-def gate_reads(ids, n=N_MOE_LAYERS):
+def gate_reads(ids, owner_id, n=N_MOE_LAYERS):
     """Simulate the N MoE gates of one forward reading the routing kind."""
-    return {ip.current_routing_kind(ids) for _ in range(n)}
+    return {ip.current_routing_kind(ids, owner_id=owner_id) for _ in range(n)}
 
 
 # --------------------------------------------------------------------------
 print("1. text batch: embed + 43 gate reads")
 reset()
-embed = embed_fn()
+embed, lm = embed_fn(), FakeLM()
 ids = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.long)
 with override_forward_context(None):
-    out = embed(None, ids, multimodal_embeddings=None, is_multimodal=None)
-ctx = fake_ctx()
-with override_forward_context(ctx):
-    kinds = gate_reads(ids)
+    out = embed(lm, ids, multimodal_embeddings=None, is_multimodal=None)
+with override_forward_context(fake_ctx()):
+    kinds = gate_reads(ids, id(lm))
 check("text kind", kinds, {"text"})
 check("text .item() count", syncs(), 0)
 check("text embed shape", tuple(out.shape), (6, 4))
@@ -91,44 +108,46 @@ check("text embed shape", tuple(out.shape), (6, 4))
 # --------------------------------------------------------------------------
 print("2. all-image batch: embed + 43 gate reads")
 reset()
-embed = embed_fn()
+embed, lm = embed_fn(), FakeLM()
 ids = torch.full((8,), ID, dtype=torch.long)
-mm = [torch.ones((8, 4), dtype=torch.float32)]
-is_mm = torch.ones(8, dtype=torch.bool)
 with override_forward_context(None):
-    embed(None, ids, multimodal_embeddings=mm, is_multimodal=is_mm)
-ctx = fake_ctx()
-with override_forward_context(ctx):
-    kinds = gate_reads(ids)
+    embed(
+        lm,
+        ids,
+        multimodal_embeddings=[torch.ones((8, 4))],
+        is_multimodal=torch.ones(8, dtype=torch.bool),
+    )
+with override_forward_context(fake_ctx()):
+    kinds = gate_reads(ids, id(lm))
 check("image kind", kinds, {"image"})
-check("image .item() count <= 1", syncs() <= 1, True)
 check("image .item() count", syncs(), 1)
 
 # --------------------------------------------------------------------------
 print("3. mixed batch: embed + 43 gate reads")
 reset()
-embed = embed_fn()
+embed, lm = embed_fn(), FakeLM()
 ids = torch.tensor([7, ID, ID, ID, 9], dtype=torch.long)
-mm = [torch.ones((3, 4), dtype=torch.float32)]
-is_mm = torch.tensor([False, True, True, True, False])
 with override_forward_context(None):
-    embed(None, ids, multimodal_embeddings=mm, is_multimodal=is_mm)
-ctx = fake_ctx()
-with override_forward_context(ctx):
-    kinds = gate_reads(ids)
+    embed(
+        lm,
+        ids,
+        multimodal_embeddings=[torch.ones((3, 4))],
+        is_multimodal=torch.tensor([False, True, True, True, False]),
+    )
+with override_forward_context(fake_ctx()):
+    kinds = gate_reads(ids, id(lm))
 check("mixed kind", kinds, {"mixed"})
 check("mixed .item() count", syncs(), 1)
 
 # --------------------------------------------------------------------------
 print("4. empty mm list is text (encoder ran but produced nothing)")
 reset()
-embed = embed_fn()
+embed, lm = embed_fn(), FakeLM()
 ids = torch.tensor([1, 2, 3], dtype=torch.long)
 with override_forward_context(None):
-    embed(None, ids, multimodal_embeddings=[], is_multimodal=None)
-ctx = fake_ctx()
-with override_forward_context(ctx):
-    kinds = gate_reads(ids)
+    embed(lm, ids, multimodal_embeddings=[], is_multimodal=None)
+with override_forward_context(fake_ctx()):
+    kinds = gate_reads(ids, id(lm))
 check("empty-mm kind", kinds, {"text"})
 check("empty-mm .item() count", syncs(), 0)
 
@@ -145,40 +164,38 @@ for name, t in [
     reset()
     with override_forward_context(None):
         got = ip.current_routing_kind(t)
-    want = ip.token_routing_kind(t)
-    check(f"fallback {name}", got, want)
+    check(f"fallback {name}", got, ip.token_routing_kind(t))
 
 # --------------------------------------------------------------------------
 print("6. fallback inside a context with no pending kind (dummy/warmup run)")
 reset()
 ids = torch.tensor([1, ID, 2], dtype=torch.long)
-ctx = fake_ctx()
-with override_forward_context(ctx):
-    kinds = gate_reads(ids)
+with override_forward_context(fake_ctx()):
+    kinds = gate_reads(ids, None)
 check("no-pending kind", kinds, {"mixed"})
 check("no-pending syncs (memoized after 1st gate)", syncs(), 1)
 
 # --------------------------------------------------------------------------
 print("7. per-step isolation: a new ForwardContext never reuses the old kind")
 reset()
-embed = embed_fn()
+embed, lm = embed_fn(), FakeLM()
 img_ids = torch.full((4,), ID, dtype=torch.long)
 with override_forward_context(None):
     embed(
-        None,
+        lm,
         img_ids,
         multimodal_embeddings=[torch.ones((4, 4))],
         is_multimodal=torch.ones(4, dtype=torch.bool),
     )
 ctx_a = fake_ctx()
 with override_forward_context(ctx_a):
-    a = ip.current_routing_kind(img_ids)
+    a = ip.current_routing_kind(img_ids, owner_id=id(lm))
 txt_ids = torch.tensor([1, 2, 3], dtype=torch.long)
 with override_forward_context(None):
-    embed(None, txt_ids, multimodal_embeddings=None, is_multimodal=None)
+    embed(lm, txt_ids, multimodal_embeddings=None, is_multimodal=None)
 ctx_b = fake_ctx()
 with override_forward_context(ctx_b):
-    b = ip.current_routing_kind(txt_ids)
+    b = ip.current_routing_kind(txt_ids, owner_id=id(lm))
 check("step A kind", a, "image")
 check("step B kind (fresh ctx)", b, "text")
 check("ctx A attr", getattr(ctx_a, ip._ROUTING_KIND_CTX_ATTR, None), "image")
@@ -187,16 +204,40 @@ check("ctx B attr", getattr(ctx_b, ip._ROUTING_KIND_CTX_ATTR, None), "text")
 # --------------------------------------------------------------------------
 print("8. stale pending is one-shot: a second forward cannot reuse it")
 reset()
-ip.set_pending_routing_kind("image")
+ip.set_pending_routing_kind("image", 777)
 with override_forward_context(fake_ctx()):
-    first = ip.current_routing_kind(torch.tensor([1, 2, 3]))
+    first = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=777)
 with override_forward_context(fake_ctx()):
-    second = ip.current_routing_kind(torch.tensor([1, 2, 3]))
+    second = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=777)
 check("1st consumes pending", first, "image")
 check("2nd falls back (not stale)", second, "text")
 
 # --------------------------------------------------------------------------
-print("9. CUDA-graph capture short-circuits before any kind resolution")
+print("9. DSpark drafter cannot eat the target's pending kind (owner stamp)")
+reset()
+target, drafter = FakeLM(), FakeLM()
+embed = embed_fn()
+img_ids = torch.full((4,), ID, dtype=torch.long)
+with override_forward_context(None):
+    embed(
+        target,
+        img_ids,
+        multimodal_embeddings=[torch.ones((4, 4))],
+        is_multimodal=torch.ones(4, dtype=torch.bool),
+    )
+reset_syncs = _counter["n"]
+# The drafter opens its own ForwardContext and runs its own wrapped MoE gates.
+with override_forward_context(fake_ctx()):
+    stolen = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=id(drafter))
+check("drafter gets its own answer, not 'image'", stolen, "text")
+check("pending survives for its owner", ip._PENDING_ROUTING_KIND[0], "image")
+check("owner mismatch warned (not silent)", len(ip._WARNED), 1)
+with override_forward_context(fake_ctx()):
+    mine = ip.current_routing_kind(img_ids, owner_id=id(target))
+check("target still gets 'image'", mine, "image")
+
+# --------------------------------------------------------------------------
+print("10. CUDA-graph capture short-circuits before any kind resolution")
 reset()
 calls = {"orig": 0}
 
@@ -217,23 +258,27 @@ class _Router:
         return ("orig", input_ids)
 
 
+lm = FakeLM()
 router = _Router()
 ap._wrap_router_compute_routing(router, _Gate())
+router._dspark_routing_owner = id(lm)
 real_capturing = torch.cuda.is_current_stream_capturing
 torch.cuda.is_current_stream_capturing = lambda: True
 try:
-    ip.set_pending_routing_kind("image")  # would route image if consulted
-    img_ids = torch.full((4,), ID, dtype=torch.long)
+    ip.set_pending_routing_kind("image", id(lm))  # would route image if consulted
     with override_forward_context(fake_ctx()):
-        r = router._compute_routing(torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=img_ids)
-    check("capturing -> orig路径", r[0], "orig")
+        r = router._compute_routing(
+            torch.zeros((4, 4)), torch.zeros((4, 4)), None,
+            input_ids=torch.full((4,), ID, dtype=torch.long),
+        )
+    check("capturing -> orig path", r[0], "orig")
     check("capturing .item() count", syncs(), 0)
-    check("capturing did not consume pending", ip._PENDING_ROUTING_KIND, "image")
+    check("capturing did not consume pending", ip._PENDING_ROUTING_KIND[0], "image")
 finally:
     torch.cuda.is_current_stream_capturing = real_capturing
 
 # --------------------------------------------------------------------------
-print("10. non-capturing text step: gate wrapper takes orig path, zero syncs")
+print("11. non-capturing text step: gate wrapper takes orig path, zero syncs")
 reset()
 calls["orig"] = 0
 torch.cuda.is_current_stream_capturing = lambda: False
@@ -241,7 +286,7 @@ try:
     embed = embed_fn()
     txt = torch.tensor([1, 2, 3, 4], dtype=torch.long)
     with override_forward_context(None):
-        embed(None, txt, multimodal_embeddings=None, is_multimodal=None)
+        embed(lm, txt, multimodal_embeddings=None, is_multimodal=None)
     with override_forward_context(fake_ctx()):
         for _ in range(N_MOE_LAYERS):
             router._compute_routing(torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=txt)
@@ -251,7 +296,7 @@ finally:
     torch.cuda.is_current_stream_capturing = real_capturing
 
 # --------------------------------------------------------------------------
-print("11. fused_topk_bias_split_vl honours a precomputed kind (no re-scan)")
+print("12. fused_topk_bias_split_vl honours a precomputed kind (no re-scan)")
 reset()
 import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as ftb_mod
 
@@ -275,7 +320,7 @@ ftb_mod.fused_topk_bias = _fake_ftb
 ap.current_routing_kind = _boom
 try:
     vl_bias = torch.zeros(4)
-    r = ap.fused_topk_bias_split_vl(
+    common = dict(
         hidden_states=torch.zeros((2, 2)),
         gating_output=torch.zeros((2, 2)),
         scoring_func="sigmoid",
@@ -284,11 +329,10 @@ try:
         topk=1,
         renormalize=False,
         indices_type=None,
-        input_tokens=torch.tensor([ID, ID]),
         hash_indices_table="HASH",
         routed_scaling_factor=1.0,
-        kind="image",
     )
+    ap.fused_topk_bias_split_vl(input_tokens=torch.tensor([ID, ID]), kind="image", **common)
     check(
         "kind=image -> bias_vl used",
         seen["e_score_correction_bias"].data_ptr() == vl_bias.data_ptr(),
@@ -296,35 +340,20 @@ try:
     )
     check("kind=image -> hash table skipped", seen["hash_indices_table"], None)
     check("kind=image -> no re-scan syncs", syncs(), 0)
-
     seen.clear()
-    r = ap.fused_topk_bias_split_vl(
-        hidden_states=torch.zeros((2, 2)),
-        gating_output=torch.zeros((2, 2)),
-        scoring_func="sigmoid",
-        e_score_correction_bias=torch.ones(4),
-        e_score_correction_bias_vl=vl_bias,
-        topk=1,
-        renormalize=False,
-        indices_type=None,
-        input_tokens=torch.tensor([1, 2]),
-        hash_indices_table="HASH",
-        routed_scaling_factor=1.0,
-        kind="text",
-    )
+    ap.fused_topk_bias_split_vl(input_tokens=torch.tensor([1, 2]), kind="text", **common)
     check("kind=text -> text bias + hash table", seen["hash_indices_table"], "HASH")
     check("kind=text -> no re-scan syncs", syncs(), 0)
 finally:
     ftb_mod.fused_topk_bias = _real_ftb
     ap.current_routing_kind = _real_curr
 
-print("12. kind=None still resolves (backwards compatible call)")
+print("13. kind=None still resolves (backwards compatible call)")
 reset()
-with override_forward_context(None):
-    k = None
-    ftb_mod.fused_topk_bias = _fake_ftb
-    try:
-        seen.clear()
+ftb_mod.fused_topk_bias = _fake_ftb
+try:
+    seen.clear()
+    with override_forward_context(None):
         ap.fused_topk_bias_split_vl(
             hidden_states=torch.zeros((2, 2)),
             gating_output=torch.zeros((2, 2)),
@@ -338,10 +367,86 @@ with override_forward_context(None):
             hash_indices_table="HASH",
             routed_scaling_factor=1.0,
         )
-        check("kind=None text -> hash table kept", seen["hash_indices_table"], "HASH")
-        check("kind=None text -> 1 fallback sync", syncs(), 1)
-    finally:
-        ftb_mod.fused_topk_bias = _real_ftb
+    check("kind=None text -> hash table kept", seen["hash_indices_table"], "HASH")
+    check("kind=None text -> 1 fallback sync", syncs(), 1)
+finally:
+    ftb_mod.fused_topk_bias = _real_ftb
+
+# --------------------------------------------------------------------------
+print("14. hardening: no silent degradation")
+reset()
+
+
+class _Slotted:
+    __slots__ = ()
+
+
+ip.set_pending_routing_kind("text", 1)
+with override_forward_context(_Slotted()):
+    try:
+        ip.current_routing_kind(torch.tensor([1, 2]), owner_id=1)
+        print("  [FAIL] setattr on a locked ForwardContext must raise")
+        FAILURES.append("locked ctx raises")
+    except AttributeError as e:
+        print(f"  [PASS] setattr on a locked ForwardContext raises: {type(e).__name__}")
+
+raises(
+    "_num_tokens on an unsized object raises (no silent 0 -> 'image')",
+    TypeError,
+    lambda: ap._num_tokens(object()),
+)
+raises(
+    "routing_kind_from_mm(n_tokens=0) raises",
+    ValueError,
+    lambda: ip.routing_kind_from_mm(3, 0),
+)
+
+_saved = ip._FORWARD_CONTEXT_HOOKS
+ip._FORWARD_CONTEXT_HOOKS = None
+import vllm.forward_context as _fcmod
+
+_saved_fn = _fcmod.is_forward_context_available
+del _fcmod.is_forward_context_available
+try:
+    raises(
+        "missing vllm forward_context symbol is a hard failure",
+        AttributeError,
+        lambda: ip._forward_context_or_none(),
+    )
+finally:
+    _fcmod.is_forward_context_available = _saved_fn
+    ip._FORWARD_CONTEXT_HOOKS = _saved
+
+# --------------------------------------------------------------------------
+print("15. tag_routing_owner binds gates by object graph, not by name")
+
+
+class _Experts(nn.Module):
+    def __init__(self, router):
+        super().__init__()
+        self.router = router
+
+
+class _MoE(nn.Module):
+    def __init__(self, with_vl):
+        super().__init__()
+        self.gate = nn.Module()
+        self.gate.e_score_correction_bias_vl = torch.zeros(4) if with_vl else None
+        self.experts = _Experts(_Router())
+
+
+class _Stack(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([_MoE(True), _MoE(True), _MoE(False)])
+
+
+stack = _Stack()
+n = ap.tag_routing_owner(stack, 4242)
+check("tagged only bias_vl gates", n, 2)
+check("moe tagged", stack.layers[0]._dspark_routing_owner, 4242)
+check("router tagged", stack.layers[0].experts.router._dspark_routing_owner, 4242)
+check("non-vl gate untagged", getattr(stack.layers[2], "_dspark_routing_owner", None), None)
 
 print()
 if FAILURES:

--- a/tests/test_issue175_routing_kind_once.py
+++ b/tests/test_issue175_routing_kind_once.py
@@ -1,0 +1,350 @@
+"""Issue #175 follow-up: the MoE gates must not host-sync once per layer.
+
+``token_routing_kind`` ends in ``.sum().item()``. It used to run in every MoE
+gate (43 per forward, and prefill is never CUDA-graphed, so text prompts paid
+it too). The batch is now classified once in ``embed_input_ids`` and carried on
+vLLM's per-step ``ForwardContext``.
+
+Run inside the container:
+  python3 tests/test_issue175_routing_kind_once.py
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "patches"))
+
+from vision_exp import apply as ap  # noqa: E402
+from vision_exp import image_processor as ip  # noqa: E402
+from vllm.forward_context import override_forward_context  # noqa: E402
+
+ID = ip.IMAGE_TOKEN_ID
+N_MOE_LAYERS = 43
+
+_real_item = torch.Tensor.item
+_counter = {"n": 0}
+
+
+def _counting_item(self, *a, **kw):
+    _counter["n"] += 1
+    return _real_item(self, *a, **kw)
+
+
+torch.Tensor.item = _counting_item
+
+
+def syncs():
+    return _counter["n"]
+
+
+def reset():
+    _counter["n"] = 0
+    ip.set_pending_routing_kind(None)
+
+
+FAILURES = []
+
+
+def check(name, got, want):
+    ok = got == want
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+    if not ok:
+        FAILURES.append(name)
+
+
+def fake_ctx():
+    return types.SimpleNamespace(tag="forward-context")
+
+
+def embed_fn():
+    """The real patched embed_input_ids over a stub base embedding."""
+
+    def orig(self, input_ids):
+        return torch.zeros((int(input_ids.numel()), 4), dtype=torch.float32)
+
+    return ap.make_embed_input_ids(orig)
+
+
+def gate_reads(ids, n=N_MOE_LAYERS):
+    """Simulate the N MoE gates of one forward reading the routing kind."""
+    return {ip.current_routing_kind(ids) for _ in range(n)}
+
+
+# --------------------------------------------------------------------------
+print("1. text batch: embed + 43 gate reads")
+reset()
+embed = embed_fn()
+ids = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.long)
+with override_forward_context(None):
+    out = embed(None, ids, multimodal_embeddings=None, is_multimodal=None)
+ctx = fake_ctx()
+with override_forward_context(ctx):
+    kinds = gate_reads(ids)
+check("text kind", kinds, {"text"})
+check("text .item() count", syncs(), 0)
+check("text embed shape", tuple(out.shape), (6, 4))
+
+# --------------------------------------------------------------------------
+print("2. all-image batch: embed + 43 gate reads")
+reset()
+embed = embed_fn()
+ids = torch.full((8,), ID, dtype=torch.long)
+mm = [torch.ones((8, 4), dtype=torch.float32)]
+is_mm = torch.ones(8, dtype=torch.bool)
+with override_forward_context(None):
+    embed(None, ids, multimodal_embeddings=mm, is_multimodal=is_mm)
+ctx = fake_ctx()
+with override_forward_context(ctx):
+    kinds = gate_reads(ids)
+check("image kind", kinds, {"image"})
+check("image .item() count <= 1", syncs() <= 1, True)
+check("image .item() count", syncs(), 1)
+
+# --------------------------------------------------------------------------
+print("3. mixed batch: embed + 43 gate reads")
+reset()
+embed = embed_fn()
+ids = torch.tensor([7, ID, ID, ID, 9], dtype=torch.long)
+mm = [torch.ones((3, 4), dtype=torch.float32)]
+is_mm = torch.tensor([False, True, True, True, False])
+with override_forward_context(None):
+    embed(None, ids, multimodal_embeddings=mm, is_multimodal=is_mm)
+ctx = fake_ctx()
+with override_forward_context(ctx):
+    kinds = gate_reads(ids)
+check("mixed kind", kinds, {"mixed"})
+check("mixed .item() count", syncs(), 1)
+
+# --------------------------------------------------------------------------
+print("4. empty mm list is text (encoder ran but produced nothing)")
+reset()
+embed = embed_fn()
+ids = torch.tensor([1, 2, 3], dtype=torch.long)
+with override_forward_context(None):
+    embed(None, ids, multimodal_embeddings=[], is_multimodal=None)
+ctx = fake_ctx()
+with override_forward_context(ctx):
+    kinds = gate_reads(ids)
+check("empty-mm kind", kinds, {"text"})
+check("empty-mm .item() count", syncs(), 0)
+
+# --------------------------------------------------------------------------
+print("5. fallback: no forward context -> identical to token_routing_kind")
+for name, t in [
+    ("text", torch.tensor([1, 2, 3])),
+    ("image", torch.full((4,), ID)),
+    ("mixed", torch.tensor([1, ID, 2])),
+    ("empty", torch.tensor([], dtype=torch.long)),
+    ("none", None),
+    ("list", [1, ID, 3]),
+]:
+    reset()
+    with override_forward_context(None):
+        got = ip.current_routing_kind(t)
+    want = ip.token_routing_kind(t)
+    check(f"fallback {name}", got, want)
+
+# --------------------------------------------------------------------------
+print("6. fallback inside a context with no pending kind (dummy/warmup run)")
+reset()
+ids = torch.tensor([1, ID, 2], dtype=torch.long)
+ctx = fake_ctx()
+with override_forward_context(ctx):
+    kinds = gate_reads(ids)
+check("no-pending kind", kinds, {"mixed"})
+check("no-pending syncs (memoized after 1st gate)", syncs(), 1)
+
+# --------------------------------------------------------------------------
+print("7. per-step isolation: a new ForwardContext never reuses the old kind")
+reset()
+embed = embed_fn()
+img_ids = torch.full((4,), ID, dtype=torch.long)
+with override_forward_context(None):
+    embed(
+        None,
+        img_ids,
+        multimodal_embeddings=[torch.ones((4, 4))],
+        is_multimodal=torch.ones(4, dtype=torch.bool),
+    )
+ctx_a = fake_ctx()
+with override_forward_context(ctx_a):
+    a = ip.current_routing_kind(img_ids)
+txt_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+with override_forward_context(None):
+    embed(None, txt_ids, multimodal_embeddings=None, is_multimodal=None)
+ctx_b = fake_ctx()
+with override_forward_context(ctx_b):
+    b = ip.current_routing_kind(txt_ids)
+check("step A kind", a, "image")
+check("step B kind (fresh ctx)", b, "text")
+check("ctx A attr", getattr(ctx_a, ip._ROUTING_KIND_CTX_ATTR, None), "image")
+check("ctx B attr", getattr(ctx_b, ip._ROUTING_KIND_CTX_ATTR, None), "text")
+
+# --------------------------------------------------------------------------
+print("8. stale pending is one-shot: a second forward cannot reuse it")
+reset()
+ip.set_pending_routing_kind("image")
+with override_forward_context(fake_ctx()):
+    first = ip.current_routing_kind(torch.tensor([1, 2, 3]))
+with override_forward_context(fake_ctx()):
+    second = ip.current_routing_kind(torch.tensor([1, 2, 3]))
+check("1st consumes pending", first, "image")
+check("2nd falls back (not stale)", second, "text")
+
+# --------------------------------------------------------------------------
+print("9. CUDA-graph capture short-circuits before any kind resolution")
+reset()
+calls = {"orig": 0}
+
+
+class _Gate:
+    e_score_correction_bias_vl = torch.zeros(4)
+
+
+class _Router:
+    scoring_func = "sigmoid"
+    top_k = 2
+    renormalize = True
+    routed_scaling_factor = 1.0
+    num_fused_shared_experts = 0
+
+    def _compute_routing(self, hidden_states, router_logits, indices_type, *, input_ids=None):
+        calls["orig"] += 1
+        return ("orig", input_ids)
+
+
+router = _Router()
+ap._wrap_router_compute_routing(router, _Gate())
+real_capturing = torch.cuda.is_current_stream_capturing
+torch.cuda.is_current_stream_capturing = lambda: True
+try:
+    ip.set_pending_routing_kind("image")  # would route image if consulted
+    img_ids = torch.full((4,), ID, dtype=torch.long)
+    with override_forward_context(fake_ctx()):
+        r = router._compute_routing(torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=img_ids)
+    check("capturing -> orig路径", r[0], "orig")
+    check("capturing .item() count", syncs(), 0)
+    check("capturing did not consume pending", ip._PENDING_ROUTING_KIND, "image")
+finally:
+    torch.cuda.is_current_stream_capturing = real_capturing
+
+# --------------------------------------------------------------------------
+print("10. non-capturing text step: gate wrapper takes orig path, zero syncs")
+reset()
+calls["orig"] = 0
+torch.cuda.is_current_stream_capturing = lambda: False
+try:
+    embed = embed_fn()
+    txt = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+    with override_forward_context(None):
+        embed(None, txt, multimodal_embeddings=None, is_multimodal=None)
+    with override_forward_context(fake_ctx()):
+        for _ in range(N_MOE_LAYERS):
+            router._compute_routing(torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=txt)
+    check("text step orig calls", calls["orig"], N_MOE_LAYERS)
+    check("text step .item() count", syncs(), 0)
+finally:
+    torch.cuda.is_current_stream_capturing = real_capturing
+
+# --------------------------------------------------------------------------
+print("11. fused_topk_bias_split_vl honours a precomputed kind (no re-scan)")
+reset()
+import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as ftb_mod
+
+seen = {}
+
+
+def _fake_ftb(**kw):
+    seen.update(kw)
+    return ("w", "ids")
+
+
+_real_ftb = ftb_mod.fused_topk_bias
+_real_curr = ap.current_routing_kind
+
+
+def _boom(*a, **k):
+    raise AssertionError("current_routing_kind must not run when kind is given")
+
+
+ftb_mod.fused_topk_bias = _fake_ftb
+ap.current_routing_kind = _boom
+try:
+    vl_bias = torch.zeros(4)
+    r = ap.fused_topk_bias_split_vl(
+        hidden_states=torch.zeros((2, 2)),
+        gating_output=torch.zeros((2, 2)),
+        scoring_func="sigmoid",
+        e_score_correction_bias=torch.ones(4),
+        e_score_correction_bias_vl=vl_bias,
+        topk=1,
+        renormalize=False,
+        indices_type=None,
+        input_tokens=torch.tensor([ID, ID]),
+        hash_indices_table="HASH",
+        routed_scaling_factor=1.0,
+        kind="image",
+    )
+    check(
+        "kind=image -> bias_vl used",
+        seen["e_score_correction_bias"].data_ptr() == vl_bias.data_ptr(),
+        True,
+    )
+    check("kind=image -> hash table skipped", seen["hash_indices_table"], None)
+    check("kind=image -> no re-scan syncs", syncs(), 0)
+
+    seen.clear()
+    r = ap.fused_topk_bias_split_vl(
+        hidden_states=torch.zeros((2, 2)),
+        gating_output=torch.zeros((2, 2)),
+        scoring_func="sigmoid",
+        e_score_correction_bias=torch.ones(4),
+        e_score_correction_bias_vl=vl_bias,
+        topk=1,
+        renormalize=False,
+        indices_type=None,
+        input_tokens=torch.tensor([1, 2]),
+        hash_indices_table="HASH",
+        routed_scaling_factor=1.0,
+        kind="text",
+    )
+    check("kind=text -> text bias + hash table", seen["hash_indices_table"], "HASH")
+    check("kind=text -> no re-scan syncs", syncs(), 0)
+finally:
+    ftb_mod.fused_topk_bias = _real_ftb
+    ap.current_routing_kind = _real_curr
+
+print("12. kind=None still resolves (backwards compatible call)")
+reset()
+with override_forward_context(None):
+    k = None
+    ftb_mod.fused_topk_bias = _fake_ftb
+    try:
+        seen.clear()
+        ap.fused_topk_bias_split_vl(
+            hidden_states=torch.zeros((2, 2)),
+            gating_output=torch.zeros((2, 2)),
+            scoring_func="sigmoid",
+            e_score_correction_bias=torch.ones(4),
+            e_score_correction_bias_vl=torch.zeros(4),
+            topk=1,
+            renormalize=False,
+            indices_type=None,
+            input_tokens=torch.tensor([1, 2, 3]),
+            hash_indices_table="HASH",
+            routed_scaling_factor=1.0,
+        )
+        check("kind=None text -> hash table kept", seen["hash_indices_table"], "HASH")
+        check("kind=None text -> 1 fallback sync", syncs(), 1)
+    finally:
+        ftb_mod.fused_topk_bias = _real_ftb
+
+print()
+if FAILURES:
+    print(f"RESULT: {len(FAILURES)} FAILED -> {FAILURES}")
+    sys.exit(1)
+print("RESULT: ALL PASS")

--- a/tests/test_issue175_routing_kind_once.py
+++ b/tests/test_issue175_routing_kind_once.py
@@ -10,6 +10,7 @@ Run inside the container:
 """
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from pathlib import Path
@@ -42,10 +43,31 @@ def syncs():
     return _counter["n"]
 
 
+class _Records(logging.Handler):
+    """Captures what vision_exp actually logs, at what level."""
+
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def levels(self):
+        return [r.levelno for r in self.records]
+
+
+_LOGS = _Records()
+ip._LOGGER.addHandler(_LOGS)
+ip._LOGGER.setLevel(logging.DEBUG)
+ip._LOGGER.propagate = False
+
+
 def reset():
     _counter["n"] = 0
     ip.set_pending_routing_kind(None)
-    ip._WARNED.clear()
+    ip._LOGGED_ONCE.clear()
+    _LOGS.records.clear()
 
 
 FAILURES = []
@@ -218,25 +240,40 @@ reset()
 target, drafter = FakeLM(), FakeLM()
 embed = embed_fn()
 img_ids = torch.full((4,), ID, dtype=torch.long)
-with override_forward_context(None):
-    embed(
-        target,
-        img_ids,
-        multimodal_embeddings=[torch.ones((4, 4))],
-        is_multimodal=torch.ones(4, dtype=torch.bool),
-    )
-reset_syncs = _counter["n"]
-# The drafter opens its own ForwardContext and runs its own wrapped MoE gates.
+
+
+def publish_image():
+    with override_forward_context(None):
+        embed(
+            target,
+            img_ids,
+            multimodal_embeddings=[torch.ones((4, 4))],
+            is_multimodal=torch.ones(4, dtype=torch.bool),
+        )
+
+
+# 9a. The routine case: the target replayed a full CUDA graph (no Python in its
+# gates, so nobody consumed the value), then the drafter's untagged gates run
+# under their own ForwardContext.
+publish_image()
 with override_forward_context(fake_ctx()):
-    stolen = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=id(drafter))
-check("drafter gets its own answer, not 'image'", stolen, "text")
+    stolen = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=None)
+check("untagged drafter gate scans for itself", stolen, "text")
 check("pending survives for its owner", ip._PENDING_ROUTING_KIND[0], "image")
-check("owner mismatch warned (not silent)", len(ip._WARNED), 1)
+check("expected drafter fallback is not a warning", _LOGS.levels(), [logging.DEBUG])
 with override_forward_context(fake_ctx()):
     mine = ip.current_routing_kind(img_ids, owner_id=id(target))
 check("target still gets 'image'", mine, "image")
 
-# --------------------------------------------------------------------------
+# 9b. Two tagged models crossing is a real anomaly and must stay loud.
+reset()
+publish_image()
+with override_forward_context(fake_ctx()):
+    crossed = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=id(drafter))
+check("tagged cross-owner falls back", crossed, "text")
+check("tagged cross-owner warns", _LOGS.levels(), [logging.WARNING])
+check("pending still survives", ip._PENDING_ROUTING_KIND[0], "image")
+
 print("10. CUDA-graph capture short-circuits before any kind resolution")
 reset()
 calls = {"orig": 0}

--- a/tests/test_issue175_routing_kind_once.py
+++ b/tests/test_issue175_routing_kind_once.py
@@ -1,16 +1,10 @@
-"""Issue #175 follow-up: the MoE gates must not host-sync once per layer.
-
-``token_routing_kind`` ends in ``.sum().item()``. It used to run in every MoE
-gate (43 per forward, and prefill is never CUDA-graphed, so text prompts paid
-it too). The batch is now classified once in ``embed_input_ids`` and carried on
-vLLM's per-step ``ForwardContext``, bound to the model that published it.
+"""Issue #175: classify routing once per model forward, not once per MoE gate.
 
 Run inside the container:
   python3 tests/test_issue175_routing_kind_once.py
 """
 from __future__ import annotations
 
-import logging
 import sys
 import types
 from pathlib import Path
@@ -26,51 +20,25 @@ from vllm.forward_context import override_forward_context  # noqa: E402
 
 ID = ip.IMAGE_TOKEN_ID
 N_MOE_LAYERS = 43
-
 _real_item = torch.Tensor.item
 _counter = {"n": 0}
+FAILURES = []
 
 
-def _counting_item(self, *a, **kw):
+def _counting_item(self, *args, **kwargs):
     _counter["n"] += 1
-    return _real_item(self, *a, **kw)
+    return _real_item(self, *args, **kwargs)
 
 
 torch.Tensor.item = _counting_item
 
 
-def syncs():
-    return _counter["n"]
-
-
-class _Records(logging.Handler):
-    """Captures what vision_exp actually logs, at what level."""
-
-    def __init__(self):
-        super().__init__(level=logging.DEBUG)
-        self.records = []
-
-    def emit(self, record):
-        self.records.append(record)
-
-    def levels(self):
-        return [r.levelno for r in self.records]
-
-
-_LOGS = _Records()
-ip._LOGGER.addHandler(_LOGS)
-ip._LOGGER.setLevel(logging.DEBUG)
-ip._LOGGER.propagate = False
-
-
 def reset():
     _counter["n"] = 0
-    ip.set_pending_routing_kind(None)
-    ip._LOGGED_ONCE.clear()
-    _LOGS.records.clear()
 
 
-FAILURES = []
+def syncs():
+    return _counter["n"]
 
 
 def check(name, got, want):
@@ -83,11 +51,11 @@ def check(name, got, want):
 def raises(name, exc_type, fn):
     try:
         fn()
-    except exc_type as e:
-        print(f"  [PASS] {name}: raised {type(e).__name__}")
+    except exc_type as exc:
+        print(f"  [PASS] {name}: raised {type(exc).__name__}")
         return
-    except Exception as e:  # noqa: BLE001
-        print(f"  [FAIL] {name}: raised {type(e).__name__}, want {exc_type.__name__}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [FAIL] {name}: raised {type(exc).__name__}, want {exc_type.__name__}")
         FAILURES.append(name)
         return
     print(f"  [FAIL] {name}: no exception, want {exc_type.__name__}")
@@ -99,7 +67,8 @@ def fake_ctx():
 
 
 class FakeLM:
-    """Stands in for DeepseekV4ForCausalLM as the embed_input_ids receiver."""
+    def __init__(self):
+        self._dspark_routing_kind_cell = [None]
 
 
 def embed_fn():
@@ -109,12 +78,10 @@ def embed_fn():
     return ap.make_embed_input_ids(orig)
 
 
-def gate_reads(ids, owner_id, n=N_MOE_LAYERS):
-    """Simulate the N MoE gates of one forward reading the routing kind."""
-    return {ip.current_routing_kind(ids, owner_id=owner_id) for _ in range(n)}
+def gate_reads(ids, kind_cell=None, n=N_MOE_LAYERS):
+    return {ip.current_routing_kind(ids, kind_cell=kind_cell) for _ in range(n)}
 
 
-# --------------------------------------------------------------------------
 print("1. text batch: embed + 43 gate reads")
 reset()
 embed, lm = embed_fn(), FakeLM()
@@ -122,13 +89,12 @@ ids = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.long)
 with override_forward_context(None):
     out = embed(lm, ids, multimodal_embeddings=None, is_multimodal=None)
 with override_forward_context(fake_ctx()):
-    kinds = gate_reads(ids, id(lm))
+    kinds = gate_reads(ids, lm._dspark_routing_kind_cell)
 check("text kind", kinds, {"text"})
 check("text .item() count", syncs(), 0)
 check("text embed shape", tuple(out.shape), (6, 4))
 
-# --------------------------------------------------------------------------
-print("2. all-image batch: embed + 43 gate reads")
+print("2. all-image batch: one existing merge sync, no gate syncs")
 reset()
 embed, lm = embed_fn(), FakeLM()
 ids = torch.full((8,), ID, dtype=torch.long)
@@ -140,12 +106,11 @@ with override_forward_context(None):
         is_multimodal=torch.ones(8, dtype=torch.bool),
     )
 with override_forward_context(fake_ctx()):
-    kinds = gate_reads(ids, id(lm))
+    kinds = gate_reads(ids, lm._dspark_routing_kind_cell)
 check("image kind", kinds, {"image"})
 check("image .item() count", syncs(), 1)
 
-# --------------------------------------------------------------------------
-print("3. mixed batch: embed + 43 gate reads")
+print("3. mixed batch: one existing merge sync, no gate syncs")
 reset()
 embed, lm = embed_fn(), FakeLM()
 ids = torch.tensor([7, ID, ID, ID, 9], dtype=torch.long)
@@ -157,25 +122,23 @@ with override_forward_context(None):
         is_multimodal=torch.tensor([False, True, True, True, False]),
     )
 with override_forward_context(fake_ctx()):
-    kinds = gate_reads(ids, id(lm))
+    kinds = gate_reads(ids, lm._dspark_routing_kind_cell)
 check("mixed kind", kinds, {"mixed"})
 check("mixed .item() count", syncs(), 1)
 
-# --------------------------------------------------------------------------
-print("4. empty mm list is text (encoder ran but produced nothing)")
+print("4. empty multimodal output is text")
 reset()
 embed, lm = embed_fn(), FakeLM()
 ids = torch.tensor([1, 2, 3], dtype=torch.long)
 with override_forward_context(None):
     embed(lm, ids, multimodal_embeddings=[], is_multimodal=None)
 with override_forward_context(fake_ctx()):
-    kinds = gate_reads(ids, id(lm))
+    kinds = gate_reads(ids, lm._dspark_routing_kind_cell)
 check("empty-mm kind", kinds, {"text"})
 check("empty-mm .item() count", syncs(), 0)
 
-# --------------------------------------------------------------------------
-print("5. fallback: no forward context -> identical to token_routing_kind")
-for name, t in [
+print("5. no ForwardContext keeps token scan behavior")
+for name, token_ids in [
     ("text", torch.tensor([1, 2, 3])),
     ("image", torch.full((4,), ID)),
     ("mixed", torch.tensor([1, ID, 2])),
@@ -185,96 +148,71 @@ for name, t in [
 ]:
     reset()
     with override_forward_context(None):
-        got = ip.current_routing_kind(t)
-    check(f"fallback {name}", got, ip.token_routing_kind(t))
+        got = ip.current_routing_kind(token_ids)
+    check(f"fallback {name}", got, ip.token_routing_kind(token_ids))
 
-# --------------------------------------------------------------------------
-print("6. fallback inside a context with no pending kind (dummy/warmup run)")
+print("6. unpublished warmup/dummy forward scans once")
 reset()
 ids = torch.tensor([1, ID, 2], dtype=torch.long)
 with override_forward_context(fake_ctx()):
-    kinds = gate_reads(ids, None)
-check("no-pending kind", kinds, {"mixed"})
-check("no-pending syncs (memoized after 1st gate)", syncs(), 1)
+    kinds = gate_reads(ids)
+check("unpublished kind", kinds, {"mixed"})
+check("unpublished syncs", syncs(), 1)
 
-# --------------------------------------------------------------------------
-print("7. per-step isolation: a new ForwardContext never reuses the old kind")
+print("7. fresh contexts do not reuse the prior step")
 reset()
 embed, lm = embed_fn(), FakeLM()
-img_ids = torch.full((4,), ID, dtype=torch.long)
+image_ids = torch.full((4,), ID, dtype=torch.long)
 with override_forward_context(None):
     embed(
         lm,
-        img_ids,
+        image_ids,
         multimodal_embeddings=[torch.ones((4, 4))],
         is_multimodal=torch.ones(4, dtype=torch.bool),
     )
 ctx_a = fake_ctx()
 with override_forward_context(ctx_a):
-    a = ip.current_routing_kind(img_ids, owner_id=id(lm))
-txt_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+    image_kind = ip.current_routing_kind(image_ids, kind_cell=lm._dspark_routing_kind_cell)
+text_ids = torch.tensor([1, 2, 3], dtype=torch.long)
 with override_forward_context(None):
-    embed(lm, txt_ids, multimodal_embeddings=None, is_multimodal=None)
+    embed(lm, text_ids, multimodal_embeddings=None, is_multimodal=None)
 ctx_b = fake_ctx()
 with override_forward_context(ctx_b):
-    b = ip.current_routing_kind(txt_ids, owner_id=id(lm))
-check("step A kind", a, "image")
-check("step B kind (fresh ctx)", b, "text")
-check("ctx A attr", getattr(ctx_a, ip._ROUTING_KIND_CTX_ATTR, None), "image")
-check("ctx B attr", getattr(ctx_b, ip._ROUTING_KIND_CTX_ATTR, None), "text")
+    text_kind = ip.current_routing_kind(text_ids, kind_cell=lm._dspark_routing_kind_cell)
+check("step A kind", image_kind, "image")
+check("step B kind", text_kind, "text")
+check("ctx A retained image", getattr(ctx_a, ip._ROUTING_KIND_CTX_ATTR), "image")
+check("ctx B retained text", getattr(ctx_b, ip._ROUTING_KIND_CTX_ATTR), "text")
 
-# --------------------------------------------------------------------------
-print("8. stale pending is one-shot: a second forward cannot reuse it")
+print("8. publication cell is consumed once")
 reset()
-ip.set_pending_routing_kind("image", 777)
+cell = ["image"]
 with override_forward_context(fake_ctx()):
-    first = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=777)
+    first = ip.current_routing_kind(torch.full((2,), ID), kind_cell=cell)
 with override_forward_context(fake_ctx()):
-    second = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=777)
-check("1st consumes pending", first, "image")
-check("2nd falls back (not stale)", second, "text")
+    second = ip.current_routing_kind(torch.tensor([1, 2]), kind_cell=cell)
+check("first consumes image", first, "image")
+check("cell empty after consume", cell[0], None)
+check("next forward scans its own text", second, "text")
+check("only fallback scanned", syncs(), 1)
 
-# --------------------------------------------------------------------------
-print("9. DSpark drafter cannot eat the target's pending kind (owner stamp)")
+print("9. model-local cells cannot cross target/drafter or target instances")
 reset()
-target, drafter = FakeLM(), FakeLM()
-embed = embed_fn()
-img_ids = torch.full((4,), ID, dtype=torch.long)
-
-
-def publish_image():
-    with override_forward_context(None):
-        embed(
-            target,
-            img_ids,
-            multimodal_embeddings=[torch.ones((4, 4))],
-            is_multimodal=torch.ones(4, dtype=torch.bool),
-        )
-
-
-# 9a. The routine case: the target replayed a full CUDA graph (no Python in its
-# gates, so nobody consumed the value), then the drafter's untagged gates run
-# under their own ForwardContext.
-publish_image()
+target_a, target_b = FakeLM(), FakeLM()
+target_a._dspark_routing_kind_cell[0] = "image"
+target_b._dspark_routing_kind_cell[0] = "text"
 with override_forward_context(fake_ctx()):
-    stolen = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=None)
-check("untagged drafter gate scans for itself", stolen, "text")
-check("pending survives for its owner", ip._PENDING_ROUTING_KIND[0], "image")
-check("expected drafter fallback is not a warning", _LOGS.levels(), [logging.DEBUG])
+    drafter = ip.current_routing_kind(torch.tensor([1, 2]))
+check("untagged drafter scans text", drafter, "text")
+check("drafter did not consume target A", target_a._dspark_routing_kind_cell[0], "image")
 with override_forward_context(fake_ctx()):
-    mine = ip.current_routing_kind(img_ids, owner_id=id(target))
-check("target still gets 'image'", mine, "image")
-
-# 9b. Two tagged models crossing is a real anomaly and must stay loud.
-reset()
-publish_image()
+    a = ip.current_routing_kind(torch.full((2,), ID), kind_cell=target_a._dspark_routing_kind_cell)
 with override_forward_context(fake_ctx()):
-    crossed = ip.current_routing_kind(torch.tensor([1, 2, 3]), owner_id=id(drafter))
-check("tagged cross-owner falls back", crossed, "text")
-check("tagged cross-owner warns", _LOGS.levels(), [logging.WARNING])
-check("pending still survives", ip._PENDING_ROUTING_KIND[0], "image")
+    b = ip.current_routing_kind(torch.tensor([1, 2]), kind_cell=target_b._dspark_routing_kind_cell)
+check("target A receives image", a, "image")
+check("target B receives text", b, "text")
 
-print("10. CUDA-graph capture short-circuits before any kind resolution")
+print("10. CUDA-graph capture exits before consuming the cell")
 reset()
 calls = {"orig": 0}
 
@@ -283,7 +221,7 @@ class _Gate:
     e_score_correction_bias_vl = torch.zeros(4)
 
 
-class _Router:
+class _Router(nn.Module):
     scoring_func = "sigmoid"
     top_k = 2
     renormalize = True
@@ -295,122 +233,100 @@ class _Router:
         return ("orig", input_ids)
 
 
-lm = FakeLM()
-router = _Router()
+lm, router = FakeLM(), _Router()
 ap._wrap_router_compute_routing(router, _Gate())
-router._dspark_routing_owner = id(lm)
+router._dspark_routing_kind_cell = lm._dspark_routing_kind_cell
+lm._dspark_routing_kind_cell[0] = "image"
 real_capturing = torch.cuda.is_current_stream_capturing
 torch.cuda.is_current_stream_capturing = lambda: True
 try:
-    ip.set_pending_routing_kind("image", id(lm))  # would route image if consulted
     with override_forward_context(fake_ctx()):
-        r = router._compute_routing(
-            torch.zeros((4, 4)), torch.zeros((4, 4)), None,
+        result = router._compute_routing(
+            torch.zeros((4, 4)),
+            torch.zeros((4, 4)),
+            None,
             input_ids=torch.full((4,), ID, dtype=torch.long),
         )
-    check("capturing -> orig path", r[0], "orig")
-    check("capturing .item() count", syncs(), 0)
-    check("capturing did not consume pending", ip._PENDING_ROUTING_KIND[0], "image")
+    check("capturing uses original path", result[0], "orig")
+    check("capturing does not sync", syncs(), 0)
+    check("capturing preserves publication", lm._dspark_routing_kind_cell[0], "image")
 finally:
     torch.cuda.is_current_stream_capturing = real_capturing
 
-# --------------------------------------------------------------------------
-print("11. non-capturing text step: gate wrapper takes orig path, zero syncs")
+print("11. non-capturing text wrapper uses original route with zero syncs")
 reset()
 calls["orig"] = 0
+lm._dspark_routing_kind_cell[0] = None
+with override_forward_context(None):
+    embed_fn()(lm, text_ids, multimodal_embeddings=None, is_multimodal=None)
 torch.cuda.is_current_stream_capturing = lambda: False
 try:
-    embed = embed_fn()
-    txt = torch.tensor([1, 2, 3, 4], dtype=torch.long)
-    with override_forward_context(None):
-        embed(lm, txt, multimodal_embeddings=None, is_multimodal=None)
     with override_forward_context(fake_ctx()):
         for _ in range(N_MOE_LAYERS):
-            router._compute_routing(torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=txt)
-    check("text step orig calls", calls["orig"], N_MOE_LAYERS)
-    check("text step .item() count", syncs(), 0)
+            router._compute_routing(
+                torch.zeros((4, 4)), torch.zeros((4, 4)), None, input_ids=text_ids
+            )
+    check("text original-route calls", calls["orig"], N_MOE_LAYERS)
+    check("text wrapper syncs", syncs(), 0)
 finally:
     torch.cuda.is_current_stream_capturing = real_capturing
 
-# --------------------------------------------------------------------------
-print("12. fused_topk_bias_split_vl honours a precomputed kind (no re-scan)")
+print("12. precomputed fused-topk kind does not re-resolve")
 reset()
 import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as ftb_mod
 
 seen = {}
 
 
-def _fake_ftb(**kw):
-    seen.update(kw)
+def fake_ftb(**kwargs):
+    seen.update(kwargs)
     return ("w", "ids")
 
 
-_real_ftb = ftb_mod.fused_topk_bias
-_real_curr = ap.current_routing_kind
-
-
-def _boom(*a, **k):
-    raise AssertionError("current_routing_kind must not run when kind is given")
-
-
-ftb_mod.fused_topk_bias = _fake_ftb
-ap.current_routing_kind = _boom
+real_ftb, real_current = ftb_mod.fused_topk_bias, ap.current_routing_kind
+ftb_mod.fused_topk_bias = fake_ftb
+ap.current_routing_kind = lambda *args, **kwargs: (_ for _ in ()).throw(
+    AssertionError("precomputed kind must not be resolved")
+)
+common = dict(
+    hidden_states=torch.zeros((2, 2)),
+    gating_output=torch.zeros((2, 2)),
+    scoring_func="sigmoid",
+    e_score_correction_bias=torch.ones(4),
+    e_score_correction_bias_vl=torch.zeros(4),
+    topk=1,
+    renormalize=False,
+    indices_type=None,
+    hash_indices_table="HASH",
+    routed_scaling_factor=1.0,
+)
 try:
-    vl_bias = torch.zeros(4)
-    common = dict(
-        hidden_states=torch.zeros((2, 2)),
-        gating_output=torch.zeros((2, 2)),
-        scoring_func="sigmoid",
-        e_score_correction_bias=torch.ones(4),
-        e_score_correction_bias_vl=vl_bias,
-        topk=1,
-        renormalize=False,
-        indices_type=None,
-        hash_indices_table="HASH",
-        routed_scaling_factor=1.0,
-    )
     ap.fused_topk_bias_split_vl(input_tokens=torch.tensor([ID, ID]), kind="image", **common)
-    check(
-        "kind=image -> bias_vl used",
-        seen["e_score_correction_bias"].data_ptr() == vl_bias.data_ptr(),
-        True,
-    )
-    check("kind=image -> hash table skipped", seen["hash_indices_table"], None)
-    check("kind=image -> no re-scan syncs", syncs(), 0)
+    check("image uses Vision-Exp bias", seen["e_score_correction_bias"].data_ptr(), common["e_score_correction_bias_vl"].data_ptr())
+    check("image skips hash table", seen["hash_indices_table"], None)
     seen.clear()
     ap.fused_topk_bias_split_vl(input_tokens=torch.tensor([1, 2]), kind="text", **common)
-    check("kind=text -> text bias + hash table", seen["hash_indices_table"], "HASH")
-    check("kind=text -> no re-scan syncs", syncs(), 0)
+    check("text keeps hash table", seen["hash_indices_table"], "HASH")
+    check("precomputed paths do not sync", syncs(), 0)
 finally:
-    ftb_mod.fused_topk_bias = _real_ftb
-    ap.current_routing_kind = _real_curr
+    ftb_mod.fused_topk_bias = real_ftb
+    ap.current_routing_kind = real_current
 
-print("13. kind=None still resolves (backwards compatible call)")
+print("13. kind=None resolves from a model cell")
 reset()
-ftb_mod.fused_topk_bias = _fake_ftb
+ftb_mod.fused_topk_bias = fake_ftb
 try:
     seen.clear()
-    with override_forward_context(None):
+    with override_forward_context(fake_ctx()):
         ap.fused_topk_bias_split_vl(
-            hidden_states=torch.zeros((2, 2)),
-            gating_output=torch.zeros((2, 2)),
-            scoring_func="sigmoid",
-            e_score_correction_bias=torch.ones(4),
-            e_score_correction_bias_vl=torch.zeros(4),
-            topk=1,
-            renormalize=False,
-            indices_type=None,
-            input_tokens=torch.tensor([1, 2, 3]),
-            hash_indices_table="HASH",
-            routed_scaling_factor=1.0,
+            input_tokens=torch.full((2,), ID), kind_cell=["image"], **common
         )
-    check("kind=None text -> hash table kept", seen["hash_indices_table"], "HASH")
-    check("kind=None text -> 1 fallback sync", syncs(), 1)
+    check("cell image skips hash table", seen["hash_indices_table"], None)
+    check("cell resolution does not sync", syncs(), 0)
 finally:
-    ftb_mod.fused_topk_bias = _real_ftb
+    ftb_mod.fused_topk_bias = real_ftb
 
-# --------------------------------------------------------------------------
-print("14. hardening: no silent degradation")
+print("14. hard failures prevent silent performance regressions")
 reset()
 
 
@@ -418,44 +334,27 @@ class _Slotted:
     __slots__ = ()
 
 
-ip.set_pending_routing_kind("text", 1)
 with override_forward_context(_Slotted()):
-    try:
-        ip.current_routing_kind(torch.tensor([1, 2]), owner_id=1)
-        print("  [FAIL] setattr on a locked ForwardContext must raise")
-        FAILURES.append("locked ctx raises")
-    except AttributeError as e:
-        print(f"  [PASS] setattr on a locked ForwardContext raises: {type(e).__name__}")
-
-raises(
-    "_num_tokens on an unsized object raises (no silent 0 -> 'image')",
-    TypeError,
-    lambda: ap._num_tokens(object()),
-)
-raises(
-    "routing_kind_from_mm(n_tokens=0) raises",
-    ValueError,
-    lambda: ip.routing_kind_from_mm(3, 0),
-)
-
-_saved = ip._FORWARD_CONTEXT_HOOKS
-ip._FORWARD_CONTEXT_HOOKS = None
-import vllm.forward_context as _fcmod
-
-_saved_fn = _fcmod.is_forward_context_available
-del _fcmod.is_forward_context_available
-try:
     raises(
-        "missing vllm forward_context symbol is a hard failure",
+        "locked ForwardContext",
         AttributeError,
-        lambda: ip._forward_context_or_none(),
+        lambda: ip.current_routing_kind(torch.tensor([1, 2]), kind_cell=["text"]),
     )
-finally:
-    _fcmod.is_forward_context_available = _saved_fn
-    ip._FORWARD_CONTEXT_HOOKS = _saved
+raises("unsized token input", TypeError, lambda: ap._num_tokens(object()))
+raises("zero-token multimodal classification", ValueError, lambda: ip.routing_kind_from_mm(3, 0))
+saved_hooks = ip._FORWARD_CONTEXT_HOOKS
+ip._FORWARD_CONTEXT_HOOKS = None
+import vllm.forward_context as fc_mod
 
-# --------------------------------------------------------------------------
-print("15. tag_routing_owner binds gates by object graph, not by name")
+saved_fn = fc_mod.is_forward_context_available
+del fc_mod.is_forward_context_available
+try:
+    raises("missing vLLM context symbol", AttributeError, ip._forward_context_or_none)
+finally:
+    fc_mod.is_forward_context_available = saved_fn
+    ip._FORWARD_CONTEXT_HOOKS = saved_hooks
+
+print("15. cell attachment follows the model graph, not names")
 
 
 class _Experts(nn.Module):
@@ -478,12 +377,12 @@ class _Stack(nn.Module):
         self.layers = nn.ModuleList([_MoE(True), _MoE(True), _MoE(False)])
 
 
-stack = _Stack()
-n = ap.tag_routing_owner(stack, 4242)
-check("tagged only bias_vl gates", n, 2)
-check("moe tagged", stack.layers[0]._dspark_routing_owner, 4242)
-check("router tagged", stack.layers[0].experts.router._dspark_routing_owner, 4242)
-check("non-vl gate untagged", getattr(stack.layers[2], "_dspark_routing_owner", None), None)
+stack, cell = _Stack(), [None]
+attached = ap.attach_routing_kind_cell(stack, cell)
+check("attached only Vision-Exp gates", attached, 2)
+check("MoE shares exact cell", stack.layers[0]._dspark_routing_kind_cell is cell, True)
+check("router shares exact cell", stack.layers[0].experts.router._dspark_routing_kind_cell is cell, True)
+check("non-Vision gate remains untagged", hasattr(stack.layers[2], "_dspark_routing_kind_cell"), False)
 
 print()
 if FAILURES:


### PR DESCRIPTION
Fixes #203.

## Exact-head design

Exact head: `4b841db707ae21603def0932c26cc6f257151426`.

The model owns one mutable one-slot routing-kind cell, shared only with that model's Vision-Exp MoE gates. `embed_input_ids` classifies once per forward: text-only publishes `text` without a tensor scan; multimodal forwards reuse the placeholder-count sync already required by the stock merge check. The first eager MoE gate consumes that model-local publication and memoizes it on the current vLLM `ForwardContext`; later gates read the context without another host sync.

There is no process-global pending kind, owner-ID registry, sequence counter, or log-once state. A second target model cannot consume the first model's publication, and the untagged MTP drafter performs the existing token-scan fallback. The CUDA-graph capture short-circuit remains before routing-kind resolution.

Publication is fail-closed: a locked/immutable `ForwardContext`, a Vision-Exp model with no attachable gates, or an invalid empty multimodal classification raises instead of silently restoring 43 per-layer scans.

## Deterministic validation

Pinned runtime-image source fixture:

- text-only routing scan calls: `43 -> 0`
- image-only routing scan calls: `43 -> 1`
- mixed routing scan calls: `43 -> 1`
- cross-model isolation: PASS
- graph-capture publication behavior: PASS
- locked-context fail-closed behavior: PASS
- `tests/test_issue175_routing_kind_once.py`: PASS
- `scripts/ci-validate.sh`: PASS

The rework removed 357 lines and added 167 relative to the prior PR head. The complete PR footprint against `main` is +585/-40 across three files.

## Local evidence

local evidence gate: blocked

## Files

- `patches/vision_exp/apply.py`
- `patches/vision_exp/image_processor.py`
- `tests/test_issue175_routing_kind_once.py`