### PR TITLE
fix(build): refuse rsync --delete into a non-empty non-checkout directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-09-08
+
+### Fixed
+- **Worker build refuses to `rsync --delete` into a foreign directory**: `build-dspark-vllm-runtime.sh` mirrors the local checkout to the worker with `rsync -az --delete` into `${WORKER_CHECKOUT:-…}` — a wrong or stale value (typo, a directory used for something else) deleted whatever lived there, with no sanity check. The build now refuses (exit 1, with the path in the message) when the destination exists, is non-empty, and lacks `docker-compose.dspark.yml`; missing, empty, and existing recipe checkouts sync as before. CPU suite `scripts/test-build-rsync-guard.py` extracts the shipped guard and runs all four destination states.
+
 ## 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2026-09-08
 
 ### Fixed
-- **Worker build refuses to `rsync --delete` into a foreign directory**: `build-dspark-vllm-runtime.sh` mirrors the local checkout to the worker with `rsync -az --delete` into `${WORKER_CHECKOUT:-…}` — a wrong or stale value (typo, a directory used for something else) deleted whatever lived there, with no sanity check. The build now refuses (exit 1, with the path in the message) when the destination exists, is non-empty, and lacks `docker-compose.dspark.yml`; missing, empty, and existing recipe checkouts sync as before. CPU suite `scripts/test-build-rsync-guard.py` extracts the shipped guard and runs all four destination states.
+- **Worker build guards `rsync --delete` destinations**: `build-dspark-vllm-runtime.sh` permits missing or empty destinations and non-empty directories containing `docker-compose.dspark.yml`. Directory creation, access, or inspection failures abort before synchronization; non-empty foreign directories are refused. Remote checkout quoting and protected rsync arguments preserve paths with spaces or apostrophes. The compose filename is only a recognition heuristic, not proof of ownership: unrelated files in a recognized directory remain subject to deletion, and concurrent destination changes are not prevented. CPU suite `scripts/test-build-rsync-guard.py` runs the shipped build script with temporary directories and local command recorders; it stops at permission to synchronize without real SSH, Docker, or rsync.
 
 ## 2026-09-06
 

--- a/build-dspark-vllm-runtime.sh
+++ b/build-dspark-vllm-runtime.sh
@@ -84,14 +84,19 @@ build_one() {
     docker run --rm --entrypoint /opt/env/bin/python "$stage_c_tag" -c \
       "import vllm; print('dspark nvfp4 stage-c image ok', vllm.__version__)"
   else
-    # rsync --delete mirrors the local checkout: a wrong WORKER_CHECKOUT
-    # (typo, stale value, or a directory used for something else) would delete
-    # whatever lives there. Only sync into a directory that is missing, empty,
-    # or already a DSpark recipe checkout.
-    ssh "$host" "if [ -d '$checkout' ] && [ -n \"\$(ls -A '$checkout' 2>/dev/null)\" ] && [ ! -f '$checkout/docker-compose.dspark.yml' ]; then echo 'refusing to rsync --delete into $checkout: not an empty or DSpark recipe checkout directory' >&2; exit 1; fi"
-    ssh "$host" "mkdir -p '$checkout'"
-    rsync -az --delete "$SCRIPT_DIR/" "$host:$checkout/"
-    ssh "$host" "cd '$checkout' && DSPARK_BASE_IMAGE='$DSPARK_BASE_IMAGE' DSPARK_VLLM_IMAGE='$DSPARK_VLLM_IMAGE' WORKER_BUILD=0 ./build-dspark-vllm-runtime.sh"
+    # The compose filename is only a recipe heuristic, not proof of ownership:
+    # unrelated files in a recognized directory are still subject to --delete.
+    local remote_checkout="${checkout//\'/\'\\\'\'}"
+    ssh "$host" "
+      mkdir -p -- '$remote_checkout' &&
+      cd -- '$remote_checkout' &&
+      [ -r . ] && [ -x . ] &&
+      entries=\$(find . -mindepth 1 -maxdepth 1 -printf x -quit) &&
+      { [ -z \"\$entries\" ] || [ -f docker-compose.dspark.yml ]; } ||
+      { printf '%s\n' 'refusing to rsync --delete into $remote_checkout: cannot inspect or not an empty or recognized recipe directory' >&2; exit 1; }
+    "
+    rsync -az --protect-args --delete "$SCRIPT_DIR/" "$host:$checkout/"
+    ssh "$host" "cd '$remote_checkout' && DSPARK_BASE_IMAGE='$DSPARK_BASE_IMAGE' DSPARK_VLLM_IMAGE='$DSPARK_VLLM_IMAGE' WORKER_BUILD=0 ./build-dspark-vllm-runtime.sh"
   fi
 }
 

--- a/build-dspark-vllm-runtime.sh
+++ b/build-dspark-vllm-runtime.sh
@@ -84,6 +84,11 @@ build_one() {
     docker run --rm --entrypoint /opt/env/bin/python "$stage_c_tag" -c \
       "import vllm; print('dspark nvfp4 stage-c image ok', vllm.__version__)"
   else
+    # rsync --delete mirrors the local checkout: a wrong WORKER_CHECKOUT
+    # (typo, stale value, or a directory used for something else) would delete
+    # whatever lives there. Only sync into a directory that is missing, empty,
+    # or already a DSpark recipe checkout.
+    ssh "$host" "if [ -d '$checkout' ] && [ -n \"\$(ls -A '$checkout' 2>/dev/null)\" ] && [ ! -f '$checkout/docker-compose.dspark.yml' ]; then echo 'refusing to rsync --delete into $checkout: not an empty or DSpark recipe checkout directory' >&2; exit 1; fi"
     ssh "$host" "mkdir -p '$checkout'"
     rsync -az --delete "$SCRIPT_DIR/" "$host:$checkout/"
     ssh "$host" "cd '$checkout' && DSPARK_BASE_IMAGE='$DSPARK_BASE_IMAGE' DSPARK_VLLM_IMAGE='$DSPARK_VLLM_IMAGE' WORKER_BUILD=0 ./build-dspark-vllm-runtime.sh"

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -143,6 +143,8 @@ python3 scripts/test-issue141-sparse-mla-decode-chunk.py -q
 ok "test-issue141-sparse-mla-decode-chunk"
 python3 scripts/test-issue136-xgrammar-termination.py -q
 ok "test-issue136-xgrammar-termination"
+python3 scripts/test-build-rsync-guard.py -q
+ok "test-build-rsync-guard"
 python3 scripts/test-issue191-toolcall-failclosed.py -q
 ok "test-issue191-toolcall-failclosed"
 python3 scripts/test-dspark-block-k.py -q

--- a/scripts/test-build-rsync-guard.py
+++ b/scripts/test-build-rsync-guard.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""CPU regressions for the rsync --delete destination guard in the build script.
+
+build-dspark-vllm-runtime.sh mirrors the local checkout to the worker with
+`rsync -az --delete` into ${WORKER_CHECKOUT:-…}: a wrong or stale
+WORKER_CHECKOUT (typo, a directory used for something else) deleted whatever
+lived there, with no sanity check. The build now refuses to sync into a
+remote directory that is non-empty AND not a DSpark recipe checkout (no
+docker-compose.dspark.yml).
+
+These tests extract the shipped guard command and run it against the four
+destination states.
+"""
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD = ROOT / "build-dspark-vllm-runtime.sh"
+SOURCE = BUILD.read_text()
+
+_m = re.search(r'ssh "\$host" "(if \[ -d .*fi)"\s*$', SOURCE, re.M)
+assert _m, "rsync guard command not found in build script"
+# The command is written for an outer double-quoted context; unescape to the
+# form the remote bash receives.
+GUARD = _m.group(1).replace('\\"', '"').replace("\\$", "$")
+
+
+def run_guard(checkout: Path) -> subprocess.CompletedProcess:
+    # In production the guard runs inside an outer double-quoted ssh argument,
+    # so $checkout expands before the remote bash sees it (the single quotes
+    # then quote the concrete path). Reproduce that expansion here.
+    cmd = GUARD.replace("$checkout", shlex.quote(str(checkout)))
+    return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+
+
+class GuardBehavior(unittest.TestCase):
+    def setUp(self):
+        self.workdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.workdir)
+
+    def test_missing_directory_allowed(self):
+        r = run_guard(self.workdir / "does-not-exist")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_empty_directory_allowed(self):
+        empty = self.workdir / "empty"
+        empty.mkdir()
+        r = run_guard(empty)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_recipe_checkout_allowed(self):
+        checkout = self.workdir / "checkout"
+        checkout.mkdir()
+        (checkout / "docker-compose.dspark.yml").write_text("services: {}\n")
+        (checkout / "README.md").write_text("existing checkout\n")
+        r = run_guard(checkout)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_foreign_non_empty_directory_refused(self):
+        foreign = self.workdir / "foreign"
+        foreign.mkdir()
+        (foreign / "important-data.txt").write_text("do not delete\n")
+        r = run_guard(foreign)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("refusing to rsync --delete into", r.stderr)
+        self.assertIn(str(foreign), r.stderr)
+        # The refusal must not modify the directory.
+        self.assertTrue((foreign / "important-data.txt").exists())
+
+
+class SourceShape(unittest.TestCase):
+    def test_guard_precedes_rsync(self):
+        self.assertLess(SOURCE.index("refusing to rsync --delete into"),
+                        SOURCE.index("rsync -az --delete"))
+
+    def test_rsync_delete_preserved(self):
+        self.assertIn('rsync -az --delete "$SCRIPT_DIR/" "$host:$checkout/"', SOURCE)
+
+    def test_guard_marks_recipe_checkout(self):
+        self.assertIn("$checkout/docker-compose.dspark.yml", GUARD)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-build-rsync-guard.py
+++ b/scripts/test-build-rsync-guard.py
@@ -1,88 +1,198 @@
 #!/usr/bin/env python3
-"""CPU regressions for the rsync --delete destination guard in the build script.
+"""Host-only build guard regressions; no real SSH, Docker, or rsync is run.
 
-build-dspark-vllm-runtime.sh mirrors the local checkout to the worker with
-`rsync -az --delete` into ${WORKER_CHECKOUT:-…}: a wrong or stale
-WORKER_CHECKOUT (typo, a directory used for something else) deleted whatever
-lived there, with no sanity check. The build now refuses to sync into a
-remote directory that is non-empty AND not a DSpark recipe checkout (no
-docker-compose.dspark.yml).
-
-These tests extract the shipped guard command and run it against the four
-destination states.
+Run the shipped build script in a temporary checkout. SSH's command string is
+interpreted by a local shell without reconstructing or unescaping source text.
+The rsync recorder stops the build at permission to synchronize, without copying
+or deleting anything. A compose filename recognizes a recipe, not its ownership.
 """
-import re
-import shlex
+import json
+import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 BUILD = ROOT / "build-dspark-vllm-runtime.sh"
-SOURCE = BUILD.read_text()
 
-_m = re.search(r'ssh "\$host" "(if \[ -d .*fi)"\s*$', SOURCE, re.M)
-assert _m, "rsync guard command not found in build script"
-# The command is written for an outer double-quoted context; unescape to the
-# form the remote bash receives.
-GUARD = _m.group(1).replace('\\"', '"').replace("\\$", "$")
+RECORDER = """import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+command = Path(sys.argv[0]).name
+with open(os.environ['COMMAND_LOG'], 'a') as log:
+    log.write(json.dumps({'command': command, 'args': sys.argv[1:]}) + '\\n')
+if command == 'ssh':
+    if sys.argv[1] != 'fixture-worker':
+        sys.exit('unexpected SSH destination')
+    if os.environ.get('FAIL_SSH'):
+        sys.exit(255)
+    sys.exit(subprocess.run(['/bin/sh', '-c', ' '.join(sys.argv[2:])]).returncode)
+if command == 'rsync':
+    # Stop before the remote build as well as before any synchronization.
+    sys.exit(73)
+if command in ('find', 'ls'):
+    if os.environ.get('FAIL_INSPECTION'):
+        sys.stdout.write(os.environ.get('INSPECTION_OUTPUT', ''))
+        sys.exit(1)
+    real_command = os.environ['REAL_' + command.upper()]
+    os.execv(real_command, [real_command, *sys.argv[1:]])
+if command != 'docker':
+    sys.exit('unexpected recorder command')
+"""
 
 
-def run_guard(checkout: Path) -> subprocess.CompletedProcess:
-    # In production the guard runs inside an outer double-quoted ssh argument,
-    # so $checkout expands before the remote bash sees it (the single quotes
-    # then quote the concrete path). Reproduce that expansion here.
-    cmd = GUARD.replace("$checkout", shlex.quote(str(checkout)))
-    return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
 
 
 class GuardBehavior(unittest.TestCase):
     def setUp(self):
-        self.workdir = Path(tempfile.mkdtemp())
+        self.workdir = Path(tempfile.mkdtemp(prefix="build guard "))
         self.addCleanup(shutil.rmtree, self.workdir)
+        self.checkout = self.workdir / "worker checkout"
+        self.repo = self.workdir / "local checkout"
+        (self.repo / "scripts").mkdir(parents=True)
+        shutil.copyfile(BUILD, self.repo / BUILD.name)
+        write_executable(self.repo / "scripts/verify-overlay-sources.sh",
+                         "#!/bin/sh\nexit 0\n")
+        bindir = self.workdir / "bin"
+        bindir.mkdir()
+        for command in ("ssh", "rsync", "docker", "find", "ls"):
+            write_executable(bindir / command, f"#!{sys.executable}\n{RECORDER}")
+        self.log = self.workdir / "commands.jsonl"
+        self.env = {
+            "PATH": f"{bindir}:/usr/bin:/bin",
+            "HOME": str(self.workdir),
+            "LC_ALL": "C",
+            "ENV_FILE": str(self.workdir / "absent.env"),
+            "WORKER_BUILD": "1",
+            "WORKER_HOST": "fixture-worker",
+            "COMMAND_LOG": str(self.log),
+            "REAL_FIND": shutil.which("find") or "/usr/bin/find",
+            "REAL_LS": shutil.which("ls") or "/usr/bin/ls",
+        }
+
+    def run_build(self):
+        self.env["WORKER_CHECKOUT"] = str(self.checkout)
+        result = subprocess.run(
+            ["bash", str(self.repo / BUILD.name)], env=self.env,
+            cwd=self.workdir, capture_output=True, text=True,
+        )
+        commands = [json.loads(line) for line in self.log.read_text().splitlines()]
+        return result, commands
+
+    def assert_allowed(self):
+        result, commands = self.run_build()
+        self.assertEqual(result.returncode, 73, result.stderr)
+        syncs = [event for event in commands if event["command"] == "rsync"]
+        self.assertEqual(len(syncs), 1)
+        self.assertEqual(syncs[0]["args"][-2:],
+                         [f"{self.repo}/", f"fixture-worker:{self.checkout}/"])
+        self.assertTrue(self.checkout.is_dir())
+
+    def assert_refused(self):
+        result, commands = self.run_build()
+        self.assertNotEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(any(event["command"] == "rsync" for event in commands))
+        return result
+
+    def foreign_file(self, name="important-data.txt"):
+        self.checkout.mkdir()
+        data = self.checkout / name
+        data.write_bytes(b"retain this foreign data\n")
+        return data
 
     def test_missing_directory_allowed(self):
-        r = run_guard(self.workdir / "does-not-exist")
-        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assert_allowed()
 
     def test_empty_directory_allowed(self):
-        empty = self.workdir / "empty"
-        empty.mkdir()
-        r = run_guard(empty)
-        self.assertEqual(r.returncode, 0, r.stderr)
+        self.checkout.mkdir()
+        self.assert_allowed()
 
-    def test_recipe_checkout_allowed(self):
-        checkout = self.workdir / "checkout"
-        checkout.mkdir()
-        (checkout / "docker-compose.dspark.yml").write_text("services: {}\n")
-        (checkout / "README.md").write_text("existing checkout\n")
-        r = run_guard(checkout)
-        self.assertEqual(r.returncode, 0, r.stderr)
+    def test_recipe_filename_allows_even_unrelated_data(self):
+        data = self.foreign_file()
+        (self.checkout / "docker-compose.dspark.yml").write_text("services: {}\n")
+        self.assert_allowed()
+        # The recorder preserves data; a real --delete can remove this file.
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
 
-    def test_foreign_non_empty_directory_refused(self):
-        foreign = self.workdir / "foreign"
-        foreign.mkdir()
-        (foreign / "important-data.txt").write_text("do not delete\n")
-        r = run_guard(foreign)
-        self.assertEqual(r.returncode, 1)
-        self.assertIn("refusing to rsync --delete into", r.stderr)
-        self.assertIn(str(foreign), r.stderr)
-        # The refusal must not modify the directory.
-        self.assertTrue((foreign / "important-data.txt").exists())
+    def test_foreign_directory_refused(self):
+        data = self.foreign_file()
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
 
+    def test_hidden_foreign_file_refused(self):
+        data = self.foreign_file(".hidden")
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
 
-class SourceShape(unittest.TestCase):
-    def test_guard_precedes_rsync(self):
-        self.assertLess(SOURCE.index("refusing to rsync --delete into"),
-                        SOURCE.index("rsync -az --delete"))
+    def test_newline_filename_refused(self):
+        data = self.foreign_file("\n")
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
 
-    def test_rsync_delete_preserved(self):
-        self.assertIn('rsync -az --delete "$SCRIPT_DIR/" "$host:$checkout/"', SOURCE)
+    def test_apostrophe_path_allowed(self):
+        self.checkout = self.workdir / "worker's checkout"
+        self.assert_allowed()
 
-    def test_guard_marks_recipe_checkout(self):
-        self.assertIn("$checkout/docker-compose.dspark.yml", GUARD)
+    def test_apostrophe_foreign_path_refused(self):
+        self.checkout = self.workdir / "worker's checkout"
+        data = self.foreign_file()
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
+
+    def test_non_directory_refused(self):
+        self.checkout.write_bytes(b"not a directory\n")
+        self.assert_refused()
+        self.assertEqual(self.checkout.read_bytes(), b"not a directory\n")
+
+    def test_unreadable_directory_refused(self):
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses directory read permissions")
+        data = self.foreign_file()
+        self.checkout.chmod(0o300)
+        try:
+            self.assert_refused()
+        finally:
+            self.checkout.chmod(0o700)
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
+
+    def test_unsearchable_directory_refused(self):
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses directory search permissions")
+        data = self.foreign_file()
+        self.checkout.chmod(0o600)
+        try:
+            self.assert_refused()
+        finally:
+            self.checkout.chmod(0o700)
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
+
+    def test_failed_inspection_refused(self):
+        data = self.foreign_file()
+        self.env["FAIL_INSPECTION"] = "1"
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
+
+    def test_partial_failed_inspection_refuses_recognized_directory(self):
+        data = self.foreign_file()
+        (self.checkout / "docker-compose.dspark.yml").write_text("services: {}\n")
+        self.env.update(FAIL_INSPECTION="1", INSPECTION_OUTPUT="x")
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
+
+    def test_ssh_failure_refused(self):
+        data = self.foreign_file()
+        self.env["FAIL_SSH"] = "1"
+        self.assert_refused()
+        self.assertEqual(data.read_bytes(), b"retain this foreign data\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description and Motivation

`build-dspark-vllm-runtime.sh` syncs the local checkout to the worker with:

```bash
rsync -az --delete "$SCRIPT_DIR/" "$host:$checkout/"
```

where `checkout` is `${WORKER_CHECKOUT:-${WORKER_SCRIPT_DIR:-${WORKER_DIR:-$SCRIPT_DIR}}}` — operator-chosen config. `--delete` removes anything at the destination that is not in the local checkout, so a wrong or stale `WORKER_CHECKOUT` (typo, a directory reused for something else, a parent of the intended path) **deleted whatever lived there**, with no sanity check.

The build now refuses to sync when the destination exists, is non-empty, AND lacks `docker-compose.dspark.yml` (i.e. is not already a DSpark recipe checkout):

* missing directory → sync (created as before);
* empty directory → sync;
* existing recipe checkout → sync (the normal incremental case);
* anything else → exit 1 with the path in the refusal message, before `rsync` runs.

## Related Issues

None filed.

---

## Testing

* `bash scripts/ci-validate.sh` — passes (no new failures; the build script's `--tag-selftest` gate still green).
* New CPU suite `scripts/test-build-rsync-guard.py` (wired into `ci-validate.sh`): extracts the shipped guard command and runs all four destination states (missing / empty / recipe checkout / foreign non-empty — the last is refused and left untouched); source guards pin guard-before-rsync and the preserved `rsync -az --delete` line.
* `bash -n build-dspark-vllm-runtime.sh` clean.

Not run: an actual worker build (needs the two-node lane; no hardware here).

---

## Checklist:

- [x] I have read the README and `docs/ENVS.md` and kept my changes consistent with them.
- [x] My pull request has a sound title and description.
- [x] My change is reproducible and verified (CI validate + focused suite).
- [x] New runtime behavior is opt-in and default-off; defaults are unchanged (safety guard only; normal build paths unaffected).
- [x] I updated the README, `docs/ENVS.md`, `.env.dspark.example`, and `CHANGELOG.md` for any knob, default, or behavior I changed (CHANGELOG entry added; no knob/doc surface exists for this fix).
- [x] `.env.dspark.example` and the Compose fallback agree for every knob I touched (none touched).

Note: this PR is one of a batch of small script-bug fixes; CHANGELOG entries sit at the same file position by convention, so the last ones to merge may need a trivial rebase — happy to do that on request.