### PR TITLE
github: issue forms + PR template (ported from Qwen3.8 kit, adapted)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -1,0 +1,102 @@
+---
+name: Bug report
+about: The recipe is not behaving as expected, produces an error, or numbers do not match the README.
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+<!-- Thank you for using this recipe!
+
+     If you are looking for support, please check the README and docs/ENVS.md first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you have found a bug, then fill out the template below.
+-->
+
+---
+
+## Environment
+
+<!-- Fill in what applies to your setup. docs/ENVS.md lists every knob and its default. -->
+
+- Hardware / nodes: <!-- e.g. 2x DGX Spark (GB10, 128 GB unified memory), 3x via start-tp3.sh, ... -->
+- Interconnect: <!-- e.g. ConnectX-7 RoCE (NCCL_IB_HCA=...), 10GbE, ... -->
+- Image / vLLM version: <!-- `docker images | grep dspark` — the pinned image is ghcr.io/anemll/dspark-vllm-gx10:0.1.1, vLLM 0.25.2.dev0 -->
+- Checkpoint (`DSPARK_MODEL` + `DSPARK_REVISION`): <!-- e.g. DeepSeek-V4-Flash-0731 @ 9e165c30, or DeepSeek-V4-Flash-Vision-Exp @ 86f746b3 -->
+- Served name (`SERVED_MODEL_NAME`): <!-- e.g. deepseek-v4-flash-0731 -->
+- How you started the serve: <!-- e.g. ./start-deepseek-v4-flash-dspark.sh, ./switch-model.sh abliterated, custom compose -->
+- Relevant `.env` values: <!-- e.g. MAX_MODEL_LEN, MAX_NUM_SEQS, GPU_MEMORY_UTILIZATION_TEXT, MTP_NUM_TOKENS, DSPARK_MAX_INFLIGHT_PREFILLS, LONG_PREFILL_TOKEN_THRESHOLD, ABLITERATED, DEFAULT_THINKING, any DSPARK_ENABLE_* opt-ins you turned on -->
+
+---
+
+## Steps to Reproduce
+
+<!-- Full steps so that we can reproduce the problem. -->
+
+1. <!-- e.g. `./start-deepseek-v4-flash-dspark.sh` — what it printed up to the failure -->
+2. ... <!-- the request or action that shows the bug -->
+3. ... <!-- e.g. "curl /v1/models returns a different served name than configured" -->
+
+**Expected results:** <!-- what did you expect to happen? -->
+
+**Actual results:** <!-- what did you actually see happen? -->
+
+---
+
+### Additional context
+
+Add anything else: a minimal failing request, JSON responses, `docker inspect` output, and so on.
+
+<details>
+<summary>Minimal reproduction sample</summary>
+
+<!--
+      If the bug is about model output or API behavior, attach a minimal reproducible
+      request below between the lines with the backticks.
+-->
+
+```bash
+curl -s http://localhost:8888/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-v4-flash-0731",
+    "messages": [{"role": "user", "content": "..."}],
+    "max_tokens": 256
+  }'
+```
+
+</details>
+
+<details>
+  <summary>Logs</summary>
+
+<!--
+      Paste the log output below between the lines with the backticks, and mention
+      whether it came from the start script, `docker logs vllm-dspark-1` (head),
+      the worker node, or a client.
+
+      Common culprits worth checking before filing:
+        * Boot fails downloading weights -> HF_HUB_OFFLINE=1 with a cold cache; warm it
+          with prepare-dspark-model-cache.sh first.
+        * Vision-Exp rejects MTP_NUM_TOKENS -> it must be >= 5 and divisible by 3,
+          or set DSPARK_ENABLE_DSPARK_BLOCK_K=1 for k=dspark_block_size.
+        * Decode collapses under concurrent long prompts -> check
+          DSPARK_MAX_INFLIGHT_PREFILLS and LONG_PREFILL_TOKEN_THRESHOLD (docs/ENVS.md).
+        * `Unknown vLLM environment variable` warnings -> the knob is not registered
+          on the Anemll 0.1.1 image; check docs/ENVS.md for the supported surface.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->

--- a/.github/ISSUE_TEMPLATE/2_improvement.md
+++ b/.github/ISSUE_TEMPLATE/2_improvement.md
@@ -1,0 +1,87 @@
+---
+name: Improvement proposal
+about: General improvements to the recipe. Anything that exists and works, but could be enhanced or optimized.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this recipe!
+
+     If you are looking for support, please check the README and docs/ENVS.md first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you think something can be improved, then fill out the template below.
+-->
+
+---
+
+## Improvement description
+
+<!--
+      What is it that you think can be improved? Give a clear explanation of what
+      element can be done better and how the recipe can benefit from it.
+
+      Examples that fit this repo: better KV cache / concurrency defaults, faster
+      startup, safer .env validation, clearer docs, a script to re-measure
+      performance after changing knobs, a benchmark harness, a change to the
+      download -> rsync -> patch -> launch pipeline, the fail-closed hotfix
+      pattern (source-exact patchers, opt-in flags, default-off), how `.env`
+      knobs map to vLLM flags, the two-node TP=2 / three-node TP=3 orchestration,
+      and so on.
+-->
+
+---
+
+### Additional context
+
+Add any other context here: code snippets, measured numbers (e.g. TTFT / decode throughput before and after), `docker logs` excerpts, screenshots, and so on.
+
+<details>
+<summary>Code sample</summary>
+
+<!--
+      Attach a minimal code sample that demonstrates the improvement you have in mind,
+      below between the lines with the backticks.
+-->
+
+```bash
+
+```
+
+</details>
+
+<details>
+  <summary>Logs / measurements</summary>
+
+<!--
+      Paste any measured numbers or log output below between the lines with the
+      backticks, so the benefit of the change can be evaluated.
+-->
+
+```
+
+```
+
+</details>
+
+<details>
+  <summary>Screenshots</summary>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Include any additional resource that doesn't fit the categories previously listed.
+-->

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,0 +1,48 @@
+---
+name: Feature request
+about: Suggest a new idea for this recipe. Something that doesn't exist currently, and you want to see.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this recipe!
+
+     If you are looking for support, please check the README and docs/ENVS.md first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you want the recipe to do something it currently doesn't, then fill out the
+     template below.
+-->
+
+## Use case
+
+<!--
+     Please tell us the challenge you are running into that led to you wanting
+     a new feature, or the workload you are trying to serve.
+
+     Examples that could fit this repo: single-node mode, an OpenAI-compatible
+     client example, a benchmark script, a systemd unit or compose file, support
+     for a different cluster topology, an opt-in runtime knob for a measured
+     behaviour (the repo's default-off hotfix pattern), a lint/validate step in
+     CI, and so on.
+
+     Describe the alternative solutions you've considered.
+-->
+
+## Proposal
+
+<!--
+     Briefly but precisely describe what you would like this recipe to be able to do.
+
+     Consider attaching something showing what you are imagining:
+      * images
+      * videos
+      * code samples
+      * a benchmark result or log you are trying to reproduce
+
+     Does this have to be provided by this recipe directly, or can it be a small
+     user-land script? If the latter, maybe consider implementing and sharing it
+     with us in a pull request rather than filing an issue.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I want help using this recipe on my own hardware.
+    url: https://x.com/MiaAI_lab
+    about: Ask questions about setting this up on a different cluster, or about how a particular piece of this recipe works.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+## Description and Motivation
+
+<!--
+
+    Please write a description of what this PR is changing, removing or adding, and why.
+    Consider including before/after comparisons.
+
+    For this recipe, a good description usually covers:
+      * which `.env` knob, default, script behavior, or runtime patch changes
+      * whether the change affects measured numbers (KV cache budget, TTFT, decode
+        throughput, fairness spread, concurrency) and, if so, the expected direction
+      * why the change is safe on both ranks of the two-node TP=2 lane
+      * if it adds a runtime patch: why it follows the repo's pattern (opt-in
+        `DSPARK_ENABLE_*` flag defaulting to 0, source-exact/fail-closed patcher
+        with fixtures and a --status/--check path)
+
+-->
+
+## Related Issues
+
+<!--
+
+    Add the list of issues related to this PR from the issue tracker.
+    Indicate which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.
+
+-->
+
+---
+
+## Testing
+
+<!--
+
+    Tell us how you verified this change. For this recipe that usually means:
+
+      * `bash scripts/ci-validate.sh` (CPU recipe gates, required)
+      * the relevant focused suites, e.g. scripts/test-*.py / tests/test_*.py
+      * for shell changes: `bash -n` on every touched script
+      * for runtime/patch changes: a boot on the two-node lane with the flag both
+        off and on, and the measured numbers (see README "What speed to expect"
+        and docs/ENVS.md for the format used)
+      * if the change touches a hotfix: the fixture/identity tests pass and the
+        patcher refuses drifted bytes fail-closed
+
+-->
+
+---
+
+## Checklist:
+
+<!--
+
+    Thanks for contributing to Mia's AI Lab!
+
+    Before you file this pull request, please follow the items on this checklist and
+    put an x in each of the boxes, like this: [x].
+
+-->
+
+- [ ] I have read the README and `docs/ENVS.md` and kept my changes consistent with them.
+- [ ] My pull request has a sound title and description (not something vague like `Update README.md`).
+- [ ] My change is reproducible and verified (CI validate, focused suites, and — for runtime changes — a measured boot).
+- [ ] New runtime behavior is opt-in and default-off, matching the recipe's existing knobs; defaults are unchanged unless the PR is explicitly about a default.
+- [ ] I updated the README, `docs/ENVS.md`, `.env.dspark.example`, and `CHANGELOG.md` for any knob, default, or behavior I changed.
+- [ ] `.env.dspark.example` and the Compose fallback agree for every knob I touched (they are locked together in `scripts/ci-validate.sh`).


### PR DESCRIPTION
## What

Ports the issue-template set that landed on MiaAI-Lab/Qwen3.8-Flash-Next-Dual-DGX-Sparks, adapted to this repo's knobs, start path, and common failure modes:

- `.github/ISSUE_TEMPLATE/1_bug.md` — environment block (nodes, interconnect, image/vLLM, checkpoint+revision, served name, start path, relevant `.env` values incl. `DSPARK_ENABLE_*` opt-ins), repro steps, expected/actual, minimal-repro curl, and a logs section whose common-culprits list is DSpark-specific (cold-cache `HF_HUB_OFFLINE`, the Vision-Exp k rule, the inflight-prefill cap, unregistered `VLLM_*` warnings).
- `2_improvement.md` / `3_feature_request.md` — light adaptations (repo-specific example areas).
- `config.yml` — **blank issues disabled** (was enabled in the source repo) so new issues must pick a form; same X contact link.
- `.github/PULL_REQUEST_TEMPLATE.md` — testing section maps to this repo's conventions (`ci-validate.sh` required, focused suites, fail-closed patcher identities, measured boot for runtime changes); checklist adds default-off discipline and the env-example/compose lock.

No code, no runtime behavior. Merging makes the forms live for new issues/PRs.
